### PR TITLE
DOC-954 enable europe-west3 for GCP

### DIFF
--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -144,6 +144,7 @@ Google Cloud Platform (GCP)::
 | australia-southeast1
 | europe-west1
 | europe-west2
+| europe-west3
 | northamerica-northeast1
 | southamerica-east1
 | us-central1


### PR DESCRIPTION
## Description
Adds europe-west3 region for GCP on Dedicated

Resolves https://redpandadata.atlassian.net/browse/DOC-954
Review deadline: Jan 21

## Page previews
https://deploy-preview-180--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/dedicated-tiers/#dedicated-supported-regions

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)