### PR TITLE
DOC-667 Enable azure_data_lake_gen2 output in Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-667_azure_data_lake_gen2_output
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-667_azure_data_lake_gen2_output
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -119,6 +119,7 @@
 **** xref:develop:connect/components/outputs/aws_sqs.adoc[]
 **** xref:develop:connect/components/outputs/azure_blob_storage.adoc[]
 **** xref:develop:connect/components/outputs/azure_cosmosdb.adoc[]
+**** xref:develop:connect/components/outputs/azure_data_lake_gen2.adoc[]
 **** xref:develop:connect/components/outputs/azure_queue_storage.adoc[]
 **** xref:develop:connect/components/outputs/azure_table_storage.adoc[]
 **** xref:develop:connect/components/outputs/broker.adoc[]

--- a/modules/develop/pages/connect/components/outputs/azure_data_lake_gen2.adoc
+++ b/modules/develop/pages/connect/components/outputs/azure_data_lake_gen2.adoc
@@ -1,0 +1,3 @@
+= azure_data_lake_gen2
+:page-aliases: components:outputs/azure_data_lake_gen2.adoc
+include::redpanda-connect:components:outputs/azure_data_lake_gen2.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 30th October

**Change to local playbook must be reverted before merging**

## Page previews

[azure_data_lake_gen2 output](https://deploy-preview-101--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/azure_data_lake_gen2/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)