### PR TITLE
Update whats-new-cloud.adoc

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -17,7 +17,7 @@ You can contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpa
 
 Redpanda now supports compute-optimized tiers with AWS Graviton3 processors. This saves over 50% in instance costs in all xref:reference:tiers/byoc-tiers.adoc[BYOC tiers].
 
-=== Redpanda Terraform Provider for Redpanda Cloud
+=== Redpanda Terraform Provider for Redpanda Cloud: beta
 
 The xref:manage:terraform-provider.adoc[Redpanda Terraform provider] lets you create and manage resources in Redpanda Cloud, such as clusters, topics, users, ACLs, networks, and resource groups.
 


### PR DESCRIPTION
This just adds "beta" to the Terraform provider in the What's New

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews
https://deploy-preview-108--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)