### PR TITLE
DOC-849 Add benchmark processor to Cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-849_Add_benchmark_processor
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-849_Add_benchmark_processor
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -180,6 +180,7 @@
 **** xref:develop:connect/components/processors/aws_dynamodb_partiql.adoc[]
 **** xref:develop:connect/components/processors/aws_lambda.adoc[]
 **** xref:develop:connect/components/processors/azure_cosmosdb.adoc[]
+**** xref:develop:connect/components/processors/benchmark.adoc[]
 **** xref:develop:connect/components/processors/bloblang.adoc[]
 **** xref:develop:connect/components/processors/bounds_check.adoc[]
 **** xref:develop:connect/components/processors/branch.adoc[]

--- a/modules/develop/pages/connect/components/processors/benchmark.adoc
+++ b/modules/develop/pages/connect/components/processors/benchmark.adoc
@@ -1,0 +1,3 @@
+= benchmark
+:page-aliases: components:processors/benchmark.adoc
+include::redpanda-connect:components:processors/benchmark.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-849](https://redpandadata.atlassian.net/browse/DOC-849)
Review deadline: 11th December

## Page previews

[`benchmark` processor](https://deploy-preview-151--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/processors/benchmark/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-849]: https://redpandadata.atlassian.net/browse/DOC-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ