### PR TITLE
Update terraform-provider.adoc

### DIFF
--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -17,7 +17,7 @@ You can use the Redpanda Terraform provider to create and manage the following r
 == Prerequisites
 
 * Install Terraform using the https://learn.hashicorp.com/tutorials/terraform/install-cli[Terraform documentation^].
-* Log in to https://cloud.redpanda.com[Redpanda Cloud^], navigate to the *Organization IAM - Service account* page, and create a service account. The service account acts as an OAuth 2.0 client, and you will use its credentials (client ID and client secret) to authenticate to the Cloud API. 
+* Log in to https://cloud.redpanda.com[Redpanda Cloud^], navigate to the *Clients* page, and create a service account. The service account acts as an OAuth 2.0 client, and you will use its credentials (client ID and client secret) to authenticate to the Cloud API. 
 
 == Limitations
 
@@ -52,7 +52,7 @@ terraform {
 terraform init
 ```
 
-. Add the credentials for the Redpanda Cloud service account you set in the prerequisites. In the Redpanda Cloud UI, find the client ID and client secret on the *Organization IAM - Service account* page. Set them as environment variables, or enter them in your Terraform configuration file:
+. Add the credentials for the Redpanda Cloud service account you set in the prerequisites. In the Redpanda Cloud UI, find the client ID and client secret on the *Clients* page. Set them as environment variables, or enter them in your Terraform configuration file:
 +
 [tabs]
 ======


### PR DESCRIPTION
Changes Organization IAM page back to Clients page (since RBAC not out yet)

## Description


## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)