### PR TITLE
Secret API requires Base64-encoded value

### DIFF
--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -169,7 +169,7 @@ curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/conne
 
 [CAUTION]
 ====
-The field `aws.secret.access.key` in the example contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the value of the key. You can then use the secret ID to inject the value of the secret in your request.
+The field `aws.secret.access.key` in the example contains sensitive information that usually shouldn't be added to a configuration directly. Use the xref:api:ROOT:cloud-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the Base64-encoded value of the key. You can then use the secret ID to inject the value of the secret in your request.
 
 To create a secret that you can reference in the connector configuration request:
 
@@ -178,7 +178,7 @@ To create a secret that you can reference in the connector configuration request
 curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/secrets" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
- -d '{"name":"<connector-name>","secret_data":"<secret-value>"}' 
+ -d '{"name":"<connector-name>","secret_data":"<secret-value-base64-encoded>"}' 
 ----
 
 Use the `id` returned in the Create Secret response to replace the placeholder `<secret-id>` in the previous Create Connector example. The syntax `${secretsManager:<secret-id>}` tells the Kafka Connect cluster to load `<secret-id>`. 


### PR DESCRIPTION
## Description

The API spec will also be updated with this PR https://github.com/redpanda-data/console/pull/1496

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 6 Nov

## Page previews

[Use the Data Plane APIs > Manage Kafka Connect > Create a Kafka Connect connector](https://deploy-preview-110--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-dataplane-api/#create-a-kafka-connect-connector)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)