### PR TITLE
2540 - Fix links to API Data Plane

### DIFF
--- a/modules/develop/pages/connect/about.adoc
+++ b/modules/develop/pages/connect/about.adoc
@@ -1,9 +1,10 @@
 = Redpanda Connect in Redpanda Cloud
+:tag-pipeline-service: api:ROOT:cloud-api.adoc#tag--PipelineService
 :description: Learn about Redpanda Connect in Redpanda Cloud and its wide range of connectors.
 
 include::develop:partial$availability-message.adoc[]
 
-Redpanda Connect in Redpanda Cloud lets you quickly build and deploy streaming data pipelines on your clusters from a fully-integrated UI or using the xref:api:ROOT:cloud-api.adoc#tag--PipelineService[Data Plane API]. 
+Redpanda Connect in Redpanda Cloud lets you quickly build and deploy streaming data pipelines on your clusters from a fully-integrated UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. 
 
 Choose from a xref:develop:connect/components/catalog.adoc[wide range of connectors] to suit your use case, including connectors to: 
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -1,5 +1,6 @@
 = What's New in Redpanda Cloud
 :description: Summary of new features in Redpanada Cloud.
+:tag-pipeline-service: api:ROOT:cloud-api.adoc#tag--PipelineService
 :page-aliases: deploy:deployment-option/cloud/whats-new-cloud.adoc
 :page-toclevels: 1
 
@@ -12,7 +13,7 @@ This page lists new features added in Redpanda Cloud.
 
 xref:develop:connect/about.adoc[Redpanda Connect] is now integrated into Redpanda Cloud and available as a fully-managed service. This is a limited availability (LA) release for BYOC and a beta release for Serverless.
 
-xref:develop:connect/components/catalog.adoc[Choose from over 100 connectors] to quickly build and deploy streaming data pipelines or AI applications from the xref:develop:connect/connect-quickstart.adoc[Cloud UI] or using the xref:api:ROOT:cloud-api.adoc#tag--PipelineService[Data Plane API]. Comprehensive metrics and monitoring are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
+xref:develop:connect/components/catalog.adoc[Choose from over 100 connectors] to quickly build and deploy streaming data pipelines or AI applications from the xref:develop:connect/connect-quickstart.adoc[Cloud UI] or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics and monitoring are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
 
 === Dedicated on Azure: LA
 


### PR DESCRIPTION
## Description

Makes sure Data Plane API links are linking to RPCN PipelineService group of endpoints.

Resolves https://github.com/redpanda-data/documentation-private/issues/2540
Review deadline: 11 September if possible

## Page previews

[Redpanda Connect overview](https://deploy-preview-60--rp-cloud.netlify.app/redpanda-cloud/develop/connect/about/)
[What's New](https://deploy-preview-60--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)