### PR TITLE
Cross region support for RRR

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -15,7 +15,7 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters. Ephem
 ** GCP: The reader cluster can be in the same or a different region as the source cluster.
 ** Azure: Remote read replicas are not supported.
 
-=== Customer-managed VPC: Grant storage permissions
+=== BYOVPC: Grant storage permissions
 
 [NOTE]
 ====
@@ -93,7 +93,7 @@ To create a remote read replica topic, run:
 rpk topic create my-topic -c redpanda.remote.readreplica=<source-cluster-tiered-storage-bucket-name> --tls-enabled
 ```
 
-For standard BYOC clusters the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-$\{SOURCE_CLUSTER_ID}`
+For standard BYOC clusters, the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-$\{SOURCE_CLUSTER_ID}`
 
 == Optional: Tune for live topics
 

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -19,7 +19,7 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters. Ephem
 
 [NOTE]
 ====
-This prerequisite only applies to customer-managed VPC deployments. Skip this step if you're enabling remote read replicas on standard BYOC clusters.
+This prerequisite only applies to BYOVPC deployments. Skip this step if you're enabling remote read replicas on standard BYOC clusters.
 
 ====
 

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -10,7 +10,10 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters. Ephem
 == Prerequisites
 
 * A BYOC source cluster in Ready state.
-* A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization and the same cloud provider account and region as the source cluster.
+* A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization and the same cloud provider account as the source cluster.
+** AWS: The reader cluster must be in the same region as the source cluster.
+** GCP: The reader cluster can be in the same or a different region as the source cluster.
+** Azure: Remote read replicas are not supported.
 
 === Customer-managed VPC: Grant storage permissions
 
@@ -29,7 +32,7 @@ To grant additional permissions to the cloud storage manager of the reader clust
 
 ```bash
 gcloud storage buckets add-iam-policy-binding \
-    gs://<source cluster tiered storage bucket name> \
+    gs://<source-cluster-tiered-storage-bucket-name> \
     --member="serviceAccount:<reader cluster redpanda_cluster_service_account email>" \
     --role="roles/storage.objectViewer"
 ```
@@ -87,7 +90,7 @@ A source cluster cannot be deleted if it has remote read replica topics. When yo
 To create a remote read replica topic, run:
 
 ```bash
-rpk topic create my-topic -c redpanda.remote.readreplica=<source cluster tiered storage bucket name> --tls-enabled
+rpk topic create my-topic -c redpanda.remote.readreplica=<source-cluster-tiered-storage-bucket-name> --tls-enabled
 ```
 
 For standard BYOC clusters the source cluster tiered storage bucket name follows the pattern: `redpanda-cloud-storage-$\{SOURCE_CLUSTER_ID}`


### PR DESCRIPTION
## Description

This PR accompanies https://github.com/redpanda-data/docs/pull/942 to clarify cross region support for RRR/tiered storage.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 14 Jan

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)