### PR TITLE
add AWS pay as you go

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -345,6 +345,8 @@
 * xref:billing:index.adoc[Billing]
 ** xref:billing:billing.adoc[]
 ** xref:billing:aws-commit.adoc[AWS: Use Commits]
+** xref:billing:aws-pay-as-you-go.adoc[]
+
 ** xref:billing:gcp-commit.adoc[GCP: Use Commits]
 
 * xref:get-started:partner-integration.adoc[]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -345,7 +345,7 @@
 * xref:billing:index.adoc[Billing]
 ** xref:billing:billing.adoc[]
 ** xref:billing:aws-commit.adoc[AWS: Use Commits]
-** xref:billing:aws-pay-as-you-go.adoc[]
+** xref:billing:aws-pay-as-you-go.adoc[AWS: Pay As You Go]
 
 ** xref:billing:gcp-commit.adoc[GCP: Use Commits]
 

--- a/modules/billing/pages/aws-pay-as-you-go.adoc
+++ b/modules/billing/pages/aws-pay-as-you-go.adoc
@@ -1,5 +1,5 @@
-= Use with AWS Pay As You Go
-:description: Subscribe to Redpanda Cloud in AWS Marketplace with pay-as-you-go billing, and cancel anytime.
+= Use AWS Pay As You Go
+:description: Subscribe to Redpanda in AWS Marketplace with pay-as-you-go billing, and cancel anytime.
 
 Subscribe to Redpanda Cloud through AWS Marketplace to quickly provision Redpanda Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
 
@@ -12,20 +12,18 @@ When you sign up for Redpanda Cloud through AWS Marketplace, you can only create
 
 . On https://aws.amazon.com/marketplace[AWS Marketplace^], search for "redpanda". 
 
-. Select *Redpanda Cloud - Fully Managed Redpanda*. 
+. Select *Redpanda Cloud - The proven Apache Kafka alternative (Pay as You Go)*. 
 
-. On the *Redpanda Cloud - Fully Managed Redpanda* overview page, click *View purchase options*.
+. On the *Redpanda Cloud - Pay as You Go** overview page, click *View purchase options*.
 
-. Select a subscription length (1 month or 12 months), renewal settings, and contract options, then click *Create contract*.  
+. Sign in to AWS. 
 +
 [NOTE]
 ====
 If you don't have a billing account associated with your project, you're prompted to enable billing to link the subscription with a billing account.
 ====
 
-. On the Order Summary page, the **Pay As You Go** plan using Redpanda consumption units is automatically selected. 
-* Read and accept the terms.
-* Click **Subscribe**, and you're taken to the Redpanda sign-up page.
+. Review the purchase details, and click **Subscribe**. You're taken to the Redpanda sign-up page.
 
 . On the Redpanda sign-up page: 
 * For **Email**, enter your email address to register with Redpanda.

--- a/modules/billing/pages/aws-pay-as-you-go.adoc
+++ b/modules/billing/pages/aws-pay-as-you-go.adoc
@@ -1,7 +1,7 @@
 = Use AWS Pay As You Go
 :description: Subscribe to Redpanda in AWS Marketplace with pay-as-you-go billing, and cancel anytime.
 
-Subscribe to Redpanda Cloud through AWS Marketplace to quickly provision Redpanda Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
+Subscribe to Redpanda Cloud through AWS Marketplace to quickly provision Redpanda Serverless and Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
 
 [IMPORTANT]
 ====
@@ -10,35 +10,34 @@ When you sign up for Redpanda Cloud through AWS Marketplace, you can only create
 
 == Sign up in AWS Marketplace
 
-. On https://aws.amazon.com/marketplace[AWS Marketplace^], search for "redpanda". 
+. In https://aws.amazon.com/marketplace[AWS Marketplace^], search for "redpanda", and select https://aws.amazon.com/marketplace/pp/prodview-ecbu7wwsfh644?applicationId=AWSMPContessa&ref_=beagle&sr=0-3[**Redpanda Cloud - The proven Apache Kafka alternative (Pay as You Go)**^]. 
 
-. Select *Redpanda Cloud - The proven Apache Kafka alternative (Pay as You Go)*. 
+. On the **Redpanda Cloud - Pay as You Go** overview page, click **View purchase options**, then click **Subscribe**. 
 
-. On the *Redpanda Cloud - Pay as You Go** overview page, click *View purchase options*.
-
-. Sign in to AWS. 
 +
 [NOTE]
 ====
-If you don't have a billing account associated with your project, you're prompted to enable billing to link the subscription with a billing account.
+If you don't have a billing account associated with your project, you're prompted to link the subscription with a billing account.
 ====
 
-. Review the purchase details, and click **Subscribe**. You're taken to the Redpanda sign-up page.
+. On the **Subscribe to Redpanda Cloud** page, click **Set up your account**. You're taken to the Redpanda sign-up page.
 
 . On the Redpanda sign-up page: 
 * For **Email**, enter your email address to register with Redpanda.
-* For **Organization name**, enter a name for your new organization connected through AWS Marketplace. Redpanda organizations contain all resources, including clusters and networks. 
+* For **Organization name**, enter a name for your new organization connected through AWS Marketplace. 
++ 
+TIP: This process creates a new organization, even for existing Redpanda customers. Organizations contain all resources, including clusters and networks.
 * Click **Sign up and create organization**.
 +
 You will receive an email sent to the address you entered.
 
 . In the email, click **Verify email address**. 
 +
-This completes the registration and associates the email with a Redpanda account. 
+This associates the email with a Redpanda account. 
 
-. On the **Accept your invitation to sign up** page, click **Sign up** or **Log in**. 
+. On the **Accept your invitation to sign up** page, enter the credentials you want to use for Redpanda Cloud. 
 +
-You can now create resource groups, clusters, and networks in your organization.
+You can now create resource groups, networks, and clusters in your organization.
 
 == Next steps
 

--- a/modules/billing/pages/aws-pay-as-you-go.adoc
+++ b/modules/billing/pages/aws-pay-as-you-go.adoc
@@ -10,7 +10,7 @@ When you sign up for Redpanda Cloud through AWS Marketplace, you can only create
 
 == Sign up in AWS Marketplace
 
-. In https://aws.amazon.com/marketplace[AWS Marketplace^], search for "redpanda", and select https://aws.amazon.com/marketplace/pp/prodview-ecbu7wwsfh644?applicationId=AWSMPContessa&ref_=beagle&sr=0-3[**Redpanda Cloud - The proven Apache Kafka alternative (Pay as You Go)**^]. 
+. In the AWS Marketplace, select https://aws.amazon.com/marketplace/pp/prodview-ecbu7wwsfh644?applicationId=AWSMPContessa&ref_=beagle&sr=0-3[**Redpanda Cloud - The proven Apache Kafka alternative (Pay as You Go)**^]. 
 
 . On the **Redpanda Cloud - Pay as You Go** overview page, click **View purchase options**, then click **Subscribe**. 
 

--- a/modules/billing/pages/aws-pay-as-you-go.adoc
+++ b/modules/billing/pages/aws-pay-as-you-go.adoc
@@ -1,7 +1,7 @@
 = Use AWS Pay As You Go
 :description: Subscribe to Redpanda in AWS Marketplace with pay-as-you-go billing, and cancel anytime.
 
-Subscribe to Redpanda Cloud through AWS Marketplace to quickly provision Redpanda Serverless and Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
+Subscribe to Redpanda Cloud through AWS Marketplace to quickly provision Redpanda Serverless and Dedicated clusters. With a usage-based pay-as-you-go subscription, you only pay for what you use and can cancel anytime. 
 
 [IMPORTANT]
 ====

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -36,11 +36,9 @@ When you create a Dedicated cluster, you select the supported xref:reference:tie
 
 ==== Sign up for Dedicated
 
-You can subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
+Subscribe to Redpanda Cloud on the xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Dedicated clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
 
-You can also sign up for a free trial on the AWS Marketplace. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After your free credits have been used, you can continue using your Dedicated cluster without any commitment, only paying for what you consume and canceling anytime. 
-
-Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount. You can then use xref:billing:gcp-commit.adoc[Google Cloud Marketplace] or xref:billing:aws-commit.adoc[AWS Marketplace] to quickly provision Dedicated Cloud clusters, and you can view invoices and manage your subscription in the marketplace.
+Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount. You can then use xref:billing:gcp-commit.adoc[Google Cloud Marketplace] or xref:billing:aws-commit.adoc[AWS Marketplace] to quickly provision Dedicated clusters, and you can view invoices and manage your subscription in the marketplace.
 
 === Bring Your Own Cloud (BYOC)
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -34,7 +34,7 @@ When you create a Dedicated cluster, you select the supported xref:reference:tie
 
 ==== Sign up for Dedicated
 
-To start using Dedicated, sign up for a free trial on the AWS Marketplace. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After 30 days, you can continue using your Dedicated cluster without any commitment, only paying for what you consume.
+To start using Dedicated, sign up for a free trial on the AWS Marketplace. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After 30 days, you can continue using your Dedicated cluster without any commitment, only paying for what you consume and canceling anytime. You can also sign up direct for xref:billing:aws-pay-as-you-go.adoc[pay-as-you-go billing], without a trial, on AWS Marketplace. 
 
 You can also contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount. You can then use xref:billing:gcp-commit.adoc[Google Cloud Marketplace] or xref:billing:aws-commit.adoc[AWS Marketplace] to quickly provision Dedicated Cloud clusters, and you can view invoices and manage your subscription in the marketplace.
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -25,6 +25,8 @@ With Serverless clusters, you host your data in Redpanda's VPC, and Redpanda han
 
 To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless[sign up for a free trial^]. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required for a trial. To continue using your Serverless cluster after the free trial, add a credit card and pay as you go. 
 
+You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Serverless clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
+
 NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#limits[usage limits]. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 
 === Dedicated Cloud
@@ -34,9 +36,11 @@ When you create a Dedicated cluster, you select the supported xref:reference:tie
 
 ==== Sign up for Dedicated
 
-To start using Dedicated, sign up for a free trial on the AWS Marketplace. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After 30 days, you can continue using your Dedicated cluster without any commitment, only paying for what you consume and canceling anytime. You can also sign up direct for xref:billing:aws-pay-as-you-go.adoc[pay-as-you-go billing], without a trial, on AWS Marketplace. 
+You can subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Dedicated clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
 
-You can also contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount. You can then use xref:billing:gcp-commit.adoc[Google Cloud Marketplace] or xref:billing:aws-commit.adoc[AWS Marketplace] to quickly provision Dedicated Cloud clusters, and you can view invoices and manage your subscription in the marketplace.
+You can also sign up for a free trial on the AWS Marketplace. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After your free credits have been used, you can continue using your Dedicated cluster without any commitment, only paying for what you consume and canceling anytime. 
+
+Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount. You can then use xref:billing:gcp-commit.adoc[Google Cloud Marketplace] or xref:billing:aws-commit.adoc[AWS Marketplace] to quickly provision Dedicated Cloud clusters, and you can view invoices and manage your subscription in the marketplace.
 
 === Bring Your Own Cloud (BYOC)
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -25,7 +25,7 @@ With Serverless clusters, you host your data in Redpanda's VPC, and Redpanda han
 
 To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless[sign up for a free trial^]. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required for a trial. To continue using your Serverless cluster after the free trial, add a credit card and pay as you go. 
 
-You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Serverless clusters. With a usage-based pay as you go subscription, you only pay for what you use and can cancel anytime. 
+You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Serverless clusters. With a usage-based pay-as-you-go subscription, you only pay for what you use and can cancel anytime. 
 
 NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#limits[usage limits]. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -36,7 +36,7 @@ Redpanda now supports xref:get-started:cluster-types/byoc/create-byoc-cluster-az
 
 === Self service sign up for Dedicated on AWS Marketplace
 
-To start using Dedicated, you can now sign up for a xref:get-started:cloud-overview.adoc#sign-up-for-dedicated[free trial on the AWS Marketplace]. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After 30 days, you can continue using your Dedicated cluster without any commitment, only paying for what you consume.
+To start using Dedicated, you can now sign up for a xref:get-started:cloud-overview.adoc#sign-up-for-dedicated[free trial on the AWS Marketplace]. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After your credits have been used, you can continue using your cluster without any commitment, only paying for what you consume.
 
 === Support for additional regions
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -36,7 +36,7 @@ Redpanda now supports xref:get-started:cluster-types/byoc/create-byoc-cluster-az
 
 === Self service sign up for Dedicated on AWS Marketplace
 
-To start using Dedicated, you can now sign up for a xref:get-started:cloud-overview.adoc#sign-up-for-dedicated[free trial on the AWS Marketplace]. New trials receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300 unless you cancel the subscription. After your credits have been used, you can continue using your cluster without any commitment, only paying for what you consume.
+To start using Dedicated, sign up on the xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace]. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your credits have been used, you can continue using your cluster without any commitment, only paying for what you consume.
 
 === Support for additional regions
 


### PR DESCRIPTION
## Description
This adds a page for pay-as-you-go billing on AWS.
This is an extension of https://github.com/redpanda-data/documentation-private/issues/2211

Review deadline: Wed Sept 18

## Page previews
[Use AWS Pay As You Go](https://deploy-preview-67--rp-cloud.netlify.app/redpanda-cloud/billing/aws-pay-as-you-go/)
[Sign up for Dedicated](https://deploy-preview-67--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#sign-up-for-dedicated)
[What's New](https://deploy-preview-67--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#self-service-sign-up-for-dedicated-on-aws-marketplace)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)