### PR TITLE
DOC-895 remove AWS privatelink feature flag

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -7,6 +7,12 @@
 
 This page lists new features added in Redpanda Cloud.
 
+== January 2025
+
+=== AWS PrivateLink: GA
+
+AWS PrivateLink is now generally available for private networking in the xref:networking:configure-privatelink-in-cloud-ui.adoc[Cloud UI] and the xref:networking:aws-privatelink.adoc[Cloud API].
+
 == December 2024
 
 === VPC peering for Dedicated clusters on Azure

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -3,8 +3,6 @@
 :page-aliases: deploy:deployment-option/cloud/aws-privatelink.adoc
 
 
-include::shared:partial$feature-flag.adoc[]
-
 NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud API. To configure and manage PrivateLink on an existing public cluster, you must use the Cloud API. See xref:networking:configure-privatelink-in-cloud-ui.adoc[Configure PrivateLink in the Cloud UI] if you want to set up the endpoint service using the Redpanda Cloud UI.
 
 The Redpanda AWS PrivateLink endpoint service provides secure access to Redpanda Cloud from your own VPC. Traffic over PrivateLink does not go through the public internet because a PrivateLink connection is treated as its own private AWS service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -23,7 +23,7 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 . For AWS PrivateLink, click *Enable*.
 . On the Enable PrivateLink page, for Allowed principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for each AWS principal allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details. 
 . Click *Add* after entering each ARN, and when finished, click *Enable*. 
-. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status on the  Cluster settings page changes from **In progress** to **Enabled**.
+. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status on the Cluster settings page changes from *In progress* to *Enabled*.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 
@@ -41,7 +41,7 @@ include::networking:partial$private-links-test-connection.adoc[]
 
 == Disable endpoint service
 
-On the Cluster settings page for the cluster, click **Disable** for PrivateLink. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
+On the Cluster settings page for the cluster, click *Disable* for PrivateLink. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -2,8 +2,6 @@
 :description: Set up AWS PrivateLink in the Redpanda Cloud UI.
 :page-aliases: deploy:deployment-option/cloud/configure-privatelink-in-cloud-ui.adoc
 
-include::shared:partial$feature-flag.adoc[]
-
 NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud UI. To configure and manage PrivateLink on an existing public cluster, you must use the xref:networking:aws-privatelink.adoc[Redpanda Cloud API].
 
 The Redpanda AWS PrivateLink endpoint service provides secure access to Redpanda Cloud from your own VPC. Traffic over PrivateLink does not go through the public internet because these connections are treated as their own private AWS service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -20,8 +20,8 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 == Enable endpoint service for existing clusters
 
 . In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
-. Under AWS PrivateLink, click **Enable**. 
 . You need the Amazon Resource Names (ARNs) for the AWS principals allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details.
+. Under AWS PrivateLink, click **Enable**. 
 . It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status in **Cluster settings** changes from **In progress** to **Enabled**.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -19,9 +19,10 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 
 == Enable endpoint service for existing clusters
 
-. In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
-. For Allowed Principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for all AWS principals allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details. 
-. For AWS PrivateLink, click **Enable**. 
+. In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and go to the **Cluster settings** page.
+. For AWS PrivateLink, click *Enable*.
+. On the Enable PrivateLink page, for Allowed principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for each AWS principal allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details. 
+. Click *Add* after entering each ARN, and when finished, click *Enable*. 
 . It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status in **Cluster settings** changes from **In progress** to **Enabled**.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -19,11 +19,11 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 
 == Enable endpoint service for existing clusters
 
-. In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and go to the **Cluster settings** page.
+. In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Cluster settings* page.
 . For AWS PrivateLink, click *Enable*.
 . On the Enable PrivateLink page, for Allowed principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for each AWS principal allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details. 
 . Click *Add* after entering each ARN, and when finished, click *Enable*. 
-. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status in **Cluster settings** changes from **In progress** to **Enabled**.
+. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status on the  Cluster settings page changes from **In progress** to **Enabled**.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 
@@ -41,7 +41,7 @@ include::networking:partial$private-links-test-connection.adoc[]
 
 == Disable endpoint service
 
-In **Cluster settings**, click **Disable**. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
+On the Cluster settings page for the cluster, click **Disable** for PrivateLink. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -19,9 +19,9 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 
 == Enable endpoint service for existing clusters
 
-. In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
-. You need the Amazon Resource Names (ARNs) for the AWS principals allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details.
-. Under AWS PrivateLink, click **Enable**. 
+. In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
+. For Allowed Principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for all AWS principals allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details. 
+. For AWS PrivateLink, click **Enable**. 
 . It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status in **Cluster settings** changes from **In progress** to **Enabled**.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].


### PR DESCRIPTION
## Description

This removes the note about needing Support to enable AWS PrivateLink. It also reorders the steps for configuring PrivateLink in the UI. 

Resolves https://redpandadata.atlassian.net/browse/DOC-895, https://redpandadata.atlassian.net/browse/DOC-896
Review deadline: Jan 7

## Page previews
- [Configure AWS PrivateLink in the Cloud UI](https://deploy-preview-163--rp-cloud.netlify.app/redpanda-cloud/networking/configure-privatelink-in-cloud-ui/)
- [Configure AWS PrivateLink with the Cloud API](https://deploy-preview-163--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)