### PR TITLE
Remove verbiage about components we don't offer

### DIFF
--- a/modules/develop/pages/managed-connectors/index.adoc
+++ b/modules/develop/pages/managed-connectors/index.adoc
@@ -13,12 +13,10 @@ Redpanda.
 Each connector is either a source or a sink:
 
 * A source connector imports data from a source system into a Redpanda cluster.
-The source could be a cloud storage system such as S3 or GCS. The source connector's
-main task is to fetch data from these sources and convert them into a format
-suitable for Redpanda.
+The source connector's main task is to fetch data from these sources and convert 
+them into a format suitable for Redpanda.
 * A sink connector exports data from a Redpanda cluster and pushes it into a
-target system. The target could be a cloud storage system such as S3 or GCS.
-Sink connectors read the data from Redpanda and transform it into a format
-that the target system can use.
+target system. Sink connectors read the data from Redpanda and transform it into 
+a format that the target system can use.
 
 These sources and sinks work together to create a data pipeline that can move and transform data from one system to another.


### PR DESCRIPTION
We don't provide a S3 or GCS source, only a sink. Remove the verbiage to prevent confusion.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)