### PR TITLE
DOC-1002 mark BYOVPC Azure as beta

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -314,7 +314,7 @@ The following features are currently in limited availability in Redpanda Cloud:
 
 * Redpanda Connect for Dedicated and BYOC (not BYOVPC)
 * Serverless Standard and Serverless Pro
-* Dedicated, BYOC, and BYOVPC for Azure
+* Dedicated and BYOC for Azure
 * BYOVPC for GCP
 * GCP Private Service Connect
 * Azure Private Link
@@ -328,7 +328,7 @@ The following features are currently in beta in Redpanda Cloud:
 * Redpanda Connect for Serverless Standard and Serverless Pro
 * Cloud API
 * Redpanda Terraform provider
-* BYOVPC for AWS
+* BYOVPC for AWS and Azure
 * Remote Read Replicas for AWS and GCP
 
 == Next steps

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -1,5 +1,6 @@
 = Create a BYOVPC Cluster on Azure
 :description: Connect Redpanda Cloud to your existing VNet for additional security.
+:page-beta: true
 
 include::shared:partial$feature-flag.adoc[]
 
@@ -189,8 +190,8 @@ EOF
 Initialize, plan, and apply Terraform to set up the Azure infrastructure:
 
 ```bash
-terraform init
-terraform plan
+terraform init &&
+terraform plan &&
 terraform apply
 ```
 
@@ -402,7 +403,7 @@ export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1beta2/clusters" \
 
 == Create cluster resources
 
-To create the initial cluster resources, first log in to Redpanda Cloud with `rpk cloud login`, and then run `rpk cloud byoc azure apply`:
+To create the initial cluster resources, first log in to Redpanda Cloud, then run `rpk cloud byoc azure apply`:
 
 ```bash
 rpk cloud login \
@@ -410,7 +411,9 @@ rpk cloud login \
   --client-id=${REDPANDA_CLIENT_ID} \
   --client-secret=${REDPANDA_CLIENT_SECRET} \
   --no-profile
+```
 
+```
 rpk cloud byoc azure apply --redpanda-id="${REDPANDA_ID}" --subscription-id="${AZURE_SUBSCRIPTION_ID}"
 ```
 


### PR DESCRIPTION
## Description
This adds the beta badge for BYOVPC for Azure + updates the LA/beta list in the overview. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1002
Review deadline: Jan 31

## Page previews
[Overview - features in LA/beta](https://deploy-preview-194--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#features-in-limited-availability)
[BYOVPC for Azure](https://deploy-preview-194--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/azure/vnet-azure/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)