### PR TITLE
Add --tls-enabled to the remote read replicas topic command

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -87,7 +87,7 @@ A source cluster cannot be deleted if it has remote read replica topics. When yo
 To create a remote read replica topic, run:
 
 ```bash
-rpk topic create my-topic -c redpanda.remote.readreplica=<source cluster tiered storage bucket name>
+rpk topic create my-topic -c redpanda.remote.readreplica=<source cluster tiered storage bucket name> --tls-enabled
 ```
 
 For standard BYOC clusters the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-$\{SOURCE_CLUSTER_ID}`


### PR DESCRIPTION
## Description

TLS is enabled by default so we've switched most of our example commands to include it. Whenever I follow this document I always forget to include it, if I'm forgetting possibly others are too.

## Page previews

https://deploy-preview-142--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/remote-read-replicas/#create-remote-read-replica

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)