### PR TITLE
Fix Azure Private Link command typo.

### DIFF
--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -240,7 +240,7 @@ az network vnet create \
 +
 ```
 az network private-endpoint create \
-    --location $REGION
+    --location $REGION \
     --connection-name <private-link-service-name> \
     --name redpanda-$CLUSTER_ID \
     --manual-request no \


### PR DESCRIPTION
Missing `\` character at end of line of part of a command.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)