### PR TITLE
Update SM vs Cloud features compatibility

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -224,11 +224,12 @@ New clusters in Redpanda Cloud generally include functionality added in Self-Man
 
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
+- Integration with Apache Iceberg (private beta for Redpanda Cloud: to unlock this feature, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^])
+- Data transforms (beta for Redpanda Cloud)
+- Remote Read Replicas (beta for Redpanda Cloud)
+- Kafka API OIDC authentication (however, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
 - Admin API
 - FIPS-compliance mode
-- Data transforms (currently in beta for Redpanda Cloud)
-- Remote Read Replicas (currently in beta for Redpanda Cloud)
-- Kafka API OIDC authentication (however, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
 - Kerberos authentication
 - Redpanda debug bundles
 - Redpanda Console topic documentation
@@ -249,10 +250,10 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk iotune`
 ** `rpk redpanda`
 ** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed)
-** `rpk transform`  (currently in beta for Redpanda Cloud)
+** `rpk transform` (beta for Redpanda Cloud)
 ** `rpk generate app` (supported in Serverless clusters only)
 ** `rpk security user` (supported in Serverless clusters only)
-
++
 NOTE: The `rpk cloud` commands are not supported in self-managed deployments.
 
 == Next steps

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -224,7 +224,7 @@ New clusters in Redpanda Cloud generally include functionality added in Self-Man
 
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
-- Integration with Apache Iceberg (private beta for Redpanda Cloud: to unlock this feature, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^])
+- Integration with Apache Iceberg (contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^] for private beta access on BYOC)
 - Data transforms (beta for Redpanda Cloud)
 - Remote Read Replicas (beta for Redpanda Cloud)
 - Kafka API OIDC authentication (however, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
@@ -234,7 +234,8 @@ Redpanda Cloud deployments do not support the following functionality available 
 - Redpanda debug bundles
 - Redpanda Console topic documentation
 - Setting `auto_create_topics_enabled=true`
-- Customer-managed encryption keys for Tiered Storage 
+- Configure access to object storage with customer-managed encryption key
+- Kubernetes Helm chart and Redpanda Operator functionality
 - The following `rpk` commands:
  
 ** `rpk cluster config`

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -233,7 +233,7 @@ Redpanda Cloud deployments do not support the following functionality available 
 - Kerberos authentication
 - Redpanda debug bundles
 - Redpanda Console topic documentation
-- Setting `auto_create_topics_enabled=true`
+- Enabling automatic topic creation (create topics on the *Topics* page or with `rpk topic create`)
 - Configure access to object storage with customer-managed encryption key
 - Kubernetes Helm chart and Redpanda Operator functionality
 - The following `rpk` commands:

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -224,18 +224,18 @@ New clusters in Redpanda Cloud generally include functionality added in Self-Man
 
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
-- Integration with Apache Iceberg (contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^] for private beta access on BYOC)
-- Data transforms (beta for Redpanda Cloud)
-- Remote Read Replicas (beta for Redpanda Cloud)
-- Kafka API OIDC authentication (however, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO])
-- Admin API
-- FIPS-compliance mode
-- Kerberos authentication
-- Redpanda debug bundles
-- Redpanda Console topic documentation
-- Enabling automatic topic creation (create topics on the *Topics* page or with `rpk topic create`)
-- Configure access to object storage with customer-managed encryption key
-- Kubernetes Helm chart and Redpanda Operator functionality
+- Integration with Apache Iceberg. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
+- Data transforms. This is in beta for Redpanda Cloud.
+- Remote Read Replicas. This is in beta for Redpanda Cloud.
+- Kafka API OIDC authentication. However, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO].
+- Admin API.
+- FIPS-compliance mode.
+- Kerberos authentication.
+- Redpanda debug bundles.
+- Redpanda Console topic documentation.
+- Enabling automatic topic creation. Create topics on the *Topics* page or with `rpk topic create`.
+- Configuring access to object storage with customer-managed encryption key.
+- Kubernetes Helm chart and Redpanda Operator functionality.
 - The following `rpk` commands:
  
 ** `rpk cluster config`
@@ -250,10 +250,10 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk debug` 
 ** `rpk iotune`
 ** `rpk redpanda`
-** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed)
-** `rpk transform` (beta for Redpanda Cloud)
-** `rpk generate app` (supported in Serverless clusters only)
-** `rpk security user` (supported in Serverless clusters only)
+** `rpk topic describe-storage` (All other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed.)
+** `rpk transform` (This is in beta for Redpanda Cloud.)
+** `rpk generate app` (This is supported in Serverless clusters only.)
+** `rpk security user` (This is supported in Serverless clusters only.)
 +
 NOTE: The `rpk cloud` commands are not supported in self-managed deployments.
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -226,8 +226,8 @@ New clusters in Redpanda Cloud generally include functionality added in Self-Man
 
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
-- Integration with Apache Iceberg. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
-- Data transforms. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
+- Integration with Apache Iceberg. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+- Data transforms. For private beta access, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 - Remote Read Replicas. This is in beta for Redpanda Cloud.
 - Kafka API OIDC authentication. However, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[SSO to the Redpanda Cloud UI].
 - Admin API.
@@ -256,7 +256,7 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk generate app` (This is supported in Serverless clusters only.)
 ** `rpk security user` (This is supported in Serverless clusters only.)
 +
-NOTE: The `rpk cloud` commands are not supported in self-managed deployments.
+NOTE: The `rpk cloud` commands are not supported in Self-Managed deployments.
 
 == Next steps
 * xref:get-started:cluster-types/serverless.adoc[Create a Serverless Cluster]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -220,8 +220,11 @@ NOTE: To create a Redpanda cluster in your virtual private cloud (VPC), follow t
 
 == Redpanda Cloud vs Self-Managed feature compatibility
 
+New clusters in Redpanda Cloud generally include functionality added in Self-Managed versions immediately. Existing clusters include new functionality when they get upgraded to the latest version. However, because Redpanda Cloud is a fully-managed service that provides maintenance, data and partition balancing, upgrades, and recovery, much of the cluster maintenance required for Self-Managed users is not necessary for Redpanda Cloud users. 
+
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
+- Admin API
 - FIPS-compliance mode
 - Data transforms (currently in beta for Redpanda Cloud)
 - Remote Read Replicas (currently in beta for Redpanda Cloud)
@@ -229,9 +232,7 @@ Redpanda Cloud deployments do not support the following functionality available 
 - Kerberos authentication
 - Redpanda debug bundles
 - Redpanda Console topic documentation
-- Redpanda Console debug bundles
 - Setting `auto_create_topics_enabled=true`
-- Admin API
 - Customer-managed encryption keys for Tiered Storage 
 - The following `rpk` commands:
  

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -220,20 +220,21 @@ NOTE: To create a Redpanda cluster in your virtual private cloud (VPC), follow t
 
 == Redpanda Cloud vs Self-Managed feature compatibility
 
-New clusters in Redpanda Cloud generally include functionality added in Self-Managed versions immediately. Existing clusters include new functionality when they get upgraded to the latest version. However, because Redpanda Cloud is a fully-managed service that provides maintenance, data and partition balancing, upgrades, and recovery, much of the cluster maintenance required for Self-Managed users is not necessary for Redpanda Cloud users. 
+Because Redpanda Cloud is a fully-managed service that provides maintenance, data and partition balancing, upgrades, and recovery, much of the cluster maintenance required for Self-Managed users is not necessary for Redpanda Cloud users. Also, Redpanda Cloud is opinionated about Kafka configurations. For example, automatic topic creation is disabled. Some systems expect the Kafka service to automatically create topics when a message is produced to a topic that doesn't exist. (You can create topics in Redpanda Cloud on the *Topics* page or with `rpk topic create`.)
+
+New clusters in Redpanda Cloud generally include functionality added in Self-Managed versions immediately. Existing clusters include new functionality when they get upgraded to the latest version. 
 
 Redpanda Cloud deployments do not support the following functionality available in Redpanda Self-Managed deployments:
 
 - Integration with Apache Iceberg. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
-- Data transforms. This is in beta for Redpanda Cloud.
+- Data transforms. For private beta access on BYOC, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 - Remote Read Replicas. This is in beta for Redpanda Cloud.
-- Kafka API OIDC authentication. However, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[user authentication to an organization with SSO].
+- Kafka API OIDC authentication. However, Redpanda Cloud does support xref:security:cloud-authentication.adoc#single-sign-on[SSO to the Redpanda Cloud UI].
 - Admin API.
 - FIPS-compliance mode.
 - Kerberos authentication.
 - Redpanda debug bundles.
 - Redpanda Console topic documentation.
-- Enabling automatic topic creation. Create topics on the *Topics* page or with `rpk topic create`.
 - Configuring access to object storage with customer-managed encryption key.
 - Kubernetes Helm chart and Redpanda Operator functionality.
 - The following `rpk` commands:

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -229,8 +229,10 @@ Redpanda Cloud deployments do not support the following functionality available 
 - Kerberos authentication
 - Redpanda debug bundles
 - Redpanda Console topic documentation
+- Redpanda Console debug bundles
 - Setting `auto_create_topics_enabled=true`
 - Admin API
+- Customer-managed encryption keys for Tiered Storage 
 - The following `rpk` commands:
  
 ** `rpk cluster config`
@@ -245,7 +247,7 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk debug` 
 ** `rpk iotune`
 ** `rpk redpanda`
-** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and self-managed)
+** `rpk topic describe-storage` (all other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed)
 ** `rpk transform`  (currently in beta for Redpanda Cloud)
 ** `rpk generate app` (supported in Serverless clusters only)
 ** `rpk security user` (supported in Serverless clusters only)


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-754
Review deadline: Nov 27

## Page previews
[Redpanda Cloud vs Self-Managed feature compatibility](https://deploy-preview-122--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-cloud-vs-self-managed-feature-compatibility)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)