### PR TITLE
DOC-956 update Serverless limits

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -18,8 +18,8 @@ Redpanda offers four types of fully-managed cloud clusters. All products have ac
 
 | For starter projects and applications with low or variable traffic. | For an enterprise-level version of Serverless, supporting moderate, sustained traffic. | For production clusters requiring expert cloud hosting, higher throughput, and extra isolation. | For production clusters requiring data sovereignty, the highest throughput, and added security.
 | Multi-tenant on AWS | Multi-tenant on AWS | Single-tenant on AWS, Azure, or GCP | In your cloud on AWS, Azure, or GCP 
-| 0.5 MB/s max write throughput | 10 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
-| 1.5 MB/s max read throughput | 20 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
+| 1 MB/s max write throughput | 10 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
+| 3 MB/s max read throughput | 30 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
 | 100 partitions | 500 partitions | 22,800 partitions | 112,500 partitions
 | 99.5% SLA | 99.5% SLA | 99.99% SLA | 99.99% SLA 
 | Public networking | Public networking | Public or private networking | Public or private networking


### PR DESCRIPTION
## Description
updates Serverless limits, per discussion [here](https://redpandadata.slack.com/archives/C088LB383B9/p1737033993145649)

Resolves https://redpandadata.atlassian.net/browse/DOC-956
Review deadline:

## Page previews
https://deploy-preview-176--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)