### PR TITLE
Add SASL mechanism to private links shell variables

### DIFF
--- a/modules/networking/partials/private-links-test-connection.adoc
+++ b/modules/networking/partials/private-links-test-connection.adoc
@@ -4,7 +4,7 @@
 ----
 export REDPANDA_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
 export RPK_TLS_ENABLED=true
-export REDPANDA_SASL_MECHANISM="<SCRAM-SHA-256 or SCRAM-SHA-512>"
+export RPK_SASL_MECHANISM="<SCRAM-SHA-256 or SCRAM-SHA-512>"
 export RPK_USER=<user>
 export RPK_PASS=<password>
 ----

--- a/modules/networking/partials/private-links-test-connection.adoc
+++ b/modules/networking/partials/private-links-test-connection.adoc
@@ -2,7 +2,7 @@
 +
 [,bash]
 ----
-export REDPANDA_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
+export RPK_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
 export RPK_TLS_ENABLED=true
 export RPK_SASL_MECHANISM="<SCRAM-SHA-256 or SCRAM-SHA-512>"
 export RPK_USER=<user>

--- a/modules/networking/partials/private-links-test-connection.adoc
+++ b/modules/networking/partials/private-links-test-connection.adoc
@@ -4,6 +4,7 @@
 ----
 export REDPANDA_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
 export RPK_TLS_ENABLED=true
+export REDPANDA_SASL_MECHANISM="<SCRAM-SHA-256 or SCRAM-SHA-512>"
 export RPK_USER=<user>
 export RPK_PASS=<password>
 ----


### PR DESCRIPTION
## Description

Fix based on https://redpandadata.slack.com/archives/C01LK3UK2K1/p1723839315545359
Review deadline: 19 Aug

[Configure AWS PrivateLink in the Cloud UI](https://deploy-preview-29--rp-cloud.netlify.app/redpanda-cloud/networking/configure-privatelink-in-cloud-ui/#test-the-connection) (this section is single sourced across multiple pages)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)