### PR TITLE
fix what's new link

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -10,11 +10,11 @@ This page lists new features added in Redpanda Cloud.
 
 === Redpanda Cloud docs
 
-The https://docs.redpanda.com/current/home/[Redpanda Docs home page] has been redesigned for an easier experience navigating Redpanda Cloud docs. We hope that our docs help and inspire our users. Please share your feedback with the links at the bottom of any doc page. 
+The https://docs.redpanda.com/home/[Redpanda Docs home page] has been redesigned for an easier experience navigating Redpanda Cloud docs. We hope that our docs help and inspire our users. Please share your feedback with the links at the bottom of any doc page. 
 
-=== BYOC on Azure: limited availability
+=== BYOC on Azure: LA
 
-Redpanda now supports xref:get-started:cluster-types/byoc/create-byoc-cluster-azure.adoc[BYOC clusters on Azure]. This is a limited availability release for BYOC clusters. Additional functionality is expected when this is generally available.
+Redpanda now supports xref:get-started:cluster-types/byoc/create-byoc-cluster-azure.adoc[BYOC clusters on Azure]. This is a limited availability (LA) release for BYOC clusters. Additional functionality is expected when this is generally available.
 
 === Serverless API
 


### PR DESCRIPTION
## Description
Change link to go to docs home instead of landing page
 
Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)