### PR TITLE
Update vpc-byo-gcp.adoc - Clarify shared VPC model for BYOVPC on GCP

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -14,7 +14,7 @@ When you create a BYOCVPC cluster, you specify your VPC and service account. The
 
 == Prerequisites
 
-* A standalone GCP project is recommended. If your host project (where your VPC project is created) and your service project (where your Redpanda cluster is created) are in different projects, you must first provision a shared VPC in Google Cloud. For more information, see the https://cloud.google.com/vpc/docs/provisioning-shared-vpc[Google shared VPC documentation^]. 
+* BYOVPC requires a shared VPC model. You must first provision a shared VPC in Google Cloud across both your host project (where your VPC project is created) and your service project (where your Redpanda cluster is created). For more information, see the https://cloud.google.com/vpc/docs/provisioning-shared-vpc[Google shared VPC documentation^]. A standalone GCP project is recommended for the service project. 
 * Redpanda creates a private Google Kubernetes Engine (GKE) cluster in your VPC. The subnet and secondary IP ranges you provide must allow public internet access. The configuration requires you to provide reserved CIDR ranges for the subnet and GKE Pods, Services, and master IP addresses. See the https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts[GKE service account documentation^] and <<Configure your VPC>>. 
 * Redpanda requires access to certain Google APIs, storage buckets, and service accounts. See <<Configure the service project>>.
 


### PR DESCRIPTION
## Description

This makes it clearer that require a shared VPC model for BYOVPC since we do not test other models of deployment, related to a customer incident. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)