### PR TITLE
DOC-820 Add `mysql_cdc` connector to Cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-820_add_mysql_cdc_input
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-820_add_mysql_cdc_input
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -101,6 +101,7 @@
 **** xref:develop:connect/components/inputs/kafka.adoc[]
 **** xref:develop:connect/components/inputs/kafka_franz.adoc[]
 **** xref:develop:connect/components/inputs/mqtt.adoc[]
+**** xref:develop:connect/components/inputs/mysql_cdc.adoc[]
 **** xref:develop:connect/components/inputs/nats.adoc[]
 **** xref:develop:connect/components/inputs/nats_jetstream.adoc[]
 **** xref:develop:connect/components/inputs/nats_kv.adoc[]

--- a/modules/develop/pages/connect/components/inputs/mysql_cdc.adoc
+++ b/modules/develop/pages/connect/components/inputs/mysql_cdc.adoc
@@ -1,0 +1,5 @@
+= mysql_cdc
+:page-aliases: components:inputs/mysql_cdc.adoc
+:page-beta: true
+
+include::redpanda-connect:components:inputs/mysql_cdc.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-820](https://redpandadata.atlassian.net/browse/DOC-820)
Review deadline: 19th February

## Page previews

[`mysql_cdc` input](https://deploy-preview-203--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/mysql_cdc/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-820]: https://redpandadata.atlassian.net/browse/DOC-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ