### PR TITLE
DOC-734 Add spicedb_watch input to Cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-734_spicedb_watch_input
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-734_spicedb_watch_input
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -106,6 +106,7 @@
 **** xref:develop:connect/components/inputs/schema_registry.adoc[]
 **** xref:develop:connect/components/inputs/sequence.adoc[]
 **** xref:develop:connect/components/inputs/sftp.adoc[]
+**** xref:develop:connect/components/inputs/spicedb_watch.adoc[]
 **** xref:develop:connect/components/inputs/splunk.adoc[]
 **** xref:develop:connect/components/inputs/sql_raw.adoc[]
 **** xref:develop:connect/components/inputs/sql_select.adoc[]

--- a/modules/develop/pages/connect/components/inputs/spicedb_watch.adoc
+++ b/modules/develop/pages/connect/components/inputs/spicedb_watch.adoc
@@ -1,0 +1,5 @@
+= spicedb_watch
+:page-aliases: components:inputs/spicedb_watch.adoc
+:page-beta: true
+
+include::redpanda-connect:components:inputs/spicedb_watch.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves: [DOC-734](https://redpandadata.atlassian.net/browse/DOC-734)
Review deadline: 15 November

## Page previews

[`spicedb_watch` input](https://deploy-preview-120--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/spicedb_watch/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-734]: https://redpandadata.atlassian.net/browse/DOC-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ