### PR TITLE
DOC-646 Document AWS BYOC prereqs

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -8,10 +8,11 @@ See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpa
 
 == Prerequisites
 
-With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, xref:security:authorization/cloud-iam-policies.adoc[IAM roles], firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check all prerequisites: 
+With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check all prerequisites: 
 
 * You have a minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
-* Your environment has the necessary AWS variables to authenticate. Use either:
+* You have the xref:security:authorization/cloud-iam-policies.adoc[IAM policies] necessary to launch infrastructure for running Redpanda. 
+* Your environment has the AWS variables necessary to authenticate. Use either:
 +
 --
 ** `AWS_PROFILE` or

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -8,17 +8,17 @@ See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpa
 
 == Prerequisites
 
-With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check all prerequisites: 
+With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check that the user creating the cluster has the following prerequisites: 
 
-* You have a minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
-* You have the xref:security:authorization/cloud-iam-policies.adoc[IAM policies] necessary to launch infrastructure for running Redpanda. 
-* Your environment has the AWS variables necessary to authenticate. Use either:
+* A minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
+* The permissions necessary to launch infrastructure for running Redpanda. See xref:security:authorization/cloud-iam-policies.adoc[IAM policies]
+* The AWS variables necessary to authenticate. Use either:
 +
 --
 ** `AWS_PROFILE` or
 ** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
 
-To verify access, you should be able to successfully run `aws sts get-caller-identity` for your region. For more information, see the https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html[AWS CLI reference^].
+To verify access, you should be able to successfully run `aws sts get-caller-identity` for your region. See the https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html[AWS CLI reference^].
 --
 
 == Create a BYOC cluster

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -6,6 +6,20 @@ To create a Redpanda cluster in your virtual private cloud (VPC), follow the ins
 
 See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpanda Cloud architecture].
 
+== Prerequisites
+
+With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, xref:security:authorization/cloud-iam-policies.adoc[IAM roles], firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check all prerequisites: 
+
+* You have a minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
+* Your environment has the necessary AWS variables to authenticate. Use either:
++
+--
+** `AWS_PROFILE` or
+** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+
+To verify access, you should be able to successfully run `aws sts get-caller-identity` for your region. For more information, see the https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html[AWS CLI reference^].
+--
+
 == Create a BYOC cluster
 
 . Log in to https://cloud.redpanda.com[Redpanda Cloud^].

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -11,7 +11,7 @@ See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpa
 With BYOC, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. Before you deploy a BYOC cluster on AWS, check that the user creating the cluster has the following prerequisites: 
 
 * A minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
-* The permissions necessary to launch infrastructure for running Redpanda. See xref:security:authorization/cloud-iam-policies.adoc[IAM policies]
+* The permissions necessary to launch infrastructure for running Redpanda. See xref:security:authorization/cloud-iam-policies.adoc[IAM policies].
 * The AWS variables necessary to authenticate. Use either:
 +
 --

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -10,7 +10,7 @@ Before you deploy a BYOC cluster on Azure, check all prerequisites to ensure tha
 
 === Verify rpk version
 
-Confirm you have a minimum version of Redpanda `rpk` v24.1. See xref:reference:rpk/rpk-version.adoc[`rpk version`] or xref:manage:rpk/intro-to-rpk.adoc[].
+Confirm you have a minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
 
 === Prepare your Azure subscription
 

--- a/modules/manage/pages/rpk/rpk-install.adoc
+++ b/modules/manage/pages/rpk/rpk-install.adoc
@@ -1,4 +1,4 @@
-= Install rpk
+= Install or Update rpk
 :page-aliases: get-started:rpk-install.adoc, quickstart:rpk-install.adoc
 :page-categories: rpk
 include::ROOT:get-started:rpk-install.adoc[tag=single-source]

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -4,7 +4,7 @@ agent access, so that brokers can communicate with the BYOC clusters.
 
 See also: xref:get-started:cloud-overview.adoc#byoc-architecture[BYOC architecture]
 
-NOTE: This page lists the IAM permissions Redpanda uses. Nothing is required by Redpanda Cloud users. 
+NOTE: This page lists the IAM permissions Redpanda needs to create BYOC clusters. Nothing is required by Redpanda Cloud users. 
 
 ifdef::env-aws[]
 == AWS IAM policies

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -4,7 +4,7 @@ agent access, so that brokers can communicate with the BYOC clusters.
 
 See also: xref:get-started:cloud-overview.adoc#byoc-architecture[BYOC architecture]
 
-NOTE: This page lists the IAM permissions Redpanda needs to create BYOC clusters. Nothing is required by Redpanda Cloud users. 
+NOTE: This page lists the IAM permissions Redpanda needs to create a BYOC cluster. No IAM permissions are required for Redpanda Cloud users. 
 
 ifdef::env-aws[]
 == AWS IAM policies


### PR DESCRIPTION
## Description
This adds a prereqs section to the doc for BYOC on AWS (based on [this slack thread](https://redpandadata.slack.com/archives/C0191NM4WU9/p1729002110977339)).

Resolves https://redpandadata.atlassian.net/browse/DOC-646
Review deadline: Friday Oct 25

## Page previews
[Create a BYOC Cluster on AWS](https://deploy-preview-96--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/create-byoc-cluster-aws/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)