### PR TITLE
DOC-734 Add timeplus input to Cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-734_Add_timeplus_input
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -109,6 +109,7 @@
 **** xref:develop:connect/components/inputs/splunk.adoc[]
 **** xref:develop:connect/components/inputs/sql_raw.adoc[]
 **** xref:develop:connect/components/inputs/sql_select.adoc[]
+**** xref:develop:connect/components/inputs/timeplus.adoc[]
 
 *** xref:develop:connect/components/outputs/about.adoc[]
 **** xref:develop:connect/components/outputs/amqp_0_9.adoc[]

--- a/modules/develop/pages/connect/components/inputs/timeplus.adoc
+++ b/modules/develop/pages/connect/components/inputs/timeplus.adoc
@@ -1,0 +1,3 @@
+= timeplus
+:page-aliases: components:inputs/timeplus.adoc
+include::redpanda-connect:components:inputs/timeplus.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves: [https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>](https://redpandadata.atlassian.net/browse/DOC-734)
Review deadline:

**Revert change to local playbook before merging.**

## Page previews

timeplus input

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)