### PR TITLE
create-byoc-cluster-azure: Microsoft.Compute/EncryptionAtHost is a feature, not a resource provider

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -16,7 +16,10 @@
 *** Microsoft.Storage
 *** Microsoft.KeyVault
 *** Microsoft.Network
-*** Microsoft.Compute.EncryptionAtHost
++
+** Features: The Azure subscription must be registered for the following feature. For more information, see the https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli#prerequisites[Microsoft documentation^].
++
+*** Microsoft.Compute/EncryptionAtHost
 +
 ** Quotas: For more information, see the https://learn.microsoft.com/en-us/azure/quotas/view-quotas[Microsoft documentation^].
 +


### PR DESCRIPTION
**Old:**

> - Resources: The Azure subscription must be registered for the following resource providers. For more information, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types).
>   - Microsoft.Compute
>   - Microsoft.ManagedIdentity
>   - Microsoft.Storage
>   - Microsoft.KeyVault
>   - Microsoft.Network
>   - Microsoft.Compute.EncryptionAtHost

**New:**

> - Resources: The Azure subscription must be registered for the following resource providers. For more information, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types).
>   - Microsoft.Compute
>   - Microsoft.ManagedIdentity
>   - Microsoft.Storage
>   - Microsoft.KeyVault
>   - Microsoft.Network
> - Features: The Azure subscription must be registered for the following features.
>   - Microsoft.Compute/EncryptionAtHost. For more information, see the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli#prerequisites).

## Preview

[Create a BYOC on Azure docs](https://deploy-preview-16--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/create-byoc-cluster-azure/) 