### PR TITLE
DOC-19 not using BYOC to manage other workloads

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -80,7 +80,7 @@ contained in your own environment. (See <<BYOC architecture>>.) This provides an
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to a standard BYOC setup, this option provides more security.
 
-The BYOC infrastructure that Redpanda manages should not be used to deploy other any other workloads.
+The BYOC infrastructure that Redpanda manages should not be used to deploy any other workloads.
 
 ==== Sign up for BYOC
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -75,10 +75,12 @@ Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterpr
 
 === Bring Your Own Cloud (BYOC)
 
-With BYOC clusters, you deploy Redpanda in your own cloud (AWS, GCP, or Azure), and all data is
-contained in your own environment. This provides an additional layer of security and isolation. When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. See also: <<BYOC architecture>>.
+With BYOC clusters, you deploy Redpanda in your own cloud (AWS, Azure, or GCP), and all data is
+contained in your own environment. (See <<BYOC architecture>>.) This provides an additional layer of security and isolation. When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to a standard BYOC setup, this option provides more security.
+
+The BYOC infrastructure that Redpanda manages should not be used to deploy other any other workloads.
 
 ==== Sign up for BYOC
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -78,7 +78,7 @@ Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterpr
 With BYOC clusters, you deploy Redpanda in your own cloud (AWS, Azure, or GCP), and all data is
 contained in your own environment. (See <<BYOC architecture>>.) This provides an additional layer of security and isolation. When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
 
-NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to a standard BYOC setup, this option provides more security.
+NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to standard BYOC, BYOVPC provides more security, but the configuration is more complex. See <<Shared responsibility model>>.
 
 The BYOC infrastructure that Redpanda manages should not be used to deploy any other workloads.
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-19
Review deadline:

## Page previews
[Redpanda Cloud Overview - BYOC](https://deploy-preview-175--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#bring-your-own-cloud-byoc)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)