### PR TITLE
Remove compute.networks.get permission from BYOVPC GCP

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -108,7 +108,6 @@ cat << EOT > redpanda-agent.role
   "description": "A role granting the redpanda agent permissions to view network resources in the project of the vpc.",
   "includedPermissions": [
     "compute.firewalls.get",
-    "compute.networks.get",
     "compute.subnetworks.get",
     "resourcemanager.projects.get",
     "compute.networks.getRegionEffectiveFirewalls",
@@ -176,7 +175,6 @@ cat << EOT > redpanda-agent.role
     "compute.instanceGroups.delete",
     "compute.instances.list",
     "compute.instanceTemplates.delete",
-    "compute.networks.get",
     "compute.networks.getRegionEffectiveFirewalls",
     "compute.networks.getEffectiveFirewalls",
     "compute.projects.get",
@@ -497,7 +495,6 @@ Log in to the https://cloud.redpanda.com[Redpanda Cloud UI^], and follow the ste
 * `compute.instances.setLabels`
 * `compute.instances.setMetadata`
 * `compute.instances.setTags`
-* `compute.networks.get`
 * `compute.subnetworks.get`
 * `compute.subnetworks.use`
 * `compute.zones.list`


### PR DESCRIPTION
## Description

This permission is no longer required as of 2/11/2025.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)