### PR TITLE
DOC-600 Fix spacing on redpanda_migrator headers

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-600_Set_beta_flags_on_connectors
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-600_Set_beta_flags_on_connectors
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/develop/pages/connect/components/inputs/redpanda_migrator.adoc
+++ b/modules/develop/pages/connect/components/inputs/redpanda_migrator.adoc
@@ -1,4 +1,3 @@
 = redpanda_migrator
 :page-aliases: components:inputs/redpanda_migrator.adoc
- 
 include::redpanda-connect:components:inputs/redpanda_migrator.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/inputs/redpanda_migrator_bundle.adoc
+++ b/modules/develop/pages/connect/components/inputs/redpanda_migrator_bundle.adoc
@@ -1,4 +1,3 @@
 = redpanda_migrator_bundle
 :page-aliases: components:inputs/redpanda_migrator_bundle.adoc
-
 include::redpanda-connect:components:inputs/redpanda_migrator_bundle.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/redpanda_migrator.adoc
+++ b/modules/develop/pages/connect/components/outputs/redpanda_migrator.adoc
@@ -1,4 +1,3 @@
 = redpanda_migrator
 :page-aliases: components:outputs/redpanda_migrator.adoc
-
 include::redpanda-connect:components:outputs/redpanda_migrator.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/redpanda_migrator_bundle.adoc
+++ b/modules/develop/pages/connect/components/outputs/redpanda_migrator_bundle.adoc
@@ -1,4 +1,3 @@
 = redpanda_migrator_bundle
 :page-aliases: components:outputs/redpanda_migrator_bundle.adoc
-
 include::redpanda-connect:components:outputs/redpanda_migrator_bundle.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/redpanda_migrator_offsets.adoc
+++ b/modules/develop/pages/connect/components/outputs/redpanda_migrator_offsets.adoc
@@ -1,4 +1,3 @@
 = redpanda_migrator_offsets
 :page-aliases: components:outputs/redpanda_migrator_offsets.adoc
-
 include::redpanda-connect:components:outputs/redpanda_migrator_offsets.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/2744
Review deadline: 16 October

See associated PR: https://github.com/redpanda-data/rp-connect-docs/pull/73

Fixes problem with beta tagging of redpanda_migrator components in the Cloud.

Changes to local-antora-playbook.yml must be reversed before merging.

## Page previews

Inputs

[redpanda_migrator](https://deploy-preview-89--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/redpanda_migrator/)
[redpanda_migrator_bundle](https://deploy-preview-89--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/redpanda_migrator_bundle/)

Outputs

[redpanda_migrator](https://deploy-preview-89--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/redpanda_migrator/)
[redpanda_migrator_bundle](https://deploy-preview-89--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/redpanda_migrator_bundle/)
[redpanda_migrator_offsets](https://deploy-preview-89--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/redpanda_migrator_offsets/) 

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)