### PR TITLE
DOC-576-change-logical-partitions-to-pre-replication

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -32,7 +32,8 @@ Each Serverless cluster has the following limits:
 
 [NOTE]
 ====
-These baseline limits are subject to change. To increase your limits, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
+* These baseline limits are subject to change. To increase your limits, contact https://support.redpanda.com/hc/en-us/requests/new[support^]. 
+* Partition counts do not include partition replicas.
 ====
 
 == Trial credits

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -22,7 +22,7 @@ Each Serverless cluster has the following limits:
 
 * Ingress: up to 10 MBps, 0.5 MBps guaranteed
 * Egress: up to 30 MBps, 1.5 MBps guaranteed
-* Partitions: 100 logical partitions
+* Partitions: 100 partitions
 * Message size: 20 MB
 * Retention: unlimited time
 * Storage: unlimited

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -91,7 +91,7 @@ Redpanda Cloud has a simplified navigation, with clusters and networks available
 
 === Additional cloud tiers for BYOC
 
-When you create a BYOC or Dedicated cluster, you select a xref:reference:tiers/byoc-tiers.adoc[cloud tier] with the expected usage for your cluster, including the maximum ingress, egress, logical partitions, and connections. Redpanda has added tiers 8 and 9 for BYOC clusters, which provide higher supported configurations.
+When you create a BYOC or Dedicated cluster, you select a xref:reference:tiers/byoc-tiers.adoc[cloud tier] with the expected usage for your cluster, including the maximum ingress, egress, partitions (pre-replication), and connections. Redpanda has added tiers 8 and 9 for BYOC clusters, which provide higher supported configurations.
 
 == March 2024
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -66,7 +66,7 @@ The response contains the current state of the operation: `IN_PROGRESS`, `COMPLE
 
 == Cluster tiers
 
-When you create a BYOC or Dedicated cluster, you select a usage tier. Each tier provides tested and guaranteed workload configurations for throughput, logical partitions, and connections. Availability depends on the region and the cluster type. See the full list of regions, zones, and tiers available with each provider in the xref:api:ROOT:cloud-api.adoc#api-description[API reference].
+When you create a BYOC or Dedicated cluster, you select a usage tier. Each tier provides tested and guaranteed workload configurations for throughput, partitions (pre-replication), and connections. Availability depends on the region and the cluster type. See the full list of regions, zones, and tiers available with each provider in the xref:api:ROOT:cloud-api.adoc#api-description[API reference].
 
 endif::[]
 

--- a/modules/reference/pages/tiers/index.adoc
+++ b/modules/reference/pages/tiers/index.adoc
@@ -1,3 +1,3 @@
 = Tiers and Regions
-:description: When you create a BYOC or Dedicated cluster, you select your region and usage tier. Each tier provides guaranteed workload configurations for throughput, logical partitions, and connections.
+:description: When you create a BYOC or Dedicated cluster, you select your region and usage tier. Each tier provides guaranteed workload configurations for throughput, partitions (pre-replication), and connections.
 :page-layout: index

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -21,7 +21,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on the assumption that the Redpanda Cloud default replication factor is 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -4,7 +4,7 @@ ifdef::env-byoc[]
 When you create a BYOC cluster, you select your usage tier. Each tier provides tested workload configurations for maximum throughput, partitions, and connections. 
 
 |=== 
-| Tier | Ingress | Egress | Logical partitions | Connections
+| Tier | Ingress | Egress | Partitions | Connections
 
 | Tier 1 | 20 MBps | 60 MBps | 1,000 | 9,000
 | Tier 2 | 50 MBps | 150 MBps | 2,800 | 22,500
@@ -21,7 +21,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Logical partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are pre-replication and assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -98,7 +98,7 @@ ifndef::env-byoc[]
 When you create a Dedicated cluster, you select your usage tier. Each tier provides tested workload configurations for maximum throughput, partitions, and connections. 
 
 |=== 
-| Tier | Ingress | Egress | Logical partitions | Connections
+| Tier | Ingress | Egress | Partitions | Connections
 
 | Tier 1 | 20 MBps | 60 MBps | 1,000 | 9,000
 | Tier 2 | 50 MBps | 150 MBps | 2,800 | 22,500
@@ -111,7 +111,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Logical partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are pre-replication and assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -4,7 +4,7 @@ ifdef::env-byoc[]
 When you create a BYOC cluster, you select your usage tier. Each tier provides tested workload configurations for maximum throughput, partitions, and connections. 
 
 |=== 
-| Tier | Ingress | Egress | Partitions | Connections
+| Tier | Ingress | Egress | Partitions, pre-replication | Connections
 
 | Tier 1 | 20 MBps | 60 MBps | 1,000 | 9,000
 | Tier 2 | 50 MBps | 150 MBps | 2,800 | 22,500
@@ -21,7 +21,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are pre-replication and assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -98,7 +98,7 @@ ifndef::env-byoc[]
 When you create a Dedicated cluster, you select your usage tier. Each tier provides tested workload configurations for maximum throughput, partitions, and connections. 
 
 |=== 
-| Tier | Ingress | Egress | Partitions | Connections
+| Tier | Ingress | Egress | Partitions (pre-replication) | Connections
 
 | Tier 1 | 20 MBps | 60 MBps | 1,000 | 9,000
 | Tier 2 | 50 MBps | 150 MBps | 2,800 | 22,500
@@ -111,7 +111,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are pre-replication and assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -21,7 +21,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on the assumption that the Redpanda Cloud default replication factor is 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on the assumption that the Redpanda Cloud replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -111,7 +111,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on the assumption that the Redpanda Cloud default replication factor is 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on the assumption that the Redpanda Cloud replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -4,7 +4,7 @@ ifdef::env-byoc[]
 When you create a BYOC cluster, you select your usage tier. Each tier provides tested workload configurations for maximum throughput, partitions, and connections. 
 
 |=== 
-| Tier | Ingress | Egress | Partitions, pre-replication | Connections
+| Tier | Ingress | Egress | Partitions (pre-replication) | Connections
 
 | Tier 1 | 20 MBps | 60 MBps | 1,000 | 9,000
 | Tier 2 | 50 MBps | 150 MBps | 2,800 | 22,500

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -111,7 +111,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 ====
 * On Azure, tiers 1-3 are supported. 
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts assume the Redpanda Cloud default replication factor of 3. If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on the assumption that the Redpanda Cloud default replication factor is 3. If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2730
Review deadline: Wed Sept 18

## Page previews

- [BYOC tiers](https://deploy-preview-70--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/byoc-tiers/) and [Dedicated tiers](https://deploy-preview-70--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/dedicated-tiers/)
- Control Plane API [BYOC](https://deploy-preview-70--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-byoc-controlplane-api/#cluster-tiers) and [Dedicated](https://deploy-preview-70--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-dedicated-controlplane-api/#cluster-tiers)
- [Serverless](https://deploy-preview-70--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)