### PR TITLE
rpcn not on byovpc

### DIFF
--- a/modules/develop/pages/connect/connect-quickstart.adoc
+++ b/modules/develop/pages/connect/connect-quickstart.adoc
@@ -9,7 +9,7 @@ include::develop:partial$availability-message.adoc[]
 
 == Prerequisites
 
-A Redpanda Cloud account for BYOC or Serverless. If you don't already have an account, https://redpanda.com/try-redpanda/cloud-trial[sign up for a free trial^].
+A Redpanda Cloud account for Serverless or standard BYOC (not customer-managed VPC). If you don't already have an account, https://redpanda.com/try-redpanda/cloud-trial[sign up for a free trial^].
 
 == Before you start
 


### PR DESCRIPTION
## Description

This adds to quickstart that it's supported on standard BYOC (not customer-managed VPC). See [slack thread](https://redpandadata.slack.com/archives/C02JDTMG8GN/p1726160338114289?thread_ts=1726140145.126409&cid=C02JDTMG8GN).

## Page previews
[Quickstart Prereqs](https://deploy-preview-65--rp-cloud.netlify.app/redpanda-cloud/develop/connect/connect-quickstart/#prerequisites)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)