### PR TITLE
Add ports for internal communication

### DIFF
--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -3,7 +3,7 @@
 :page-aliases: deploy:deployment-option/cloud/security/cloud-security-network.adoc
 
 Redpanda Cloud deploys two different types of networks: one for private Redpanda
-clusters and another for public Redpanda clusters. By default, networks are always
+clusters and one for public Redpanda clusters. By default, networks are always
 laid out across multiple availability zones (AZs) to enable the creation of one or
 many single and multi-AZ Redpanda clusters within them.
 
@@ -32,14 +32,16 @@ image::shared:cloud-private-network.png[Redpanda Cloud Security Architecture]
 
 == Network ports
 
-This section lists the ports on which Redpanda Cloud components communicate. Redpanda manages security group and firewall configurations on your behalf, but if you need to add to your own rule sets, these are the available network ports. 
+This section lists the external ports on which Redpanda Cloud components communicate. Redpanda manages security group and firewall configurations on your behalf, but if you need to add to your own rule sets, these are the available network ports. 
+
+NOTE: Redpanda also uses some ports for internal communication inside the cluster, including ports 80, 8081, 8082, and 9644. 
 
 === North-South
 
 The following table lists the network ports available to external clients within
 each data plane. For private-only Redpanda clusters, access to these ports is
 only possible through Redpanda Cloud network connections such as xref:networking:dedicated/vpc-peering.adoc[VPC peering],
-transit gateway attachments, or private links.
+transit gateway attachments, or Private Links/Private Service Connect.
 
 |===
 | Service | Port


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-171
Review deadline: Friday Nov 8

## Page previews
https://deploy-preview-112--rp-cloud.netlify.app/redpanda-cloud/networking/cloud-security-network/#network-ports

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)