### PR TITLE
Specify a valid semver range for extensions package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@antora/cli": "3.1.2",
         "@antora/site-generator": "3.1.2",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redpanda-data/docs-extensions-and-macros": "latest"
+        "@redpanda-data/docs-extensions-and-macros": "^3.0.0"
       },
       "devDependencies": {
         "@web/dev-server": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@antora/cli": "3.1.2",
     "@antora/site-generator": "3.1.2",
     "@asciidoctor/tabs": "^1.0.0-beta.5",
-    "@redpanda-data/docs-extensions-and-macros": "latest"
+    "@redpanda-data/docs-extensions-and-macros": "^3.0.0"
   },
   "devDependencies": {
     "@web/dev-server": "^0.2.1",


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 10 Jan

Using `latest` is considered bad practice because we could auto-update to a version with breaking changes.

This PR specifies a range that allows upgrades to new minor and patch versions.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)