### PR TITLE
DOC-1020 link artifact in BYOVPC for AWS

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -20,7 +20,7 @@ The https://github.com/redpanda-data/cloud-examples/tree/main/customer-managed/a
 
 * Access to an AWS project in which you create your cluster.
 * Minimum permissions in that AWS project. For the actions required by the user who will create the cluster with `rpk cloud byoc aws apply`, see https://github.com/redpanda-data/cloud-examples/blob/main/customer-managed/aws/terraform/iam_rpk_user.tf[`iam_rpk_user.tf`^].
-* Familiarity with the Redpanda Cloud API. For example, you should be familiar with how to use the Cloud API to xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[authenticate] and xref:redpanda-cloud:manage:api/controlplane/index.adoc[create a cluster.
+* Familiarity with the Redpanda Cloud API. For example, you should be familiar with how to use the Cloud API to xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[authenticate] and xref:redpanda-cloud:manage:api/cloud-byoc-controlplane-api.adoc[create a cluster].
 * https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli[Terraform^] version 1.8.5 or later.
 
 == Limitations


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1020
Review deadline: Feb 7

## Page previews
https://deploy-preview-202--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/vpc-byo-aws/#prerequisites

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)