### PR TITLE
Remove reference to `aws ec2 create-vpc`

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -38,7 +38,7 @@ export AWS_REGION=us-east-2
 export AWS_VPC_NAME=sample-redpanda-vpc
 export REDPANDA_COMMON_PREFIX=sample-
 
-export AWS_VPC_ID=$(aws ec2 create-vpc --cidr-block 10.0.0.0/16 --query Vpc.VpcId --region ${AWS_REGION} --tag-specification ResourceType=vpc,Tags='[{Key=Name,Value="${AWS_VPC_NAME}"}]' --output text --profile AWSAdministratorAccess-605419575229)
+export AWS_VPC_ID=
 ```
 
 The https://github.com/redpanda-data/cloud-examples/blob/main/customer-managed/aws/terraform/variables.tf[`variables.tf`] file contains a number of variables that allow you to modify the Terraform code to meet your specific needs. In some cases, it lets you skip creation of certain resources (for example, the VPC) or modify the configuration of a resource.


### PR DESCRIPTION
## Description

When creating an AWS BYOVPC cluster the customer typically has 1 of 2 scenarios:
1) They already have a VPC created that they want to use 2) They are using our terraform code to create a VPC following our specifications

Never would they want to create the VPC using an `aws ec2 create-vpc` command as specified here. The command even includes a hard-coded profile name that is only valid internal to Redpanda. We should not expose this profile name outside of Redpanda.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)