### PR TITLE
DOC-894 allow `rpk security user` in Cloud

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -302,7 +302,6 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk topic describe-storage` (All other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed.)
 ** `rpk transform` (This is in beta for Redpanda Cloud.)
 ** `rpk generate app` (This is supported in Serverless clusters only.)
-** `rpk security user` (This is supported in Serverless clusters only.)
 +
 NOTE: The `rpk cloud` commands are not supported in Self-Managed deployments.
 


### PR DESCRIPTION
## Description
This removes `rpk security user` from the list of commands not supported in Cloud, since they are now supported. (The commands already appeared in the rpk reference in Cloud, since they were previously supported in Serverless clusters.)

Resolves https://redpandadata.atlassian.net/browse/DOC-894
Review deadline:

## Page previews
[Cloud vs Self-Managed feature compatibility](https://deploy-preview-186--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-cloud-vs-self-managed-feature-compatibility)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)