### PR TITLE
DOC-1007 clarify BYOVPC limitations

### DIFF
--- a/modules/develop/pages/connect/about.adoc
+++ b/modules/develop/pages/connect/about.adoc
@@ -2,9 +2,9 @@
 :tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--PipelineService
 :description: Learn about Redpanda Connect in Redpanda Cloud and its wide range of connectors.
 
-include::develop:partial$availability-message.adoc[]
-
 Redpanda Connect in Redpanda Cloud lets you quickly build and deploy streaming data pipelines on your clusters from a fully-integrated UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. 
+
+include::develop:partial$availability-message.adoc[]
 
 Choose from a xref:develop:connect/components/catalog.adoc[wide range of connectors] to suit your use case, including connectors to: 
 

--- a/modules/develop/partials/availability-message.adoc
+++ b/modules/develop/partials/availability-message.adoc
@@ -1,7 +1,7 @@
 [NOTE]
 ====
 
-* Redpanda Connect is available in limited availability (LA) for BYOC and Dedicated clusters. Features in LA are production-ready and are covered by Redpanda Support for early adoptors. To unlock Redpanda Connect for your account, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
+* Redpanda Connect is available in limited availability (LA) for BYOC and Dedicated clusters. Features in LA are production-ready and are covered by Redpanda Support for early adopters. To unlock Redpanda Connect for your account, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
 * Redpanda Connect is not available for BYOVPC clusters. 
 * Redpanda Connect is available in beta for Serverless clusters. Features in beta are not covered by Redpanda Support and should not be used in production environments.
 ==== 

--- a/modules/develop/partials/availability-message.adoc
+++ b/modules/develop/partials/availability-message.adoc
@@ -1,2 +1,9 @@
-NOTE: Redpanda Connect is currently in a limited availability (LA) release for  
-BYOC and Dedicated clusters. While it is also available as a beta feature for Serverless Standard and Pro clusters, it is not suitable for production deployments.
+[NOTE]
+====
+
+* Redpanda Connect is available in limited availability (LA) for BYOC and Dedicated clusters. Features in LA are production-ready and are covered by Redpanda Support for early adoptors. To unlock Redpanda Connect for your account, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
+* Redpanda Connect is not available for BYOVPC clusters. 
+* Redpanda Connect is available in beta for Serverless clusters. Features in beta are not covered by Redpanda Support and should not be used in production environments.
+==== 
+
+

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -307,7 +307,7 @@ NOTE: The `rpk cloud` commands are not supported in Self-Managed deployments.
 
 == Features in limited availability
 
-Features in limited availability are production-ready and are covered by Redpanda Support for early adoptors. 
+Features in limited availability are production-ready and are covered by Redpanda Support for early adopters. 
 
 The following features are currently in limited availability in Redpanda Cloud:
 

--- a/modules/get-started/pages/cluster-types/byoc/aws/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/index.adoc
@@ -1,4 +1,4 @@
 = BYOC: AWS
-:description: Learn how to create a BYOC cluster on AWS.
+:description: Learn how to create a BYOC or BYOVPC cluster on AWS.
 :page-layout: index
 :page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -27,6 +27,7 @@ The https://github.com/redpanda-data/cloud-examples/tree/main/customer-managed/a
 
 * Existing clusters cannot be moved to a BYOVPC cluster.
 * After creating a BYOVPC cluster, you cannot change to a different VPC.
+* Only primary CIDR ranges are supported for the VPC.
 
 == Set environment variables
 

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -4,7 +4,7 @@
 :page-cloud: true
 :page-beta: true
 
-include::shared:partial$feature-flag.adoc[]
+include::shared:partial$feature-flag-rpcn.adoc[]
 
 This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/index.adoc
@@ -1,4 +1,4 @@
 = BYOC: Azure
-:description: Learn how to create a BYOC cluster on Azure.
+:description: Learn how to create a BYOC or BYOVPC cluster on Azure.
 :page-layout: index
 :page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -35,6 +35,7 @@ See the code for the complete list of resources required to create and deploy Re
 
 * Existing clusters cannot be moved to a BYOVPC cluster.
 * After creating a BYOVPC cluster, you cannot change to a different VNet.
+* Only primary CIDR ranges are supported for the VNet.
 
 == Set environment variables
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -2,7 +2,7 @@
 :description: Connect Redpanda Cloud to your existing VNet for additional security.
 :page-beta: true
 
-include::shared:partial$feature-flag.adoc[]
+include::shared:partial$feature-flag-rpcn.adoc[]
 
 This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing virtual network (VNet) and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/index.adoc
@@ -1,4 +1,4 @@
 = BYOC: GCP
-:description: Learn how to create a BYOC cluster on GCP.
+:description: Learn how to create a BYOC or BYOVPC cluster on GCP.
 :page-layout: index
 :page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -16,6 +16,7 @@ When you create a BYOCVPC cluster, you specify your VPC and service account. The
 
 * A standalone GCP project is recommended. If your host project (where your VPC project is created) and your service project (where your Redpanda cluster is created) are in different projects, you must first provision a shared VPC in Google Cloud. For more information, see the https://cloud.google.com/vpc/docs/provisioning-shared-vpc[Google shared VPC documentation^]. 
 * Redpanda creates a private Google Kubernetes Engine (GKE) cluster in your VPC. The subnet and secondary IP ranges you provide must allow public internet access. The configuration requires you to provide reserved CIDR ranges for the subnet and GKE Pods, Services, and master IP addresses. See the https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts[GKE service account documentation^] and <<Configure your VPC>>. 
+* Only primary CIDR ranges are supported for the VPC.
 * Redpanda requires access to certain Google APIs, storage buckets, and service accounts. See <<Configure the service project>>.
 
 == Limitations

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -2,7 +2,7 @@
 :description: Connect Redpanda Cloud to your existing VPC for additional security.
 :page-aliases: deploy:deployment-option/cloud/vpc-byo-gcp.adoc, get-started:cluster-types/byoc/vpc-byo-gcp.adoc
 
-include::shared:partial$feature-flag.adoc[]
+include::shared:partial$feature-flag-rpcn.adoc[]
 
 This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 

--- a/modules/get-started/pages/cluster-types/byoc/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/index.adoc
@@ -1,5 +1,5 @@
 = BYOC
-:description: Learn how to create a Bring Your Own Cloud (BYOC) cluster.
+:description: Learn how to create a Bring Your Own Cloud (BYOC) or Bring Your Own Virtual Private Cloud (BYOVPC) cluster.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/provision-a-byoc-cluster/index.adoc
 :page-categories: Deployment

--- a/modules/shared/partials/feature-flag-rpcn.adoc
+++ b/modules/shared/partials/feature-flag-rpcn.adoc
@@ -1,0 +1,6 @@
+[IMPORTANT]
+====
+
+* BYOVPC is an add-on feature that may require an additional purchase. To unlock this feature for your account, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
+* Redpanda Connect is not available for BYOVPC clusters. 
+==== 


### PR DESCRIPTION
## Description
This adds clarifications about BYOVPC and Redpanda Connect availability. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1007, https://redpandadata.atlassian.net/browse/DOC-1009
Review deadline: Feb 6

## Page previews

- [RPCN in Redpanda Cloud](https://deploy-preview-196--rp-cloud.netlify.app/redpanda-cloud/develop/connect/about/) (also in [RPCN Quickstart](https://deploy-preview-196--rp-cloud.netlify.app/redpanda-cloud/develop/connect/connect-quickstart/))
- BYOVPC on [AWS](https://deploy-preview-196--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/vpc-byo-aws/), [Azure](https://deploy-preview-196--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/azure/vnet-azure/), [GCP](https://deploy-preview-196--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/gcp/vpc-byo-gcp/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)