### PR TITLE
Enable console with PrivateLink

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -105,6 +105,7 @@ CLUSTER_POST_BODY=`cat << EOF
     "type": "<type>",
     "aws_private_link": {
         "enabled": true,
+        "connect_console": true,
         "allowed_principals": ["<principal_1>","<principal_2>"]
     }
 }
@@ -150,6 +151,7 @@ CLUSTER_PATCH_BODY=`cat << EOF
 {
   "aws_private_link": {
     "enabled": true,
+    "connect_console": true,
     "allowed_principals": ["<principal_1>","<principal_2>"]
   }
 }

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -87,6 +87,7 @@ In the example below, make sure to set your own values for the following fields:
 - `type`: `TYPE_DEDICATED` for Dedicated Cloud clusters, or `TYPE_BYOC` for BYOC clusters
 - `tier`: for example, `tier-1-aws-v2-arm`
 - `name`
+- `connect_console`: Whether to enable connections to Redpanda Console (boolean)
 - `allowed_principals`: Amazon Resource Names (ARNs) for the AWS principals allowed to access the endpoint service. For example, for all principals in an account, use `arn:aws:iam::account_id:root`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[Configure an endpoint service^] for details.
 --
 +
@@ -142,6 +143,7 @@ CLUSTER_ID=<cluster_id>
 In the example below, make sure to set your own value for the following field:
 +
 --
+- `connect_console`: Whether to enable connections to Redpanda Console (boolean)
 - `allowed_principals`: Amazon Resource Names (ARNs) for the AWS principals allowed to access the endpoint service. For example, for all principals in an account, use `arn:aws:iam::account_id:root`. See https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[Configure an endpoint service^] for details.
 --
 +


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2673
Add field in API request body to enable RP Console
Review deadline: 16 Aug

## Page previews

https://deploy-preview-28--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/#create-new-cluster-with-privatelink-endpoint-service-enabled

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)