### PR TITLE
DOC-972 Remove beta attribute from snowflake_streaming output

### DIFF
--- a/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
+++ b/modules/develop/pages/connect/components/outputs/snowflake_streaming.adoc
@@ -1,5 +1,4 @@
 = snowflake_streaming
 :page-aliases: components:outputs/snowflake_streaming.adoc
-:page-beta: true
 
 include::redpanda-connect:components:outputs/snowflake_streaming.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-972](https://redpandadata.atlassian.net/browse/DOC-972)
Review deadline: 4th February

## Page previews

[`snowflake_streaming` output](https://deploy-preview-195--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/snowflake_streaming/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-972]: https://redpandadata.atlassian.net/browse/DOC-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ