### PR TITLE
Doc-194 Clarification about who is responsible for certain Kafka Connect tasks

### DIFF
--- a/modules/develop/pages/managed-connectors/index.adoc
+++ b/modules/develop/pages/managed-connectors/index.adoc
@@ -7,7 +7,7 @@
 Use Kafka Connect to integrate your Redpanda data with different
 data systems. As managed solutions, connectors offer a simpler way to integrate
 your data than manually creating a solution with the Kafka API. You can set up
-and manage these connectors in Redpanda Console. Note that you remain responsible 
+and manage these connectors for BYOC and Dedicated clusters in the Redpanda Cloud UI. Note that you remain responsible 
 for monitoring, alerting, and restarting Kafka Connect connectors, as these tasks 
 are not managed or monitored by Redpanda support.
 

--- a/modules/develop/pages/managed-connectors/index.adoc
+++ b/modules/develop/pages/managed-connectors/index.adoc
@@ -7,8 +7,9 @@
 Use Kafka Connect to integrate your Redpanda data with different
 data systems. As managed solutions, connectors offer a simpler way to integrate
 your data than manually creating a solution with the Kafka API. You can set up
-and manage these connectors in Redpanda Console. All connectors are managed by
-Redpanda.
+and manage these connectors in Redpanda Console. Note that you remain responsible 
+for monitoring, alerting, and restarting Kafka Connect connectors, as these tasks 
+are not managed or monitored by Redpanda support.
 
 Each connector is either a source or a sink:
 


### PR DESCRIPTION
## Description

Resolves [Doc-194](https://redpandadata.atlassian.net/browse/DOC-194)
Review deadline: **Monday, January 13**

## Page previews
[Kafka Connect 1st paragraph](https://deploy-preview-171--rp-cloud.netlify.app/redpanda-cloud/develop/managed-connectors/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)