### PR TITLE
2540 - Add cookbook to cloud docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -291,6 +291,7 @@
 **** xref:develop:connect/cookbooks/enrichments.adoc[]
 **** xref:develop:connect/cookbooks/filtering.adoc[]
 **** xref:develop:connect/cookbooks/joining_streams.adoc[]
+**** xref:develop:connect/cookbooks/rag.adoc[]
 
 ** xref:develop:managed-connectors/index.adoc[Kafka Connect]
 *** xref:develop:managed-connectors/converters-and-serialization.adoc[Converters and serialization]

--- a/modules/develop/pages/connect/cookbooks/rag.adoc
+++ b/modules/develop/pages/connect/cookbooks/rag.adoc
@@ -1,0 +1,3 @@
+= Retrieval-Augmented Generation (RAG)
+:page-aliases: cookbooks:rag.adoc
+include::redpanda-connect:cookbooks:rag.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Adds AI cookbook to Cloud.

Resolves https://github.com/redpanda-data/documentation-private/issues/2540
Review deadline: 11 September

## Page previews

https://deploy-preview-62--rp-cloud.netlify.app/redpanda-cloud/develop/connect/cookbooks/rag/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)