### PR TITLE
Doc 956 update serverless limits

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -18,8 +18,8 @@ Redpanda offers four types of fully-managed cloud clusters. All products have ac
 
 | For starter projects and applications with low or variable traffic. | For an enterprise-level version of Serverless, supporting moderate, sustained traffic. | For production clusters requiring expert cloud hosting, higher throughput, and extra isolation. | For production clusters requiring data sovereignty, the highest throughput, and added security.
 | Multi-tenant on AWS | Multi-tenant on AWS | Single-tenant on AWS, Azure, or GCP | In your cloud on AWS, Azure, or GCP 
-| 0.5 MB/s max write throughput | 10 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
-| 1.5 MB/s max read throughput | 20 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
+| 1 MB/s max write throughput | 10 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
+| 3 MB/s max read throughput | 30 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
 | 100 partitions | 500 partitions | 22,800 partitions | 112,500 partitions
 | 99.5% SLA | 99.5% SLA | 99.99% SLA | 99.99% SLA 
 | Public networking | Public networking | Public or private networking | Public or private networking

--- a/modules/get-started/pages/cluster-types/serverless-pro.adoc
+++ b/modules/get-started/pages/cluster-types/serverless-pro.adoc
@@ -14,7 +14,7 @@ Make sure you have the latest version of `rpk`. See xref:get-started:rpk-install
 Each Serverless Pro cluster has the following limits:
 
 * Ingress: 10 MBps
-* Egress: 20 MBps
+* Egress: 30 MBps
 * Partitions: 500 
 * Topics: 200
 * Message size: 20 MB

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -16,8 +16,8 @@ NOTE: Serverless Standard is currently in a limited availability (LA) release wi
 
 Each Serverless cluster has the following limits:
 
-* Ingress: up to 10 MBps, 0.5 MBps guaranteed
-* Egress: up to 30 MBps, 1.5 MBps guaranteed
+* Ingress: up to 10 MBps, 1 MBps guaranteed
+* Egress: up to 30 MBps, 3 MBps guaranteed
 * Partitions: 100
 * Topics: 20 
 * Message size: 20 MB


### PR DESCRIPTION
## Description
This updates the standard and pro limits on the deployment pages

Resolves https://redpandadata.atlassian.net/browse/DOC-957
Review deadline:

## Page previews
[Serverless Standard](https://deploy-preview-178--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/)
[Serverless Pro](https://deploy-preview-178--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless-pro/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)