### PR TITLE
DOC-734 Adds `snowflake_streaming` output to the Cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-734_snowflake_streaming_output
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-734_snowflake_streaming_output
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -156,6 +156,7 @@
 **** xref:develop:connect/components/outputs/schema_registry.adoc[]
 **** xref:develop:connect/components/outputs/sftp.adoc[]
 **** xref:develop:connect/components/outputs/snowflake_put.adoc[]
+**** xref:develop:connect/components/outputs/snowflake_streaming.adoc[]
 **** xref:develop:connect/components/outputs/splunk_hec.adoc[]
 **** xref:develop:connect/components/outputs/sql_insert.adoc[]
 **** xref:develop:connect/components/outputs/sql_raw.adoc[]

--- a/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
+++ b/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
@@ -1,0 +1,3 @@
+= snowflake_streaming
+:page-aliases: components:outputs/snowflake_streaming.adoc
+include::redpanda-connect:components:outputs/snowflake_streaming.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
+++ b/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
@@ -1,3 +1,5 @@
 = snowflake_streaming
 :page-aliases: components:outputs/snowflake_streaming.adoc
+:page-beta: true
+
 include::redpanda-connect:components:outputs/snowflake_streaming.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-734](https://redpandadata.atlassian.net/browse/DOC-734)
Review deadline: 14 November

Adds `snowflake-streaming` output to the Cloud docs.

**Revert change to local playbook before merging**

## Page previews

[`snowflake_streaming` output](https://deploy-preview-118--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/snowflake_streaming/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-734]: https://redpandadata.atlassian.net/browse/DOC-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ