### PR TITLE
remove feature flag for SSO user authentication

### DIFF
--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -14,8 +14,6 @@ Redpanda Cloud can authenticate users with emails and passwords. Passwords are h
 
 === Single sign-on
 
-include::shared:partial$feature-flag.adoc[]
-
 Redpanda Cloud can authenticate users with single sign-on (SSO) to an OIDC-based identity provider (IdP). Redpanda integrates with any OIDC-compliant IdP that supports discovery, including Okta, Auth0, Microsoft Entra, and Active Directory Federation Services (AD-FS). After SSO is enabled for an organization, new users in that organization can authenticate with SSO. 
 
 ==== Integrate IdP


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2661 
Review deadline:

## Page previews
[User authentication/SSO](https://deploy-preview-20--rp-cloud.netlify.app/redpanda-cloud/security/cloud-authentication/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)