### PR TITLE
Add automation for npm update

### DIFF
--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -47,10 +47,8 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b update-branch-${{ matrix.branch }}
           git add package.json package-lock.json
           git commit -m "Update @redpanda-data/docs-extensions-and-macros"
-          git push origin update-branch-${{ matrix.branch }}
         env:
           ACCESS_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
 
@@ -58,9 +56,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "auto-docs: update @redpanda-data/docs-extensions-and-macros"
-          git-token: ${{ env.ACTIONS_BOT_TOKEN }}
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
           branch: update-branch-${{ matrix.branch }}
-          base: ${{ matrix.branch }}
           title: "auto-docs: Update extensions on ${{ matrix.branch }}"
           body: "This PR updates the @redpanda-data/docs-extensions-and-macros package on the ${{ matrix.branch }} branch."
           labels: auto-docs

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [main, v/24.1, v/23.3, api]
+        branch: [main]
 
     steps:
       - name: configure aws credentials

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -64,4 +64,4 @@ jobs:
           title: "auto-docs: Update extensions on ${{ matrix.branch }}"
           body: "This PR updates the @redpanda-data/docs-extensions-and-macros package on the ${{ matrix.branch }} branch."
           labels: auto-docs
-          reviewers: JakeSCahill, Deflaimun
+          reviewers: micheleRP, JakeSCahill, Deflaimun

--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -1,0 +1,67 @@
+name: Update @redpanda-data/docs-extensions-and-macros
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [trigger-npm-update]
+
+jobs:
+  update-dependency:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [main, v/24.1, v/23.3, api]
+
+    steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update @redpanda-data/docs-extensions-and-macros
+        run: npm update @redpanda-data/docs-extensions-and-macros
+
+      - name: Commit changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-branch-${{ matrix.branch }}
+          git add package.json package-lock.json
+          git commit -m "Update @redpanda-data/docs-extensions-and-macros"
+          git push origin update-branch-${{ matrix.branch }}
+        env:
+          ACCESS_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "auto-docs: update @redpanda-data/docs-extensions-and-macros"
+          git-token: ${{ env.ACTIONS_BOT_TOKEN }}
+          branch: update-branch-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          title: "auto-docs: Update extensions on ${{ matrix.branch }}"
+          body: "This PR updates the @redpanda-data/docs-extensions-and-macros package on the ${{ matrix.branch }} branch."
+          labels: auto-docs
+          reviewers: JakeSCahill, Deflaimun


### PR DESCRIPTION
## Description

Whenever we update our extensions in https://github.com/redpanda-data/docs-extensions-and-macros, we need to remember to manually do npm update @redpanda-data/docs-extensions-and-macros to get the latest changes in all our local builds. This PR adds a GH Action that can be triggered manually or automatically every time a new extension version is released. The action runs npm update @redpanda-data/docs-extensions-and-macros and submits a pull request to the respective branches.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)