### PR TITLE
DOC-628 document TLS for private networking

### DIFF
--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -7,10 +7,10 @@ clusters and another for public Redpanda clusters. By default, networks are alwa
 laid out across multiple availability zones (AZs) to enable the creation of one or
 many single and multi-AZ Redpanda clusters within them.
 
-== Public Redpanda clusters
-
-With public Redpanda clusters, TCP listeners are protected by SASL/SCRAM
+With both private and public Redpanda clusters, TCP listeners are protected by SASL/SCRAM
 (SCRAM-SHA-256, SCRAM-SHA-512) authentication and encrypted in transit using TLS 1.2.
+
+== Public Redpanda clusters
 
 The following diagram shows the public subnet used by public Redpanda clusters.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-628
Review deadline: Friday Oct 25

## Page previews
https://deploy-preview-97--rp-cloud.netlify.app/redpanda-cloud/networking/cloud-security-network/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)