### PR TITLE
Add Azure to cloud docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -36,6 +36,7 @@
 *** xref:networking:dedicated/aws/index.adoc[AWS]
 **** xref:networking:configure-privatelink-in-cloud-ui.adoc[Configure PrivateLink in the Cloud UI]
 **** xref:networking:aws-privatelink.adoc[]
+*** xref:networking:azure-private-link.adoc[Azure (Private Link)]
 *** xref:networking:dedicated/gcp/index.adoc[GCP]
 **** xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI]
 **** xref:networking:gcp-private-service-connect.adoc[Configure Private Service Connect with the Cloud API]

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -19,6 +19,12 @@ BYOC or Dedicated::
 . Create a cluster by making a xref:api:ROOT:cloud-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] request.
 . For BYOC, run `rpk cloud byoc`, passing the `metadata.cluster_id` from the Create Cluster response as a flag:
 +
+Azure:
++
+```bash
+rpk cloud byoc azure apply --redpanda-id=<metadata.cluster_id> --subscription-id=<redpanda-cluster-azure-subscription-id>
+```
++
 GCP:
 +
 ```bash

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -19,6 +19,12 @@ BYOC or Dedicated::
 . Create a cluster by making a xref:api:ROOT:cloud-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] request.
 . For BYOC, run `rpk cloud byoc`, passing the `metadata.cluster_id` from the Create Cluster response as a flag:
 +
+AWS:
++
+```bash
+rpk cloud byoc aws apply --redpanda-id=<metadata.cluster_id>
+```
++
 Azure:
 +
 ```bash
@@ -29,12 +35,6 @@ GCP:
 +
 ```bash
 rpk cloud byoc gcp apply --redpanda-id=<metadata.cluster_id> --project-id=<gcp-project-id>
-```
-+
-AWS:
-+
-```bash
-rpk cloud byoc aws apply --redpanda-id=<metadata.cluster_id>
 ```
 --
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -145,6 +145,13 @@ ifdef::env-byoc[]
 +
 [tabs]
 ====
+Azure::
++
+--
+```bash
+rpk cloud byoc azure apply --redpanda-id=<metadata.cluster_id> --subscription-id=<redpanda-cluster-azure-subscription-id>
+```
+--
 GCP::
 +
 --
@@ -269,6 +276,13 @@ ifdef::env-byoc[]
 +
 [tabs]
 ====
+Azure::
++
+--
+```bash
+rpk cloud byoc azure destroy --redpanda-id=<cluster-id> 
+```
+--
 GCP::
 +
 --

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -145,6 +145,13 @@ ifdef::env-byoc[]
 +
 [tabs]
 ====
+AWS::
++
+--
+```bash
+rpk cloud byoc aws apply --redpanda-id=<metadata.cluster_id>
+```
+--
 Azure::
 +
 --
@@ -157,13 +164,6 @@ GCP::
 --
 ```bash
 rpk cloud byoc gcp apply --redpanda-id=<metadata.cluster_id> --project-id=<gcp-project-id>
-```
---
-AWS::
-+
---
-```bash
-rpk cloud byoc aws apply --redpanda-id=<metadata.cluster_id>
 ```
 --
 ====
@@ -276,6 +276,13 @@ ifdef::env-byoc[]
 +
 [tabs]
 ====
+AWS::
++
+--
+```bash
+rpk cloud byoc aws destroy --redpanda-id=<cluster-id>
+```
+--
 Azure::
 +
 --
@@ -288,13 +295,6 @@ GCP::
 --
 ```bash
 rpk cloud byoc gcp destroy --redpanda-id=<cluster-id> --project-id=<gcp-project-id>
-```
---
-AWS::
-+
---
-```bash
-rpk cloud byoc aws destroy --redpanda-id=<cluster-id>
 ```
 --
 ====

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -66,6 +66,7 @@ export RESOURCE_GROUP_ID=<uuid>
 Make sure to supply your own values in the following example request. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
 --
+- `cluster-type`: `TYPE_BYOC` or `TYPE_DEDICATED`
 - `network-name`
 - `cidr_block`
 - `azure-region`
@@ -102,7 +103,7 @@ In the following example, make sure to set your own values for the following fie
 +
 --
 - `name`
-- `tier`: For example, `tier-1-azure`. See available Azure tiers in the xref:api:ROOT:cloud-api.adoc#api-description[Cloud API reference]. To learn more about tiers, see xref:reference:tiers/byoc-tiers.adoc[BYOC Tiers and Regions]. 
+- `tier`: For example, `tier-1-azure`. See available Azure tiers in the xref:api:ROOT:cloud-api.adoc#api-description[Cloud API reference]. To learn more about tiers, see xref:reference:tiers/byoc-tiers.adoc[BYOC Tiers and Regions] or xref:reference:tiers/dedicated-tiers.adoc[Dedicated Tiers and Regions]. 
 - `zones`: For example, `"uksouth-az1",  "uksouth-az2", "uksouth-az3"`
 --
 +
@@ -135,7 +136,7 @@ CLUSTER_ID=`curl -vv -X POST \
 echo $CLUSTER_ID
 ----
 
-. Check that the cluster operation is completed by calling xref:api:ROOT:cloud-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+. **BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster with Private Link enabled:
 +

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -79,7 +79,7 @@ REGION=<azure-region>
 NETWORK_POST_BODY=`cat << EOF
 {
     "cloud_provider": "CLOUD_PROVIDER_AZURE",
-    "cluster_type": "TYPE_BYOC",
+    "cluster_type": "<cluster-type>",
     "name": "<network-name>",
     "cidr_block": "<10.0.0.0/20>",
     "resource_group_id": "$RESOURCE_GROUP_ID",
@@ -103,6 +103,7 @@ In the following example, make sure to set your own values for the following fie
 +
 --
 - `name`
+- `type`: `TYPE_BYOC` or `TYPE_DEDICATED`
 - `tier`: For example, `tier-1-azure`. See available Azure tiers in the xref:api:ROOT:cloud-api.adoc#api-description[Cloud API reference]. To learn more about tiers, see xref:reference:tiers/byoc-tiers.adoc[BYOC Tiers and Regions] or xref:reference:tiers/dedicated-tiers.adoc[Dedicated Tiers and Regions]. 
 - `zones`: For example, `"uksouth-az1",  "uksouth-az2", "uksouth-az3"`
 --
@@ -118,7 +119,7 @@ CLUSTER_POST_BODY=`cat << EOF
   "network_id": "$NETWORK_ID",
   "region": "$REGION",
   "throughput_tier": "<tier>",
-  "type": "TYPE_BYOC",
+  "type": "<type>",
   "zones": [ <zones> ],
   "azure_private_link": { 
       "allowed_subscriptions": ["$SOURCE_CONNECTION_SUBSCRIPTION_ID"],

--- a/modules/networking/pages/dedicated/vpc-peering.adoc
+++ b/modules/networking/pages/dedicated/vpc-peering.adoc
@@ -10,7 +10,7 @@ When you select a network for deploying your Redpanda Dedicated cluster, you hav
 
 == Prerequisites
 
-* *VPC network*: Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
+* *VPC network*: VPC peering is supported in AWS and GCP. This page describes the steps for AWS. Before you set up a peering connection in the Redpanda Cloud UI, you must have a VPC in your own account for Redpanda's VPC to connect to. If you do not already have a VPC, log in to the AWS VPC Console and create one.
 * *Matching region*: VPC peering connections can only be established between networks created in the *same region*. Redpanda Cloud does not support inter-region VPC peering connections.
 * *Non-overlapping CIDR blocks*: The CIDR block for your VPC network cannot match or overlap with the CIDR block for the Redpanda Cloud VPC.
 

--- a/modules/networking/partials/private-links-api-access-token.adoc
+++ b/modules/networking/partials/private-links-api-access-token.adoc
@@ -5,7 +5,7 @@
 export PUBLIC_API_ENDPOINT="https://api.cloud.redpanda.com"
 ----
 
-. In your organization in the Redpanda Cloud UI, go https://cloud.redpanda.com/clients[**Clients**^]. If you don't have an existing client (also known as service account), you can create a new one by clicking **Add client**.
+. In your organization in the Redpanda Cloud UI, go to https://cloud.redpanda.com/clients[**Clients**^]. If you don't have an existing client (also known as service account), you can create a new one by clicking **Add client**.
 +
 Copy and store the client ID and secret.
 +


### PR DESCRIPTION
## Description

- Add support for Dedicated clusters to Private Link doc
- Add Azure to Cloud API docs

Resolves https://github.com/redpanda-data/documentation-private/issues/2691
Resolves https://github.com/redpanda-data/documentation-private/issues/2692
Review deadline: 28 Aug 2024

## Page previews

[Cloud API Quickstart](https://deploy-preview-38--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-api-quickstart/)
[Use the Control Plane API with BYOC](https://deploy-preview-38--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-byoc-controlplane-api/)
[Configure Azure Private Link with the Cloud API](https://deploy-preview-38--rp-cloud.netlify.app/redpanda-cloud/networking/azure-private-link/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)