### PR TITLE
Update GitHub user

### DIFF
--- a/.github/workflows/update-extensions.yml
+++ b/.github/workflows/update-extensions.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "vbotbuildovich"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
           git add package.json package-lock.json
           git commit -m "Update @redpanda-data/docs-extensions-and-macros"
         env:


### PR DESCRIPTION
## Description

GitHub treats the placeholder email as a user and requires the CLA to be signed. This change sets the user to [vbotbuildovich](https://github.com/vbotbuildovich) which doesn't require this.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)