### PR TITLE
doc cloud minimum replication factor

### DIFF
--- a/modules/get-started/pages/create-topic.adoc
+++ b/modules/get-started/pages/create-topic.adoc
@@ -14,9 +14,7 @@ After creating a cluster, you can create a topic for that cluster. Topic propert
 | The number of partitions for the topic.
 
 | *Replication factor*
-| The number of partition replicas for the topic. In Redpanda Cloud, the number of topic replicas is set to three. 
-
-IMPORTANT: Redpanda recommends that you do not change the replication factor value without discussing potential outcomes with your Redpanda support or customer success contact. In particular, updating the value for running Redpanda Cloud topics to a replication factor of one is _not_ recommended. If you do so, and data is lost, Redpanda is unable to assist with recovery. 
+| The number of partition replicas for the topic. Redpanda Cloud requires a minimum of 3 topic replicas. All topics are set to a replication factor 3 at topic creation. 
 
 | *Cleanup policy*
 | The policy that determines how to clean up old log segments. The default is *delete*.

--- a/modules/get-started/pages/create-topic.adoc
+++ b/modules/get-started/pages/create-topic.adoc
@@ -14,7 +14,7 @@ After creating a cluster, you can create a topic for that cluster. Topic propert
 | The number of partitions for the topic.
 
 | *Replication factor*
-| The number of partition replicas for the topic. Redpanda Cloud requires a minimum of 3 topic replicas. All topics are set to a replication factor 3 at topic creation. 
+| The number of partition replicas for the topic. Redpanda Cloud requires a minimum of 3 topic replicas. If a topic is created with a replication factor of 1, Redpanda resets the replication factor to 3. 
 
 | *Cleanup policy*
 | The policy that determines how to clean up old log segments. The default is *delete*.


### PR DESCRIPTION
## Description

Documents the new RF=3 enforcement in Redpanda Cloud. 

Resolves https://redpandadata.atlassian.net/browse/DOC-290
Review deadline: Monday Nov 11

## Page previews
[Create a topic](https://deploy-preview-115--rp-cloud.netlify.app/redpanda-cloud/get-started/create-topic/)

See also:
- https://github.com/redpanda-data/docs/pull/840 (for single-sourced content in `docs` repo)
- https://github.com/redpanda-data/docs/pull/841 (for glossary update in `shared` repo)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)