### PR TITLE
edit self-hosted

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -214,9 +214,9 @@ Agents also manage VPC peering networks. One agent manages each network resource
 +
 image::shared:byoc_apply.png[cloud_byoc_apply]
 
-== Redpanda Cloud vs self-hosted feature compatibility
+== Redpanda Cloud vs Self-Managed feature compatibility
 
-Redpanda Cloud does not support the following self-hosted functionality:
+Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
 - FIPS-compliance mode
 - Data transforms (currently in beta for Redpanda Cloud)

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -16,19 +16,16 @@ The https://docs.redpanda.com/home/[Redpanda Docs site] has been redesigned for 
 
 Redpanda now supports xref:get-started:cluster-types/byoc/create-byoc-cluster-azure.adoc[BYOC clusters on Azure]. This is a limited availability (LA) release for BYOC clusters. Additional functionality is expected when this is generally available.
 
-=== Serverless API
+=== Enhancements to Serverless: LA 
 
-The xref:manage:api/cloud-serverless-controlplane-api.adoc[Redpanda Cloud API] now includes support for xref:get-started:cluster-types/serverless.adoc[Serverless]. This lets you start event streaming in the cloud even faster through automating the creation and deletion of Serverless clusters. 
+* The xref:manage:api/cloud-serverless-controlplane-api.adoc[Redpanda Cloud API] now includes support for xref:get-started:cluster-types/serverless.adoc[Serverless]. 
+* The Redpanda Schema Registry API is now exposed for Serverless.
+* Serverless subscriptions can now see detailed billing activity on the *Billing* page. 
+* Serverless added a 99.5% uptime https://www.redpanda.com/legal/redpanda-cloud-service-level-agreement[SLA] (service level agreement).
 
 === Self service sign up for Dedicated on AWS Marketplace
 
 To start using Dedicated, you can now sign up for a xref:get-started:cloud-overview.adoc#sign-up-for-dedicated[free trial on the AWS Marketplace]. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After 30 days, you can continue using your Dedicated cluster without any commitment, only paying for what you consume.
-
-=== Enhancements to Serverless: LA 
-
-* The Redpanda Schema Registry API is now exposed for Serverless.
-* Serverless subscriptions can now see detailed billing activity on the *Billing* page. 
-* Serverless added a 99.5% uptime https://www.redpanda.com/legal/redpanda-cloud-service-level-agreement[SLA] (service level agreement).
 
 === Support for additional regions
 


### PR DESCRIPTION
## Description

Changes self-hosted to Self-Managed + consolidates the new features in July for Serverless (which came in separately initially). 

## Page previews
[Overview](https://deploy-preview-22--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-cloud-vs-self-managed-feature-compatibility)
[What's New in Cloud](https://deploy-preview-22--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)