### PR TITLE
clarify NetworkWatcherRG required

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -24,20 +24,34 @@ In the https://login.microsoftonline.com/[Azure Portal^], confirm that the dedic
 ** Microsoft.KeyVault
 ** Microsoft.Network
 +
-TIP: To check if an Azure resource provider is registered, run the following command using the Azure CLI or in the Azure Cloud Shell. For example, to check for Microsoft.Compute:
+To check if a resource provider is registered, run the following command using the Azure CLI or in the Azure Cloud Shell. For example, to check for Microsoft.Compute:
 +
 ``` 
 az provider show -n Microsoft.Compute
 ```
++ 
+If it is not registered, run: 
++
+```
+az provider register --namespace 'Microsoft.Compute'
+```
 
 * Feature: The subscription must be registered for Microsoft.Compute/EncryptionAtHost. See the https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli#prerequisites[Microsoft documentation^].
++
+To register EncryptionAtHost, run:
++
+```
+az feature register --name EncryptionAtHost  --namespace Microsoft.Compute
+```
 
 * Quota: The subscription must have the following quota in the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/quotas/view-quotas[Microsoft documentation^].
 
 ** Standard LASv3-series vCPUs: 24
 ** Standard DADSv5-series vCPUs: 8
 
-* Monitoring: Azure Network Watcher should be enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
+* Monitoring: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
++
+To enable Azure Network Watcher:
 +
 ```
 # Create the NetworkWatcherRG resource group

--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -10,21 +10,23 @@ Before you deploy a BYOC cluster on Azure, follow the prerequisites to ensure th
 
 Confirm you have a minimum version of Redpanda `rpk` v24.1. See xref:reference:rpk/rpk-version.adoc[`rpk version`] or xref:manage:rpk/intro-to-rpk.adoc[].
 
-=== Check your Azure subscription
+=== Prepare your Azure subscription
 
 In the https://login.microsoftonline.com/[Azure Portal^], confirm that the dedicated subscription you intend to use with Redpanda includes the following: 
 
 * Role: The Azure user must have the _Owner_ role in the subscription.
 
 * Resources: The subscription must be registered for the following resource providers. See the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types[Microsoft documentation^]. 
-
++
+--
 ** Microsoft.Compute
 ** Microsoft.ManagedIdentity
 ** Microsoft.Storage
 ** Microsoft.KeyVault
 ** Microsoft.Network
+--
 +
-To check if a resource provider is registered, run the following command using the Azure CLI or in the Azure Cloud Shell. For example, to check for Microsoft.Compute:
+To check if a resource provider is registered, run the following command using the Azure CLI or in the Azure Cloud Shell. For example, to check for Microsoft.Compute, run:
 +
 ``` 
 az provider show -n Microsoft.Compute
@@ -49,11 +51,10 @@ az feature register --name EncryptionAtHost  --namespace Microsoft.Compute
 ** Standard LASv3-series vCPUs: 24
 ** Standard DADSv5-series vCPUs: 8
 
-* Monitoring: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
+* Monitoring: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. Network Watcher lets you monitor and diagnose conditions at a network level. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-create?tabs=portaly
+[Microsoft documentation^]. To enable it, run:
 +
-To enable Azure Network Watcher:
-+
-```
+``` 
 # Create the NetworkWatcherRG resource group
 az group create --name 'NetworkWatcherRG' --location '<region_name>'
 
@@ -63,7 +64,7 @@ az network watcher configure --resource-group 'NetworkWatcherRG' --locations '<r
 
 === Check Azure SKU restrictions
 
-Check to ensure that the Azure subscription does not have any SKU restrictions for the VM sizes in the region where you intend to use Redpanda. Using the Azure CLI or in the Azure Cloud Shell, run:
+Check to ensure that the Azure subscription does not have any SKU restrictions for the VM sizes in the region where you will use Redpanda. Using the Azure CLI or in the Azure Cloud Shell, run:
 
 ----
 az vm list-skus -l eastus2 --zone --size Standard_L8as_v3 --output table

--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -51,8 +51,7 @@ az feature register --name EncryptionAtHost  --namespace Microsoft.Compute
 ** Standard LASv3-series vCPUs: 24
 ** Standard DADSv5-series vCPUs: 8
 
-* Monitoring: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. Network Watcher lets you monitor and diagnose conditions at a network level. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-create?tabs=portaly
-[Microsoft documentation^]. To enable it, run:
+* Monitoring: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. Network Watcher lets you monitor and diagnose conditions at a network level. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-create?tabs=portaly[Microsoft documentation^]. To enable it, run:
 +
 ``` 
 # Create the NetworkWatcherRG resource group

--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -37,10 +37,10 @@ az provider show -n Microsoft.Compute
 ** Standard LASv3-series vCPUs: 24
 ** Standard DADSv5-series vCPUs: 8
 
-* Monitoring: Ensure that Azure Network Watcher is enabled in the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
+* Monitoring: Ensure that Azure Network Watcher is enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
 +
 ```
-# Create the NetworkWatcherRG
+# Create the NetworkWatcherRG resource group
 az group create --name 'NetworkWatcherRG' --location '<region_name>'
 
 # Enable Network Watcher in <region_name>

--- a/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/create-byoc-cluster-azure.adoc
@@ -37,7 +37,7 @@ az provider show -n Microsoft.Compute
 ** Standard LASv3-series vCPUs: 24
 ** Standard DADSv5-series vCPUs: 8
 
-* Monitoring: Ensure that Azure Network Watcher is enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
+* Monitoring: Azure Network Watcher should be enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview[Microsoft documentation^]. To enable it:
 +
 ```
 # Create the NetworkWatcherRG resource group

--- a/modules/manage/pages/schema-reg/edit-topic-configuration.adoc
+++ b/modules/manage/pages/schema-reg/edit-topic-configuration.adoc
@@ -1,3 +1,4 @@
 = Edit Topic Configuration
-:page-aliases: manage:console/edit-topic-configuration/
+:page-aliases: manage:console/edit-topic-configuration.adoc
+
 include::ROOT:manage:console/edit-topic-configuration.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/programmable-push-filters.adoc
+++ b/modules/manage/pages/schema-reg/programmable-push-filters.adoc
@@ -1,3 +1,4 @@
 = Programmable Push Filters
 :page-aliases: console:features/programmable-push-filters.adoc, reference:console/programmable-push-filters.adoc
+
 include::ROOT:reference:console/programmable-push-filters.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/record-deserialization.adoc
+++ b/modules/manage/pages/schema-reg/record-deserialization.adoc
@@ -1,3 +1,4 @@
 = Deserialization
 :page-aliases: console:features/record-deserialization.adoc, manage:console/protobuf.adoc, reference:console/record-deserialization.adoc
+
 include::ROOT:reference:console/record-deserialization.adoc[tag=single-source]


### PR DESCRIPTION
## Description

This clarifies that Azure Network Watcher should be enabled within the NetworkWatcherRG resource group.

## Page previews
https://deploy-preview-59--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/create-byoc-cluster-azure/#check-your-azure-subscription

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)