### PR TITLE
DOC-667 Adds timeplus output to cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-667_timeplus_output
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-667_timeplus_output
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -157,6 +157,7 @@
 **** xref:develop:connect/components/outputs/sql_raw.adoc[]
 **** xref:develop:connect/components/outputs/switch.adoc[]
 **** xref:develop:connect/components/outputs/sync_response.adoc[]
+**** xref:develop:connect/components/outputs/timeplus.adoc[]
 
 *** xref:develop:connect/components/processors/about.adoc[]
 **** xref:develop:connect/components/processors/archive.adoc[]

--- a/modules/develop/pages/connect/components/outputs/timeplus.adoc
+++ b/modules/develop/pages/connect/components/outputs/timeplus.adoc
@@ -1,0 +1,3 @@
+= timeplus
+:page-aliases: components:outputs/timeplus.adoc
+include::redpanda-connect:components:outputs/timeplus.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves: https://github.com/redpanda-data/cloud-docs/pull/new/DOC-667-timeplus_output_cloud
Review deadline: 30th October

## Page previews

[Timeplus output](https://deploy-preview-102--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/timeplus/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)