### PR TITLE
Fix missing attribute warning

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -90,7 +90,7 @@ To create a remote read replica topic, run:
 rpk topic create my-topic -c redpanda.remote.readreplica=<source cluster tiered storage bucket name>
 ```
 
-For standard BYOC clusters the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-${SOURCE_CLUSTER_ID}`
+For standard BYOC clusters the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-$\{SOURCE_CLUSTER_ID}`
 
 == Optional: Tune for live topics
 


### PR DESCRIPTION
## Description

Fixes the following warning in the docs:

```
[17:25:31.660] WARN (asciidoctor): skipping reference to missing attribute: source_cluster_id
    file: modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
    source: https://github.com/redpanda-data/cloud-docs (branch: main)
```

The fix was to escape the attribute syntax to tell Antora not to treat that string as an attribute. See https://docs.asciidoctor.org/asciidoc/latest/subs/prevent/#escape-with-backslashes

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)