### PR TITLE
DOC-974 updated topic limit in Serverless Pro

### DIFF
--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -18,7 +18,7 @@ Pricing for Serverless clusters depends on the data in, data out, data stored, p
 
 | Uptime | Tracks the number of hours the instance is running. 
 
-Note: Serverless Pro only. There is no base cost for Serverless Standard clusters.
+Note: Serverless Pro only. There is no base cost for Serverless Standard.
 
 | Ingress | Tracks the data written into Redpanda (in GB).
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -44,7 +44,7 @@ To start using Serverless Standard, https://redpanda.com/try-redpanda/cloud-tria
 
 You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] and quickly provision Serverless clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
 
-NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#serverless-standard-usage-limits[usage limits]. 
+NOTE: Serverless Standard is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#serverless-standard-usage-limits[usage limits]. 
 
 === Serverless Pro
 
@@ -60,7 +60,7 @@ You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.
 
 With AWS Marketplace sign up, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. To access your Enterprise support, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
 
-NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless-pro.adoc#serverless-pro-usage-limits[usage limits]. 
+NOTE: Serverless Pro is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless-pro.adoc#serverless-pro-usage-limits[usage limits]. 
 
 === Dedicated Cloud
 
@@ -76,7 +76,7 @@ Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterpr
 === Bring Your Own Cloud (BYOC)
 
 With BYOC clusters, you deploy Redpanda in your own cloud (AWS, Azure, or GCP), and all data is
-contained in your own environment. (See <<BYOC architecture>>.) This provides an additional layer of security and isolation. When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
+contained in your own environment. This provides an additional layer of security and isolation. (See <<BYOC architecture>>.) When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to standard BYOC, BYOVPC provides more security, but the configuration is more complex. See <<Shared responsibility model>>.
 
@@ -101,7 +101,7 @@ Consider Dedicated or BYOC if you need more control over the deployment or if yo
 * Private networking
 * Single-zone or multi-zone availability. A multi-zone cluster provides higher resiliency in the event of a failure in one of the zones. 
 * Ability to export metrics to a 3rd-party monitoring system
-* Kafka connectors
+* Kafka Connect
 * Higher limits and quotas. See xref:reference:tiers/dedicated-tiers.adoc[Dedicated usage tiers] and xref:reference:tiers/byoc-tiers.adoc[BYOC usage tiers] compared to xref:get-started:cluster-types/serverless.adoc#serverless-standard-usage-limits[Serverless Standard limits] and xref:get-started:cluster-types/serverless-pro.adoc#serverless-pro-usage-limits[Serverless Pro limits].
 
 == Shared responsibility model

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -50,7 +50,7 @@ NOTE: Serverless is currently in a limited availability (LA) release with xref:g
 
 Serverless Pro is similar to Serverless Standard, but it provides higher usage limits and Enterprise support. 
 
-You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. This is a production-ready deployment option with a cluster available instantly. With pay-as-you-go billing, you only pay for what you consume. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page.
+You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. This is a production-ready deployment option with a cluster available instantly. A payment method is required for Serverless Pro. With pay-as-you-go billing, you only pay for what you consume. 
 
 ==== Sign up for Serverless Pro
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -24,7 +24,7 @@ Redpanda offers four types of fully-managed cloud clusters. All products have ac
 | 99.5% SLA | 99.5% SLA | 99.99% SLA | 99.99% SLA 
 | Public networking | Public networking | Public or private networking | Public or private networking
 | SSO (GitHub, Google), Kafka ACLs | SSO (GitHub, Google), Kafka ACLs | SSO (GitHub, Google, OIDC), RBAC, audit logs  | SSO (GitHub, Google, OIDC), RBAC, audit logs 
-| Community support | Enterprise support | Enterprise support | Enterprise support
+| Community support | Enterprise support with annual contracts| Enterprise support | Enterprise support
 |===
 
 [NOTE]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -50,13 +50,13 @@ NOTE: Serverless is currently in a limited availability (LA) release with xref:g
 
 Serverless Pro is similar to Serverless Standard, but it provides higher usage limits and Enterprise support. 
 
-You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. This is a production-ready deployment option with a cluster available instantly. A payment method is required for Serverless Pro. With pay-as-you-go billing, you only pay for what you consume. 
+You host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. This is a production-ready deployment option with a cluster available instantly. A payment method is required for Serverless Pro. With pay-as-you-go billing, you only pay for what you consume. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
 
 ==== Sign up for Serverless Pro
 
 To start using Serverless Pro, contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^]. With this subscription, you get immediate access to Enterprise support. 
 
-You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] and quickly provision Serverless clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
+You can also subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] and quickly provision Serverless clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
 
 With AWS Marketplace sign up, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. To access your Enterprise support, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
 

--- a/modules/get-started/pages/cluster-types/serverless-pro.adoc
+++ b/modules/get-started/pages/cluster-types/serverless-pro.adoc
@@ -16,7 +16,7 @@ Each Serverless Pro cluster has the following limits:
 * Ingress: 10 MBps
 * Egress: 30 MBps
 * Partitions: 500 
-* Topics: 200
+* Topics: 300
 * Message size: 20 MB
 * Retention: unlimited
 * Storage: unlimited

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -107,4 +107,4 @@ Serverless clusters are currently available in certain AWS regions. Redpanda exp
 
 * xref:get-started:cloud-overview.adoc[Learn more about Redpanda Cloud]
 * xref:get-started:config-topics.adoc[Manage topics]
-* xref:get-started:cluster-types/serverless-pro.adoc[Try Serverless Pro for higher usage limits and dedicated support]
+* xref:get-started:cluster-types/serverless-pro.adoc[Try Serverless Pro for higher usage limits and Enterprise support]


### PR DESCRIPTION
## Description
To match code, this updates topic limit for Serverless Pro from 200 to 300. 

Resolves https://redpandadata.atlassian.net/browse/DOC-974
Review deadline: Jan 24

## Page previews
https://deploy-preview-183--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless-pro/#serverless-pro-usage-limits

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)