### PR TITLE
DOC-662 interrupted communication after private networking

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -32,8 +32,6 @@ include::networking:partial$private-links-api-access-token.adoc[]
 
 == Create new cluster with PrivateLink endpoint service enabled
 
-CAUTION: As soon as PrivateLink is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
-
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI^], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +
 Copy and store the resource group ID (UUID) from the URL in the browser.
@@ -130,6 +128,8 @@ rpk cloud byoc aws apply --redpanda-id=$CLUSTER_ID
 ----
 
 == Enable PrivateLink endpoint service for existing clusters
+
+CAUTION: As soon as PrivateLink is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -26,17 +26,13 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps below to <<get-an-access-token,get an access token>>.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI^] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
-[TIP] 
-====
-* As soon as PrivateLink is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
-* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-====
-
 == Get a Cloud API access token
 
 include::networking:partial$private-links-api-access-token.adoc[]
 
 == Create new cluster with PrivateLink endpoint service enabled
+
+CAUTION: As soon as PrivateLink is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI^], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -5,7 +5,7 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud API. See xref:networking:configure-privatelink-in-cloud-ui.adoc[Configure PrivateLink in the Cloud UI] if you want to set up the endpoint service using the UI.
+NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud API. To configure and manage PrivateLink on an existing public cluster, you must use the Cloud API. See xref:networking:configure-privatelink-in-cloud-ui.adoc[Configure PrivateLink in the Cloud UI] if you want to set up the endpoint service using the Redpanda Cloud UI.
 
 The Redpanda AWS PrivateLink endpoint service provides secure access to Redpanda Cloud from your own VPC. Traffic over PrivateLink does not go through the public internet because a PrivateLink connection is treated as its own private AWS service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
@@ -19,14 +19,18 @@ Consider using the PrivateLink endpoint service if you have multiple VPCs and co
 
 After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-cluster-with-privatelink-endpoint-service-enabled,enable PrivateLink when creating a new cluster>>, or you can <<enable-privatelink-endpoint-service-for-existing-clusters,enable PrivateLink for existing clusters>>.
 
-TIP: Make sure to replace the variable values in the code examples on this page with your own values, before running the commands in the terminal or in a script.
-
 == Requirements
 
 * Install `rpk`.
 * Your Redpanda cluster and <<create-client-vpc,VPC>> must be in the same region.
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps below to <<get-an-access-token,get an access token>>.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI^] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
+
+[TIP] 
+====
+* As soon as PrivateLink is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
+====
 
 == Get a Cloud API access token
 

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -129,7 +129,7 @@ rpk cloud byoc aws apply --redpanda-id=$CLUSTER_ID
 
 == Enable PrivateLink endpoint service for existing clusters
 
-CAUTION: As soon as PrivateLink is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
+CAUTION: As soon as PrivateLink is available on your VPC, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding PrivateLink ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -28,7 +28,7 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 
 [TIP] 
 ====
-* As soon as PrivateLink is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* As soon as PrivateLink is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
 * Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
 ====
 

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -50,8 +50,6 @@ If you have not yet created a cluster in Redpanda Cloud, <<create-new-cluster-wi
 
 === Create new cluster with Private Link service enabled
 
-CAUTION: As soon as Private Link is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
-
 . In the Redpanda Cloud UI, go to https://cloud.redpanda.com/resource-groups[**Resource groups**^] and select the Redpanda Cloud resource group in which you want to create a cluster.
 +
 NOTE: Redpanda Cloud resource groups exist in your Redpanda Cloud account only. They do not correspond to Azure resource groups and do not appear in your Azure tenant.
@@ -151,6 +149,8 @@ rpk cloud byoc azure apply --redpanda-id=$CLUSTER_ID --subscription-id=$REDPANDA
 . Continue to <<configure-azure-private-link-connection-to-redpanda-cloud,configure the Private Link connection to Redpanda>>.
 
 === Enable Private Link service for existing clusters
+
+CAUTION: As soon as Private Link is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -150,7 +150,7 @@ rpk cloud byoc azure apply --redpanda-id=$CLUSTER_ID --subscription-id=$REDPANDA
 
 === Enable Private Link service for existing clusters
 
-CAUTION: As soon as Private Link is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
+CAUTION: As soon as Private Link is available on your virtual network, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your virtual network are ready to start using the corresponding Private Link ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -21,12 +21,6 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 * You will use the https://learn.microsoft.com/en-us/cli/azure/[Azure CLI^] to authenticate with Azure and configure resources in your Azure account.
 * You will use the xref:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda Private Link service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 
-[TIP]
-====
-* As soon as Private Link is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
-* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-====
-
 To learn more about Azure Private Link, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
 
 == Set up Redpanda Private Link Service
@@ -55,6 +49,8 @@ export SOURCE_CONNECTION_SUBSCRIPTION_ID=<source-connection-subscription-id>
 If you have not yet created a cluster in Redpanda Cloud, <<create-new-cluster-with-private-link-service-enabled,create a Private Link-enabled cluster>>. If you already have a cluster where you want to use Private Link, see the steps to <<enable-private-link-service-for-existing-clusters,enable Private Link for existing clusters>>.
 
 === Create new cluster with Private Link service enabled
+
+CAUTION: As soon as Private Link is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the Redpanda Cloud UI, go to https://cloud.redpanda.com/resource-groups[**Resource groups**^] and select the Redpanda Cloud resource group in which you want to create a cluster.
 +

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -15,13 +15,17 @@ Consider using Private Link if you have multiple virtual networks and require mo
 
 After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-cluster-with-private-link-service-enabled,enable Private Link when creating a new cluster>>, or you can <<enable-private-link-service-for-existing-clusters,enable Private Link for existing clusters>>.
 
-TIP: Make sure to replace the variable values in the code examples on this page with your own values before running the commands in the terminal or in a script.
-
 == Requirements
 
 * Install xref:manage:rpk/rpk-install.adoc[`rpk`].
 * You will use the https://learn.microsoft.com/en-us/cli/azure/[Azure CLI^] to authenticate with Azure and configure resources in your Azure account.
 * You will use the xref:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda Private Link service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
+
+[TIP]
+====
+* As soon as Private Link is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
+====
 
 To learn more about Azure Private Link, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
 

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -23,7 +23,7 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 
 [TIP]
 ====
-* As soon as Private Link is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* As soon as Private Link is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
 * Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
 ====
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -19,8 +19,6 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 * The client VPC must be in the same region as your Redpanda cluster.
 
-TIP: Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-
 == Enable endpoint service for existing clusters
 
 . In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. See xref:networking:gcp-private-service-connect.adoc[] if you want to set up this service using the API.
+NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because these connections are treated as their own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
@@ -18,6 +18,12 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 * The client VPC must be in the same region as your Redpanda cluster.
+
+[TIP]
+==== 
+* As soon as Private Service Connect is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
+====
 
 == Enable endpoint service for existing clusters
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -19,11 +19,7 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 * The client VPC must be in the same region as your Redpanda cluster.
 
-[TIP]
-==== 
-* As soon as Private Service Connect is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
-* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-====
+TIP: Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
 
 == Enable endpoint service for existing clusters
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud UI. See xref:networking:aws-privatelink.adoc[Configure AWS PrivateLink for Redpanda Cloud] if you want to set up the endpoint service using the API.
+NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud UI. To configure and manage PrivateLink on an existing public cluster, you must use the xref:networking:aws-privatelink.adoc[Redpanda Cloud API].
 
 The Redpanda AWS PrivateLink endpoint service provides secure access to Redpanda Cloud from your own VPC. Traffic over PrivateLink does not go through the public internet because these connections are treated as their own private AWS service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
@@ -18,6 +18,12 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 
 * Your Redpanda cluster and VPC must be in the same region.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
+
+[TIP] 
+====
+* As soon as PrivateLink is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
+====
 
 == Enable endpoint service for existing clusters
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -19,11 +19,7 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 * Your Redpanda cluster and VPC must be in the same region.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
-[TIP] 
-====
-* As soon as PrivateLink is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
-* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-====
+TIP: Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
 
 == Enable endpoint service for existing clusters
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -19,8 +19,6 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 * Your Redpanda cluster and VPC must be in the same region.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
-TIP: Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-
 == Enable endpoint service for existing clusters
 
 . In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] if you want to set up the endpoint service using the UI.
+NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] if you want to set up the endpoint service using the Redpanda Cloud UI.
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
@@ -23,6 +23,12 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
+
+[TIP]
+==== 
+* As soon as Private Service Connect is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
+====
 
 == Get a Cloud API access token
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -26,7 +26,7 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 
 [TIP]
 ==== 
-* As soon as Private Service Connect is available on your VPC, all communication on Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
+* As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
 * Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
 ====
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -54,8 +54,6 @@ See the GCP documentation for https://cloud.google.com/vpc/docs/configure-privat
 
 == Create new BYOC cluster with Private Service Connect enabled
 
-CAUTION: As soon as Private Service Connect is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
-
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +
 Copy and store the resource group ID (UUID) from the URL in the browser.
@@ -194,6 +192,8 @@ Replace the following placeholders for the request body. Variables with a `byovp
 --
 
 == Enable Private Service Connect on an existing BYOC cluster
+
+CAUTION: As soon as Private Service Connect is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -193,7 +193,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 
 == Enable Private Service Connect on an existing BYOC cluster
 
-CAUTION: As soon as Private Service Connect is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
+CAUTION: As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -24,12 +24,6 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 * Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 
-[TIP]
-==== 
-* As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda public ports is interrupted due to the change on the private DNS resolution. Have all applications running in your VPC ready to start using the corresponding private ports.
-* Make sure to replace the variable values in the code examples with your own values before running the commands in the terminal or in a script.
-====
-
 == Get a Cloud API access token
 
 include::networking:partial$private-links-api-access-token.adoc[]
@@ -59,6 +53,8 @@ Provide your values for the following placeholders:
 See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
 
 == Create new BYOC cluster with Private Service Connect enabled
+
+CAUTION: As soon as Private Service Connect is available on your VPC, all communication on an existing Redpanda bootstrap server port and on broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding private ports.
 
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +


### PR DESCRIPTION
## Description

This adds a tip to the AWS Private Link, Azure PrivateLink, and GCP Private Service Connect pages to alert users that as soon as the private service is available on your VPC, all communication on existing Redpanda public ports is interrupted & to have apps running in your VPC ready to start using the corresponding private ports.

Resolves https://redpandadata.atlassian.net/browse/DOC-662
Review deadline: Dec 12

## Page previews

- [AWS PrivateLink API](https://deploy-preview-154--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/)
- [Azure Private Link API](https://deploy-preview-154--rp-cloud.netlify.app/redpanda-cloud/networking/azure-private-link/)
- [GCP API](https://deploy-preview-154--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/)
- [AWS PrivateLink UI](https://deploy-preview-154--rp-cloud.netlify.app/redpanda-cloud/networking/configure-privatelink-in-cloud-ui/)
- [GCP UI](https://deploy-preview-154--rp-cloud.netlify.app/redpanda-cloud/networking/configure-private-service-connect-in-cloud-ui/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)