### PR TITLE
Update related to self-managed ticket pre cloud split (482)

### DIFF
--- a/modules/networking/partials/private-links-access-rp-services-through-vpc.adoc
+++ b/modules/networking/partials/private-links-access-rp-services-through-vpc.adoc
@@ -16,7 +16,7 @@ Use port `30292` to access the Kafka API seed service.
 
 [,bash]
 ----
-export REDPANDA_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
+export RPK_BROKERS='<kafka-api-bootstrap-server-hostname>:30292'
 rpk cluster info -X tls.enabled=true -X user=<user> -X pass=<password>
 ----
 


### PR DESCRIPTION
## Description

Resolves doc 482

See also: https://github.com/redpanda-data/cloud-docs/pull/192 and https://github.com/redpanda-data/docs/pull/972
Review deadline: **Jan 31**

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)