### PR TITLE
2540 Add Kafka Migrator Cookbook to Cloud docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -291,6 +291,7 @@
 **** xref:develop:connect/cookbooks/enrichments.adoc[]
 **** xref:develop:connect/cookbooks/filtering.adoc[]
 **** xref:develop:connect/cookbooks/joining_streams.adoc[]
+**** xref:develop:connect/cookbooks/kafka_migrator.adoc[]
 **** xref:develop:connect/cookbooks/rag.adoc[]
 
 ** xref:develop:managed-connectors/index.adoc[Kafka Connect]

--- a/modules/develop/pages/connect/cookbooks/kafka_migrator.adoc
+++ b/modules/develop/pages/connect/cookbooks/kafka_migrator.adoc
@@ -1,0 +1,3 @@
+= Kafka Migrator
+:page-aliases: cookbooks:kafka_migrator.adoc
+include::redpanda-connect:cookbooks:kafka_migrator.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Adds Kafka Migrator cookbook to Cloud.

Resolves https://github.com/redpanda-data/documentation-private/issues/2540
Review deadline: 12 September

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)