### PR TITLE
DOC-919 enable Kafka Connect in Azure Dedicated

### DIFF
--- a/modules/develop/pages/managed-connectors/index.adoc
+++ b/modules/develop/pages/managed-connectors/index.adoc
@@ -10,6 +10,8 @@ your data than manually creating a solution with the Kafka API. You can set up
 and manage these connectors in Redpanda Console. All connectors are managed by
 Redpanda.
 
+include::shared:partial$kafka-connect.adoc[]
+
 Each connector is either a source or a sink:
 
 * A source connector imports data from a source system into a Redpanda cluster.

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -1,5 +1,6 @@
 = Redpanda Cloud Overview
 :description: Learn about Redpanda Serverless, Dedicated, and Bring Your Own Cloud (BYOC) clusters.
+:tag-pipeline-service: api:ROOT:cloud-api.adoc#tag--PipelineService
 :page-aliases: cloud:dedicated-byoc.adoc, deploy:deployment-option/cloud/dedicated-byoc.adoc, deploy:deployment-option/cloud/cloud-overview.adoc
 
 
@@ -173,6 +174,12 @@ BYOVPC::
 
 --
 =====
+
+== Redpanda Connect and Kafka Connect
+
+xref:develop:connect/about.adoc[Redpanda Connect] is integrated into Redpanda Cloud and available as a fully-managed service. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications from the Cloud UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
+
+Kafka Connect is automatically enabled on AWS and GCP clusters. With this, there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
 
 == Maintenance windows
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -179,7 +179,7 @@ BYOVPC::
 
 xref:develop:connect/about.adoc[Redpanda Connect] is integrated into Redpanda Cloud and available as a fully-managed service. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications from the Cloud UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
 
-Kafka Connect is automatically enabled on AWS and GCP clusters. With this, there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
+xref:develop:managed-connectors/index.adoc[Kafka Connect] is automatically enabled on AWS and GCP clusters. With this, there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
 
 == Maintenance windows
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -124,7 +124,7 @@ As part of agent deployment, Redpanda assigns the permissions required to run th
 
 == Enable Kafka Connect
 
-To enable xref:develop:managed-connectors/index.adoc[Kafka Connect] on your BYOC cluster:
+To enable xref:develop:managed-connectors/index.adoc[Kafka Connect] for clusters on Azure:
 
 . Authenticate to the Redpanda Cloud API. Follow the steps in xref:manage:api/cloud-api-authentication.adoc[].
 
@@ -145,7 +145,3 @@ Replace the following placeholders:
 - `<token>`: Enter the API token you received in step 1.
 
 include::partial$no-access.adoc[]
-
-== Next steps
-
-xref:networking:azure-private-link.adoc[]

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -145,3 +145,7 @@ Replace the following placeholders:
 - `<token>`: Enter the API token you received in step 1.
 
 include::partial$no-access.adoc[]
+
+== Next steps
+
+xref:networking:azure-private-link.adoc[]

--- a/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
@@ -27,7 +27,7 @@ To unlock this feature for Azure, contact https://support.redpanda.com/hc/en-us/
 ** Your network name is used to identify this network.
 ** For a xref:networking:cidr-ranges.adoc[CIDR range], choose one that does not overlap with your existing VPCs or your Redpanda network.
 +
-NOTE: Private networks require either a VPC peering connection or a private connectivity service, such as xref:networking:configure-privatelink-in-cloud-ui.adoc[AWS PrivateLink], xref:networking:configure-private-service-connect-in-cloud-ui.adoc[GCP Private Service Connect], or xref:networking:azure-private-link.adoc[Azure Private Link]. 
+Private networks require either a VPC peering connection or a private connectivity service, such as xref:networking:configure-privatelink-in-cloud-ui.adoc[AWS PrivateLink], xref:networking:configure-private-service-connect-in-cloud-ui.adoc[GCP Private Service Connect], or xref:networking:azure-private-link.adoc[Azure Private Link]. 
 
 . Click *Create*.
 

--- a/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
@@ -33,4 +33,4 @@ Private networks require either a VPC peering connection or a private connectivi
 
 After the cluster is created, you can click the cluster name on the *Clusters* page to see the overview for it.
 
-NOTE: Kafka Connect is automatically enabled on AWS and GCP clusters, which means there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
+include::shared:partial$kafka-connect.adoc[]

--- a/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/dedicated/create-dedicated-cloud-cluster.adoc
@@ -32,3 +32,5 @@ NOTE: Private networks require either a VPC peering connection or a private conn
 . Click *Create*.
 
 After the cluster is created, you can click the cluster name on the *Clusters* page to see the overview for it.
+
+NOTE: Kafka Connect is automatically enabled on AWS and GCP clusters, which means there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].

--- a/modules/shared/partials/kafka-connect.adoc
+++ b/modules/shared/partials/kafka-connect.adoc
@@ -1,0 +1,1 @@
+NOTE: Kafka Connect is automatically enabled on AWS and GCP clusters, which means there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].


### PR DESCRIPTION
## Description

- This adds a section to the Redpanda Cloud Overview about Redpanda Connect and Kafka Connect, explaining that it's enabled with a running node for it on AWS and GCP + link to how to enable on Azure. 
- This also adds a link to Enable Kafka Connect on Azure on the page for creating Dedicated clusters. 

Resolves https://redpandadata.atlassian.net/browse/DOC-919, https://redpandadata.atlassian.net/browse/DOC-452
Review deadline: Jan 10

## Page previews

- [Redpanda Cloud Overview - Redpanda Connect and Kafka Connect](https://deploy-preview-167--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-connect-and-kafka-connect)
- [Create a Dedicated Cluster](https://deploy-preview-167--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/dedicated/create-dedicated-cloud-cluster/)
- [Kafka Connect](https://deploy-preview-167--rp-cloud.netlify.app/redpanda-cloud/develop/managed-connectors/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)