### PR TITLE
DOC-616 Update Serverless doc

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -7,7 +7,7 @@ Redpanda Cloud is a complete data streaming platform delivered as a fully-manage
 
 TIP: For more detailed information about the Redpanda platform, see xref:get-started:intro-to-events.adoc[] and xref:get-started:architecture.adoc[].
 
-== Cluster types
+== Redpanda Cloud cluster types
 
 Redpanda offers three types of fully-managed cloud clusters:
 
@@ -51,27 +51,21 @@ To start using BYOC, contact https://redpanda.com/try-redpanda?section=enterpris
 
 == Serverless vs Dedicated/BYOC
 
-Serverless clusters are a good fit for the following:
+Serverless clusters are a good fit for the following use cases:
 
 * Starter and growing workloads
 * Spiky workloads (that is, development environments, systems that only occasionally get busy, or workloads that come and go)
 * Fast and dynamic cluster creation: you can use a Serverless cluster as an isolated container for topics
 
-With Serverless (or if you sign up for Dedicated through the AWS Marketplace), you only pay for what you consume, without any commitment. A cluster is created instantly, so you can surface it in your applications (for example, for tenant isolation). If your workload increases, you can migrate it to a Dedicated or BYOC cluster.
+With Serverless (and for Dedicated when procured through the AWS Marketplace), you only pay for what you consume, without any commitment. A cluster is created instantly, so you can surface it in your applications (for example, for tenant isolation). If your workload increases, you can migrate it to a Dedicated or BYOC cluster.
 
-Dedicated and BYOC clusters offer the following features:
+Consider Dedicated or BYOC if you need more control over the deployment or if you have workloads with consistently-high throughput. Dedicated and BYOC clusters offer the following features:
 
-* Single-zone or multi-zone availability (a multi-zone cluster provides higher resiliency in the event of a failure in one of the zones)
-* Private networking using VPC peering or a private connectivity service, such as AWS PrivateLink, GCP Private Service Connect, or Azure Private Link. 
-* Ability to export metrics to a 3rd-party monitoring system
-* Managed connectors
-* Higher limits and quotas (see xref:get-started:cluster-types/serverless.adoc#limits[Serverless limits])
-
-Consider Dedicated or BYOC if you need any of the following:
-
-* Control over the deployment
 * Private networking
-* Workloads with consistently-high throughput
+* Single-zone or multi-zone availability. A multi-zone cluster provides higher resiliency in the event of a failure in one of the zones. 
+* Ability to export metrics to a 3rd-party monitoring system
+* Kafka connectors
+* Higher limits and quotas. See xref:reference:tiers/dedicated-tiers.adoc[Dedicated usage tiers] and xref:reference:tiers/byoc-tiers.adoc[BYOC usage tiers] compared to xref:get-started:cluster-types/serverless.adoc#limits[Serverless limits].
 
 == Shared responsibility model
 
@@ -251,10 +245,10 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk cluster storage`
 ** `rpk generate app` (supported in Serverless clusters)
 ** `rpk security user` (supported in Serverless clusters)
-** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and self-hosted)
+** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and self-managed)
 ** `rpk transform` commands (currently in beta for Redpanda Cloud)
 
-NOTE: The `rpk cloud` commands are not supported in self-hosted deployments.
+NOTE: The `rpk cloud` commands are not supported in self-managed deployments.
 
 == Next steps
 * xref:get-started:cluster-types/serverless.adoc[Create a Serverless Cluster]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -25,7 +25,7 @@ With Serverless clusters, you host your data in Redpanda's VPC, and Redpanda han
 
 To start using Serverless, https://redpanda.com/try-redpanda/cloud-trial#serverless[sign up for a free trial^]. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required for a trial. To continue using your Serverless cluster after the free trial, add a credit card and pay as you go. 
 
-You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Serverless clusters. With a usage-based pay-as-you-go subscription, you only pay for what you use and can cancel anytime. 
+You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Serverless clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
 
 NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#limits[usage limits]. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -70,7 +70,7 @@ Here are some helpful `rpk` commands:
 
 NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example, automatic topic creation is disabled. Some systems expect the Kafka service to automatically create topics when a message is produced to a topic that doesn't exist. Create topics on the *Topics* page or with `rpk topic create`.
 
-=== Run a demo application
+=== Create a demo application
 
 To generate a sample application to connect with Redpanda, run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`]. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -74,7 +74,7 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 
 To generate a sample application to connect with Redpanda, run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`]. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
 
-== Create a Serverless cluster
+== Create a new Serverless cluster
 
 To create additional Serverless clusters: 
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -72,7 +72,9 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 
 === Create a demo application
 
-To generate a sample application to connect with Redpanda, run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`]. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
+Redpanda can generate a sample application to interact with your cluster. Run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`] and select a programming language. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
+
+Or, you can create your own Kafka client to interact with your cluster. 
 
 == Create a new Serverless cluster
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -41,7 +41,7 @@ When either the 100 credits expire or the 14 days in the trial expire, the clust
 * To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel, or contact https://support.redpanda.com/hc/en-us/requests/new[support^].
 * For information about billing after the trial ends, see xref:billing:billing.adoc[].
 
-== Interact with your trial cluster
+== Explore your trial cluster
 
 After you click to start a trial, Redpanda instantly prepares an account for you. Your account includes a `welcome` cluster with a `hello-world` demo topic you can explore. The `hello-world` topic starts as a free read-only topic. It is materialized and becomes billable with your credits if you produce messages to it. 
 
@@ -59,7 +59,13 @@ rpk cloud login
 rpk topic consume hello-world
 ```
 
-In the https://cloud.redpanda.com[Redpanda Cloud UI^], you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. The *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. 
+In the https://cloud.redpanda.com[Redpanda Cloud UI^], you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
+
+== Connect with your cluster
+
+Create a Kafka client to interact with your cluster. The *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. 
+
+Or, Redpanda can generate a sample application to interact with your cluster. Run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`], and select your preferred programming language. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
 
 Here are some helpful `rpk` commands:
 
@@ -70,21 +76,13 @@ Here are some helpful `rpk` commands:
 
 NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example, automatic topic creation is disabled. Some systems expect the Kafka service to automatically create topics when a message is produced to a topic that doesn't exist. Create topics on the *Topics* page or with `rpk topic create`.
 
-=== Create a demo application
-
-Redpanda can generate a sample application to interact with your cluster. Run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`] and select a programming language. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
-
-Or, you can create your own Kafka client to interact with your cluster. 
-
 == Create a new Serverless cluster
 
 To create additional Serverless clusters: 
 
-. Log in to https://cloud.redpanda.com[Redpanda Cloud^].
+. In Redpanda Cloud UI, on the **Clusters** page, click **Create cluster**, then click **Create Serverless cluster**. 
 
-. On the **Clusters** page, click **Create cluster**, then click **Create Serverless cluster**. 
-+
-Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one. Refresh the page to see newly-created resource groups. 
+. Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one. Refresh the page to see newly-created resource groups. 
 +
 Serverless clusters are currently available in certain AWS regions. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
 
@@ -100,3 +98,8 @@ Serverless clusters are currently available in certain AWS regions. Redpanda exp
 * Data transforms
 * Redpanda Admin API 
 * HTTP Proxy API
+
+== Next steps
+
+* xref:get-started:cloud-overview.adoc[Learn more about Redpanda Cloud]
+* xref:get-started:config-topics.adoc[Manage topics]

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -84,7 +84,7 @@ To create additional Serverless clusters:
 
 . On the **Clusters** page, click **Create cluster**, then click **Create Serverless cluster**. 
 +
-Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one.  
+Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one. Refresh the page to see newly-created resource groups. 
 +
 Serverless clusters are currently available in certain AWS regions. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -2,7 +2,7 @@
 :description: Learn how to create a Serverless cluster.
 :page-aliases: deploy:deployment-option/cloud/serverless.adoc
 
-Serverless is the fastest and easiest way to start data streaming. There is no base cost, and with pay-as-you-go billing after the free trial, you only pay for what you consume. For information about all Redpanda Cloud cluster types, see xref:get-started:cloud-overview.adoc[].
+Serverless is the fastest and easiest way to start data streaming. A cluster is available instantly, there is no base cost, and you only pay for what you consume. For information about all Redpanda Cloud cluster types, see xref:get-started:cloud-overview.adoc[].
 
 NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#limits[usage limits]. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 
@@ -34,11 +34,9 @@ Each Serverless cluster has the following limits:
 
 == Get started with Serverless trial
 
-New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
+New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. Each trial supports five Serverless clusters. 
 
 When either the 100 credits expire or the 14 days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a 7 day grace period following the end of the trial. After that, the data is permanently deleted. 
-
-Each trial supports five Serverless clusters. To continue after the trial expires, you can enter a credit card and pay as you go. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
 
 * To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel, or contact https://support.redpanda.com/hc/en-us/requests/new[support^].
 * For information about billing after the trial ends, see xref:billing:billing.adoc[].
@@ -47,7 +45,7 @@ Each trial supports five Serverless clusters. To continue after the trial expire
 
 After you click to start a trial, Redpanda instantly prepares an account for you. Your account includes a `welcome` cluster with a `hello-world` demo topic you can explore. The `hello-world` topic starts as a free read-only topic. It is materialized and becomes billable with your credits if you produce messages to it. 
 
-Use `rpk` to interact with your cluster from the command line. Follow the steps in the UI:
+Follow the steps in the UI to use `rpk` to interact with your cluster from the command line:
 
 . Log in:
 +
@@ -61,7 +59,7 @@ rpk cloud login
 rpk topic consume hello-world
 ```
 
-In the https://cloud.redpanda.com[Redpanda Cloud UI^], you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
+In the https://cloud.redpanda.com[Redpanda Cloud UI^], you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. The *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. 
 
 Here are some helpful `rpk` commands:
 
@@ -72,11 +70,9 @@ Here are some helpful `rpk` commands:
 
 NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example, automatic topic creation is disabled. Some systems expect the Kafka service to automatically create topics when a message is produced to a topic that doesn't exist. Create topics on the *Topics* page or with `rpk topic create`.
 
-== Run a demo application
+=== Run a demo application
 
-You can run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`] to generate a sample application to connect with Redpanda. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
-
-The Redpanda Cloud *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. 
+To generate a sample application to connect with Redpanda, run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`]. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
 
 == Create a Serverless cluster
 
@@ -93,14 +89,10 @@ Serverless clusters are currently available in certain AWS regions. Redpanda exp
 == Supported features
 
 * Redpanda Serverless supports the Kafka API. 
-
 * Serverless clusters work with all Kafka clients. For more information, see xref:develop:kafka-clients.adoc[].
-
 * Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
 
 === Unsupported features
-
-The following features are not yet supported in Serverless clusters: 
 
 * Kafka Connect managed connectors
 * Data transforms

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -2,11 +2,7 @@
 :description: Learn how to create a Serverless cluster.
 :page-aliases: deploy:deployment-option/cloud/serverless.adoc
 
-To start using Redpanda Serverless, sign up for a free trial. Each trial supports five Serverless clusters. To continue after the trial expires, you can enter a credit card and pay as you go. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
-
-* To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel, or contact https://support.redpanda.com/hc/en-us/requests/new[support^].
-* For information about Redpanda Cloud cluster types, see xref:get-started:cloud-overview.adoc[].
-* For information about billing after the trial ends, see xref:billing:billing.adoc[].
+Serverless is the fastest and easiest way to start data streaming. There is no base cost, and with pay-as-you-go billing after the free trial, you only pay for what you consume. For information about all Redpanda Cloud cluster types, see xref:get-started:cloud-overview.adoc[].
 
 NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#limits[usage limits]. During LA, existing clusters can scale to the usage limits, but new clusters may need to wait for availability.
 
@@ -36,52 +32,77 @@ Each Serverless cluster has the following limits:
 * Partition counts do not include partition replicas.
 ====
 
-== Trial credits
+== Get started with Serverless trial
 
 New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
 
 When either the 100 credits expire or the 14 days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a 7 day grace period following the end of the trial. After that, the data is permanently deleted. 
 
-== Get started
+Each trial supports five Serverless clusters. To continue after the trial expires, you can enter a credit card and pay as you go. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
+
+* To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel, or contact https://support.redpanda.com/hc/en-us/requests/new[support^].
+* For information about billing after the trial ends, see xref:billing:billing.adoc[].
+
+== Interact with your trial cluster
 
 After you click to start a trial, Redpanda instantly prepares an account for you. Your account includes a `welcome` cluster with a `hello-world` demo topic you can explore. The `hello-world` topic starts as a free read-only topic. It is materialized and becomes billable with your credits if you produce messages to it. 
 
-== Interact with your cluster
+Use `rpk` to interact with your cluster from the command line. Follow the steps in the UI:
 
-Similar to Dedicated and BYOC clusters, you can interact with your Serverless cluster with `rpk` CLI commands or with the Redpanda Cloud UI. For example, you can run `rpk topic consume hello-world` to read the messages in that topic explaining the `rpk` steps to stream data. Here are some helpful `rpk` commands:
+. Log in:
++
+```
+rpk cloud login
+```
+
+. Consume from the `hello-world` topic:
++
+```
+rpk topic consume hello-world
+```
+
+In the https://cloud.redpanda.com[Redpanda Cloud UI^], you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
+
+Here are some helpful `rpk` commands:
 
 * xref:reference:rpk/rpk-cloud/rpk-cloud-login.adoc[`rpk cloud login`]: Use this to log in to Redpanda Cloud or to refresh the session.
 * xref:reference:rpk/rpk-topic.adoc[`rpk topic`]: Use this to manage topics, produce data, and consume data. 
 * xref:reference:rpk/rpk-profile/rpk-profile-print.adoc[`rpk profile print`]: Use this to view your `rpk` configuration and see the URL for your Serverless cluster.
 * xref:reference:rpk/rpk-security/rpk-security-user.adoc[`rpk security user`]: Use this to manage users and permissions. 
 
-Alternatively, in the Redpanda Cloud UI, you can navigate to the *Topics* page and open the `hello-world` topic to see the included messages. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
-
 NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example, automatic topic creation is disabled. Some systems expect the Kafka service to automatically create topics when a message is produced to a topic that doesn't exist. Create topics on the *Topics* page or with `rpk topic create`.
 
 == Run a demo application
 
-Run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`] to generate a sample application to connect with Redpanda. 
+You can run xref:reference:rpk/rpk-generate/rpk-generate-app.adoc[`rpk generate app`] to generate a sample application to connect with Redpanda. Follow the commands in the terminal to run the application, create a demo topic, produce to the topic, and consume the data back.
 
-The Redpanda Cloud *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. In the same section, you can click *Go*, *Python*, or *Node.js* for code examples to create a topic and produce and consume messages. 
+The Redpanda Cloud *Overview* page lists your bootstrap server URL and security settings in the *How to connect - Kafka API* tab. 
 
-== Create a new cluster
+== Create a Serverless cluster
 
-Click the default resource group in the breadcrumbs to return to the *Clusters* page and create a new Serverless cluster. 
+To create additional Serverless clusters: 
 
+. Log in to https://cloud.redpanda.com[Redpanda Cloud^].
+
+. On the **Clusters** page, click **Create cluster**, then click **Create Serverless cluster**. 
++
+Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one.  
++
 Serverless clusters are currently available in certain AWS regions. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
 
 == Supported features
 
-Serverless clusters work with all Kafka clients. For more information, see xref:develop:kafka-clients.adoc[].
+* Redpanda Serverless supports the Kafka API. 
 
-Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
+* Serverless clusters work with all Kafka clients. For more information, see xref:develop:kafka-clients.adoc[].
+
+* Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
 
 === Unsupported features
-
-Redpanda Serverless supports the Kafka API. The Redpanda Admin and HTTP Proxy APIs are not exposed. 
 
 The following features are not yet supported in Serverless clusters: 
 
 * Kafka Connect managed connectors
 * Data transforms
+* Redpanda Admin API 
+* HTTP Proxy API


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-616
Review deadline: Oct 11

## Page previews
https://deploy-preview-83--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)