### PR TITLE
DOC-1015 clarify K8s access

### DIFF
--- a/modules/get-started/partials/no-access.adoc
+++ b/modules/get-started/partials/no-access.adoc
@@ -1,1 +1,1 @@
-NOTE: Redpanda Cloud does not support user access to the control plane with `kubectl`. This restriction allows Redpanda Data to manage all configuration changes internally to ensure a 99.99% service level agreement (SLA) for BYOC clusters.
+NOTE: Redpanda Cloud does not support customer access to the Kubernetes control plane with `kubectl`. This restriction allows Redpanda Data to manage all configuration changes internally to ensure a 99.99% service level agreement (SLA) for BYOC clusters.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1015
Review deadline: Feb 5

## Page previews
The note on all pages has been updated to: https://deploy-preview-198--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/create-byoc-cluster-aws/#next-steps

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)