### PR TITLE
DOC-951 Doc Dedicated region AWS eu-west-3

### DIFF
--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -165,6 +165,7 @@ Amazon Web Services (AWS)::
 | eu-central-1
 | eu-west-1
 | eu-west-2
+| eu-west-3
 | us-east-1
 | us-east-2
 | us-west-2


### PR DESCRIPTION
## Description
Resolves https://redpandadata.atlassian.net/browse/DOC-951

add eu-west-3 region for AWS Dedicated
available in UI:
![image](https://github.com/user-attachments/assets/da4cdb50-1842-4c57-b66a-77426ef4501e)

Review deadline: Jan 15

## Page previews
[Dedicated regions](https://deploy-preview-174--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/dedicated-tiers/?tab=tabs-1-amazon-web-services-aws#dedicated-supported-regions)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)