### PR TITLE
DOC-255-Cloud-Upgrades-Maintenance-Windows

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -179,9 +179,9 @@ BYOC with customer-managed VPC::
 
 Redpanda runs maintenance and upgrade operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
 
-By default, Redpanda Cloud maintenance cycles start on Tuesdays and may run on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
+By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
 
-TIP: By default, clusters scheduled on Tuesdays are updated first and clusters scheduled on Mondays are updated last. Keep this in my mind when sequencing updates for multiple clusters.
+TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in my mind when sequencing updates for multiple clusters.
 
 == Redpanda Cloud architecture
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -177,9 +177,9 @@ BYOC with customer-managed VPC::
 
 == Maintenance windows
 
-Redpanda runs maintenance operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
+Redpanda runs maintenance and upgrade operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
 
-By default, Redpanda Cloud maintenance cycles start on Tuesdays. Optionally, on the **Cluster settings** page, you can schedule a day and window of time for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC), and operations typically take six hours. Maintenance may start at any time during that window, and some operations may complete after the window ends. 
+By default, Redpanda Cloud maintenance cycles start on Tuesdays and may run on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
 
 TIP: By default, clusters scheduled on Tuesdays are updated first and clusters scheduled on Mondays are updated last. Keep this in my mind when sequencing updates for multiple clusters.
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -177,7 +177,11 @@ BYOC with customer-managed VPC::
 
 == Maintenance windows
 
-By default, Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
+Redpanda runs maintenance operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
+
+By default, Redpanda Cloud maintenance cycles start on Tuesdays. Optionally, on the **Cluster settings** page, you can schedule a day and window of time for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC), and operations typically take six hours. Maintenance may start at any time during that window, and some operations may complete after the window ends. 
+
+TIP: By default, clusters scheduled on Tuesdays are updated first and clusters scheduled on Mondays are updated last. Keep this in my mind when sequencing updates for multiple clusters.
 
 == Redpanda Cloud architecture
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added in Redpanda Cloud.
 
 == September 2024
 
+=== Schedule maintenance windows
+
+Redpanda Cloud now offers greater flexibility to schedule upgrades to your cluster. By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and xref:get-started:cloud-overview.adoc#maintenance-windows[schedule a maintenance window], which requires Redpanda Cloud to run operations on your specified day and time. 
+
 === Redpanda Connect: LA for BYOC, beta for Serverless
 
 xref:develop:connect/about.adoc[Redpanda Connect] is now integrated into Redpanda Cloud and available as a fully-managed service. This is a limited availability (LA) release for BYOC and a beta release for Serverless. xref:develop:connect/components/catalog.adoc[Choose from a range of connectors, processors, and other components] to quickly build and deploy streaming data pipelines or AI applications from the xref:develop:connect/connect-quickstart.adoc[Cloud UI] or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics and monitoring are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2467
Review deadline: Wed Sept 18

## Page previews
[Redpanda Overview - Maintenance windows](https://deploy-preview-68--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#maintenance-windows)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)