### PR TITLE
Using secrets with Kafka Connect Service API

### DIFF
--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -105,7 +105,9 @@ curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.c
 
 NOTE: Connector management is supported in BYOC and Dedicated clusters only.
 
-To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/connect/clusters/-cluster_name-/connectors[`/v1alpha1/connect/clusters/\{cluster_name}/connectors`]. The following example shows how to create an S3 sink connector with the name `my-connector`:
+To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/connect/clusters/-cluster_name-/connectors[`/v1alpha1/connect/clusters/\{cluster_name}/connectors`]. 
+
+The following example shows how to create an S3 sink connector with the name `my-connector`:
 
 [,bash]
 ----
@@ -113,8 +115,25 @@ curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.c
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
- -d '{"config":{"connector.class":"com.redpanda.kafka.connect.s3.S3SinkConnector","topics":"test-topic","aws.secret.access.key":"secret-key","aws.s3.bucket.name":"bucket-name","aws.access.key.id":"access-key","aws.s3.bucket.check":"false","region":"us-east-1"},"name":"my-sample-connector"}'
+ -d '{"config":{"connector.class":"com.redpanda.kafka.connect.s3.S3SinkConnector","topics":"test-topic","aws.secret.access.key":"secret-key","${secretsManager:<secret-id>}":"bucket-name","aws.access.key.id":"access-key","aws.s3.bucket.check":"false","region":"us-east-1"},"name":"my-sample-connector"}'
 ----
+
+[CAUTION]
+====
+The field `aws.secret.access.key` contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
+
+To create a secret that you can reference in the connector configuration request:
+
+[,bash]
+----
+curl -X POST "https://api.redpanda.com/v1alpha2/kafka-connect/clusters/<cluster-name>/secrets" \
+ -H 'accept: application/json'\
+ -H 'content-type: application/json' \
+ -d '{"name":"<>","secret_data":"<secret-value>"}' 
+----
+
+Use the `id` returned in the response to replace the placeholder `<secret-id>` in the above example.
+====
 
 Example success response:
 

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -105,7 +105,7 @@ curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
 
 NOTE: Kafka Connect is supported in BYOC and Dedicated clusters only.
 
-To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
+To create a Kafka Connect connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
 The following example shows how to create an S3 sink connector with the name `my-connector`:
 
@@ -120,7 +120,7 @@ curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/conne
 
 [CAUTION]
 ====
-The field `aws.secret.access.key` in the above example contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
+The field `aws.secret.access.key` in the example contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
 
 To create a secret that you can reference in the connector configuration request:
 
@@ -132,7 +132,7 @@ curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpan
  -d '{"name":"<connector-name>","secret_data":"<secret-value>"}' 
 ----
 
-Use the `id` returned in the Create Secret response to replace the placeholder `<secret-id>` in the Create Connector example above. The syntax `${secretsManager:<secret-id>}` tells the Kafka Connect cluser to load `<secret-id>`. 
+Use the `id` returned in the Create Secret response to replace the placeholder `<secret-id>` in the previous Create Connector example. The syntax `${secretsManager:<secret-id>}` tells the Kafka Connect cluster to load `<secret-id>`. 
 ====
 
 Example success response:

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -103,7 +103,7 @@ curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
 
 === Create a connector
 
-NOTE: Connector management is supported in BYOC and Dedicated clusters only.
+NOTE: Kafka Connect is supported in BYOC and Dedicated clusters only.
 
 To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
@@ -158,7 +158,7 @@ Example success response:
 
 === Restart a connector
 
-NOTE: Connector management is supported in BYOC and Dedicated clusters only.
+NOTE: Kafka Connect is supported in BYOC and Dedicated clusters only.
 
 To restart a connector, make a POST request to the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
 

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -7,7 +7,7 @@ The Redpanda Cloud API is a collection of REST APIs that allow you to interact w
 
 For the full Cloud API reference documentation, see xref:api:ROOT:cloud-api.adoc[Redpanda Cloud API Reference].
 
-The xref:manage:api/cloud-api-overview.adoc#cloud-api-architecture[data plane] contains the actual Redpanda clusters. Every cluster is its own data plane, and so it has its own distinct Data Plane API URL.
+The xref:manage:api/cloud-api-overview.adoc#cloud-api-architecture[data plane] contains the actual Redpanda clusters. Every cluster is its own data plane, and so it has its own distinct xref:manage:api/cloud-api-overview.adoc#data-plane-apis-url[Data Plane API URL].
 
 == Get Data Plane API URL
 
@@ -43,11 +43,11 @@ The response includes a `dataplane_api.url` value:
 
 === Create a user
 
-To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/users[`/v1alpha1/users`] endpoint, including the SASL mechanism, username, and password in the request body:
+To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/users[`/v1alpha2/users`] endpoint, including the SASL mechanism, username, and password in the request body:
 
 [,bash]
 ----
-curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha1/users" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/users" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -70,11 +70,11 @@ The success response returns the newly-created username and SASL mechanism:
 
 === Create an ACL
 
-To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/acls[`POST /v1alpha1/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
+To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/acls[`POST /v1alpha2/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
 
 [,bash]
 ----
-curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha1/acls" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/acls" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -90,49 +90,49 @@ The success response is empty, with a 201 status code.
 
 === Create a topic
 
-To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/topics[`/v1alpha1/topics`] endpoint:
+To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/topics[`/v1alpha2/topics`] endpoint:
 
 [,bash]
 ----
-curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha1/topics" \
+curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
- -d '{"name":"my-simple-test-topic"}'
+ -d '{"name":"<topic-name>"}'
 ----
 
 === Create a connector
 
 NOTE: Connector management is supported in BYOC and Dedicated clusters only.
 
-To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/connect/clusters/-cluster_name-/connectors[`/v1alpha1/connect/clusters/\{cluster_name}/connectors`]. 
+To create a managed connector, make a POST request to xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
 The following example shows how to create an S3 sink connector with the name `my-connector`:
 
 [,bash]
 ----
-curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha1/connect/clusters/redpanda/connectors" \
+curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
- -d '{"config":{"connector.class":"com.redpanda.kafka.connect.s3.S3SinkConnector","topics":"test-topic","aws.secret.access.key":"secret-key","${secretsManager:<secret-id>}":"bucket-name","aws.access.key.id":"access-key","aws.s3.bucket.check":"false","region":"us-east-1"},"name":"my-sample-connector"}'
+ -d '{"config":{"connector.class":"com.redpanda.kafka.connect.s3.S3SinkConnector","topics":"test-topic","aws.secret.access.key":"${secretsManager:<secret-id>}","aws.s3.bucket.name":"bucket-name","aws.access.key.id":"access-key","aws.s3.bucket.check":"false","region":"us-east-1"},"name":"my-connector"}'
 ----
 
 [CAUTION]
 ====
-The field `aws.secret.access.key` contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
+The field `aws.secret.access.key` in the above example contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
 
 To create a secret that you can reference in the connector configuration request:
 
 [,bash]
 ----
-curl -X POST "https://api.redpanda.com/v1alpha2/kafka-connect/clusters/<cluster-name>/secrets" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/secrets" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
- -d '{"name":"<>","secret_data":"<secret-value>"}' 
+ -d '{"name":"<connector-name>","secret_data":"<secret-value>"}' 
 ----
 
-Use the `id` returned in the response to replace the placeholder `<secret-id>` in the above example.
+Use the `id` returned in the Create Secret response to replace the placeholder `<secret-id>` in the Create Connector example above. The syntax `${secretsManager:<secret-id>}` tells the Kafka Connect cluser to load `<secret-id>`. 
 ====
 
 Example success response:
@@ -140,14 +140,14 @@ Example success response:
 [.no-copy]
 ----
 {
-  "name": "my-sample-connector",
+  "name": "my-connector",
   "config": {
     "aws.access.key.id": "access-key",
     "aws.s3.bucket.check": "false",
     "aws.s3.bucket.name": "bucket-name",
     "aws.secret.access.key": "secret-key",
     "connector.class": "com.redpanda.kafka.connect.s3.S3SinkConnector",
-    "name": "my-sample-connector",
+    "name": "my-connector",
     "region": "us-east-1",
     "topics": "test-topic"
   },
@@ -160,11 +160,11 @@ Example success response:
 
 NOTE: Connector management is supported in BYOC and Dedicated clusters only.
 
-To restart a connector, make a POST request to the xref:api:ROOT:cloud-api.adoc#post-/v1alpha1/connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha1/connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
+To restart a connector, make a POST request to the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
 
 [,bash]
 ----
-curl -X POST "https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha1/connect/clusters/redpanda/connectors/my-connector/restart" \
+curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \


### PR DESCRIPTION
## Description

Cautions readers to use secrets to inject sensitive information into Create Connector API calls.

This PR also updates the API URLs to
- use the current data plane API version `v1alpha2`
- use `kafka-connect` for connector API urls
(So there is some overlap with #91 )

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 5 Nov

## Page previews

[Use the Data Plane APIs > Create a connector](https://deploy-preview-107--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-dataplane-api/#create-a-connector)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)