### PR TITLE
AWS PrivateLink - add security group rule for Console

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -303,6 +303,12 @@ aws ec2 authorize-security-group-ingress --region $REGION --profile $PROFILE \
     --group-id $SECURITY_GROUP_ID --protocol "tcp" \
     --port 30282 \
     --cidr 0.0.0.0/0
+# Allow Redpanda Console connection
+aws ec2 authorize-security-group-ingress --region $REGION --profile $PROFILE \
+    --group-id $SECURITY_GROUP_ID \
+    --protocol "tcp" \
+    --port 443-443 \
+    --cidr 0.0.0.0/0
 # Adjust the port 32094 if the Redpanda broker count is not 3.
 aws ec2 authorize-security-group-ingress --region $REGION --profile $PROFILE \
     --group-id $SECURITY_GROUP_ID \


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2673
Review deadline: 16 Aug

## Page previews

[Configure AWS PrivateLink with the Cloud API > Configure PrivateLink connection to Redpanda Cloud > Add security group rules](https://deploy-preview-27--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/#add-security-group-rules)
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)