### PR TITLE
DOC-1014 update BYOVPC and PSC

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -248,7 +248,7 @@ either a public endpoint or a VPC peering network connection. Sensitive data and
 
 image::shared:d_c_plane.png[Data plane and control plane]
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]
 
 A BYOC cluster is initially set up from the control plane. This is a two-step process performed by `rpk cloud byoc apply`:
 

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -44,7 +44,7 @@ Optionally, click *Advanced settings* to specify up to five key-value custom tag
 +
 As part of agent deployment, Redpanda assigns the permission required to run the agent. For details about these permissions, see xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]
 
 == Next steps
 

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -387,4 +387,4 @@ After that completes, run:
 rpk cloud byoc aws destroy --redpanda-id ${REDPANDA_ID}
 ```
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -6,7 +6,7 @@
 
 include::shared:partial$feature-flag-rpcn.adoc[]
 
-This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
+This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cloud (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 
 When you create a BYOCVPC cluster, you specify your VPC and service account. The Redpanda Cloud agent doesn't create any new resources or alter any settings in your account. With BYOVPC: 
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -144,7 +144,7 @@ Replace the following placeholders:
 - `<cluster-id>`: Enter the cluster ID listed in the Redpanda Cloud UI. Go to the Cluster Overview page, and look in the Details section.
 - `<token>`: Enter the API token you received in step 1.
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]
 
 == Next steps
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag-rpcn.adoc[]
 
-This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing virtual network (VNet) and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
+This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing virtual network (VNet) and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cloud (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 
 When you create a BYOVPC cluster, you specify your VNet and managed identities. The Redpanda Cloud agent doesn't create any new resources or alter any settings in your account. With a customer-managed VNet: 
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -459,4 +459,4 @@ After that completes, run:
 rpk cloud byoc azure destroy --redpanda-id ${REDPANDA_ID}
 ```
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -32,7 +32,7 @@ Optionally, click *Advanced settings* to specify up to five key-value custom lab
 +
 Note that `rpk` configures the permissions required by the agent to provision and actively maintain the cluster. For details about these permissions, see xref:security:authorization/cloud-iam-policies-gcp.adoc[GCP IAM permissions].
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]
 
 == Next steps
 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag-rpcn.adoc[]
 
-This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
+This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cloud (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 
 When you create a BYOVPC cluster, you specify your VPC and service account. The Redpanda Cloud agent doesn't create any new resources or alter any settings in your account. With BYOVPC: 
 
@@ -149,7 +149,7 @@ gcloud storage buckets create gs://<management-storage-bucket-name> \
 gcloud storage buckets update gs://<management-storage-bucket-name> --versioning
 ``` 
 +
-* Redpanda uses the Tiered Storage bucket for writing log segments. This should not be versioned.
+* Redpanda uses the tiered storage bucket for writing log segments. This should not be versioned.
 * Redpanda uses the management storage bucket to store cluster metadata. This can have versioning enabled.
 
 . Create service accounts with necessary permissions and roles.
@@ -579,7 +579,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=<keyfile for service account>
 gcloud config set account $SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com
 ```
 
-. Run the following `rpk` command to validate your configuration: 
+. To validate your configuration, run: 
 +
 ```bash
 rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>' --validate-only

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -6,7 +6,7 @@ include::shared:partial$feature-flag-rpcn.adoc[]
 
 This topic explains how to create a Bring Your Own Virtual Private Cloud (BYOVPC) cluster. This setup allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC and take full control of managing the networking lifecycle. Compared to a standard Bring Your Own Cluster (BYOC) setup, where Redpanda manages the networking lifecycle for you, this option provides more security.
 
-When you create a BYOCVPC cluster, you specify your VPC and service account. The Redpanda Cloud agent doesn't create any new resources or alter any settings in your account. With BYOVPC: 
+When you create a BYOVPC cluster, you specify your VPC and service account. The Redpanda Cloud agent doesn't create any new resources or alter any settings in your account. With BYOVPC: 
 
 * You provide your own VPC in your Google Cloud account.
 * You maintain more control of your Google Cloud account, because Redpanda requires fewer permissions than standard BYOC clusters.
@@ -169,13 +169,14 @@ cat << EOT > redpanda-agent.role
   "title": "Redpanda Agent Role",
   "description": "A role comprising general permissions allowing the agent to manage Redpanda cluster resources.",
   "includedPermissions": [
-    "compute.firewalls.get",
+   "compute.firewalls.get",
     "compute.globalOperations.get",
     "compute.instanceGroupManagers.get",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroups.delete",
     "compute.instances.list",
     "compute.instanceTemplates.delete",
+    "compute.networks.get",
     "compute.networks.getRegionEffectiveFirewalls",
     "compute.networks.getEffectiveFirewalls",
     "compute.projects.get",
@@ -208,6 +209,42 @@ cat << EOT > redpanda-agent.role
     "serviceusage.services.list",
     "storage.buckets.get",
     "storage.buckets.getIamPolicy",
+    "compute.subnetworks.use",
+    "compute.instances.use",
+    "compute.networks.use",
+    "compute.regionOperations.get",
+    "compute.serviceAttachments.create",
+    "compute.serviceAttachments.delete",
+    "compute.serviceAttachments.get",
+    "compute.serviceAttachments.list",
+    "compute.serviceAttachments.update",
+    "compute.forwardingRules.use",
+    "compute.forwardingRules.create",
+    "compute.forwardingRules.delete",
+    "compute.forwardingRules.get",
+    "compute.forwardingRules.setLabels",
+    "compute.forwardingRules.setTarget",
+    "compute.forwardingRules.pscCreate",
+    "compute.forwardingRules.pscDelete",
+    "compute.forwardingRules.pscSetLabels",
+    "compute.forwardingRules.pscSetTarget",
+    "compute.forwardingRules.pscUpdate",
+    "compute.regionBackendServices.create",
+    "compute.regionBackendServices.delete",
+    "compute.regionBackendServices.get",
+    "compute.regionBackendServices.use",
+    "compute.regionNetworkEndpointGroups.create",
+    "compute.regionNetworkEndpointGroups.delete",
+    "compute.regionNetworkEndpointGroups.get",
+    "compute.regionNetworkEndpointGroups.use",
+    "compute.regionNetworkEndpointGroups.attachNetworkEndpoints",
+    "compute.regionNetworkEndpointGroups.detachNetworkEndpoints",
+    "compute.disks.list",
+    "compute.disks.setLabels",
+    "compute.instanceGroupManagers.update",
+    "compute.instances.delete",
+    "compute.instances.get",
+    "compute.instances.setLabels"
   ],
 }
 EOT
@@ -330,7 +367,7 @@ cat << EOT > redpanda-gke.role
   "title": "Redpanda cluster utility node role",
   "description": "Redpanda cluster utility node role",
   "includedPermissions": [
-    "artifactregistry.dockerimages.get",
+   "artifactregistry.dockerimages.get",
     "artifactregistry.dockerimages.list",
     "artifactregistry.files.get",
     "artifactregistry.files.list",
@@ -402,6 +439,14 @@ cat << EOT > redpanda-gke.role
     "stackdriver.resourceMetadata.write",
     "storage.objects.get",
     "storage.objects.list"
+    "compute.instances.use",
+    "iam.serviceAccounts.getAccessToken",
+    "compute.regionNetworkEndpointGroups.create",
+    "compute.regionNetworkEndpointGroups.delete",
+    "compute.regionNetworkEndpointGroups.get",
+    "compute.regionNetworkEndpointGroups.use",
+    "compute.regionNetworkEndpointGroups.attachNetworkEndpoints",
+    "compute.regionNetworkEndpointGroups.detachNetworkEndpoints"
   ],
 }
 EOT
@@ -470,6 +515,18 @@ gcloud iam service-accounts add-iam-policy-binding <gke-service-account-name>@<s
 ```
 ====
 
+* Private Service Connect Controller service account
++
+.Show commands
+[%collapsible]
+====
+```
+gcloud iam service-accounts add-iam-policy-binding <gke-service-account-name>@<service-project-id>.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:<service-project-id>.svc.id.goog[redpanda-psc/psc-controller]"
+```
+====
+
 == Create cluster
 
 Log in to the https://cloud.redpanda.com[Redpanda Cloud UI^], and follow the steps to xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[create a BYOC cluster], with the following exceptions:
@@ -533,4 +590,8 @@ rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-pr
 
 . On the *Deploy* page, similar to standard BYOC clusters, log in to Redpanda Cloud and deploy the agent.
 
-include::partial$no-access.adoc[]
+include::get-started:partial$no-access.adoc[]
+
+== Next steps
+
+xref:networking:byoc/gcp/index.adoc[Configure private networking]

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -73,7 +73,7 @@ gcloud compute routers nats create <nat-config-name> \
 ```bash
 gcloud compute firewall-rules create redpanda-ingress \
   --description="Allow access to Redpanda cluster" \
-  --network="<vpc-name>" \
+  --network="<shared-vpc-name>" \
   --project="<host-project-id>" \
   --direction="INGRESS" \
   --target-tags="redpanda-node" \
@@ -86,7 +86,7 @@ gcloud compute firewall-rules create redpanda-ingress \
 ```bash
 gcloud compute firewall-rules create gke-redpanda-cluster-webhooks \
   --description="Allow master to hit pods for admission controllers/webhooks" \
-  --network="<vpc-name>" \
+  --network="<shared-vpc-name>" \
   --project="<host-project-id>" \
   --direction="INGRESS" \
   --source-ranges="<gke-master-cidr-range>" \

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -176,7 +176,6 @@ cat << EOT > redpanda-agent.role
     "compute.instanceGroups.delete",
     "compute.instances.list",
     "compute.instanceTemplates.delete",
-    "compute.networks.get",
     "compute.networks.getRegionEffectiveFirewalls",
     "compute.networks.getEffectiveFirewalls",
     "compute.projects.get",

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added in Redpanda Cloud.
 
 == February 2025
 
+=== Improved Private Service Connect support with AZ affinity
+
+xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] now provides the ability to allow requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+
 === Serverless Pro usage limits increased
 
 xref:get-started:cluster-types/serverless-pro.adoc[Usage limits for Serverless Pro] clusters increased to: ingress = 100 MBps, egress = 300 MBps, partitions = 5000, and topics = 3000.

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added in Redpanda Cloud.
 
 === Improved Private Service Connect support with AZ affinity
 
-xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] now provides the ability to allow requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] now provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 === Serverless Pro usage limits increased
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -30,8 +30,8 @@ NOTE: The firewall rules support up to 20 Redpanda brokers. If you have more tha
 [,bash]
 ----
 gcloud compute networks subnets create <subnet-name> \
-    --project=<project> \
-    --network=<network-name> \
+    --project=<host-project-id> \
+    --network=<shared-vpc-name> \
     --region=<region> \
     --range=<subnet-range> \
     --purpose=PRIVATE_SERVICE_CONNECT
@@ -41,8 +41,8 @@ gcloud compute networks subnets create <subnet-name> \
 ----
 gcloud compute firewall-rules create redpanda-psc \
   --description="Allow access to Redpanda PSC endpoints" \
-  --network="<network-name>" \
-  --project="<project>" \
+  --network="<shared-vpc-name>" \
+  --project="<host-project-id>" \
   --direction="INGRESS" \
   --target-tags="redpanda-node" \
   --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
@@ -52,8 +52,8 @@ gcloud compute firewall-rules create redpanda-psc \
 Provide your values for the following placeholders:
 +
 - `<subnet-name>`: The name of the NAT subnet.
-- `<project>`: The **host** GCP project ID.
-- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
+- `<host-project-id>`: The **host** GCP project ID.
+- `<shared-vpc-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
 - `<region>`: The region of the Redpanda Cloud cluster.
 - `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
 +

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -8,7 +8,7 @@ include::shared:partial$feature-flag.adoc[]
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
-* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 ==== 
 
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -16,7 +16,7 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 
 == Requirements
 
-* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
+* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a client VPC and forwarding rule, or to modify existing resources to use the Private Service Connect service attachment created for your cluster.
 * The client VPC must be in the same region as your Redpanda cluster.
 
 == Enable endpoint service for existing clusters
@@ -52,7 +52,7 @@ gcloud compute firewall-rules create redpanda-psc \
 Provide your values for the following placeholders:
 +
 - `<subnet-name>`: The name of the NAT subnet.
-- `<host-project-id>`: The **host** GCP project ID.
+- `<host-project-id>`: The host GCP project ID.
 - `<shared-vpc-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
 - `<region>`: The region of the Redpanda Cloud cluster.
 - `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -23,7 +23,7 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 
 . In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
 . Under Private Service Connect, click **Enable**. 
-. For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with the *Purpose* set to `PRIVATE_SERVICE_CONNECT`. You can create the subnet using the `gcloud` command-line interface (CLI):
+. For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You also need to create VPC firewall rules to allow Private Service Connect traffic. The firewall rules support up to 20 Redpanda brokers. If the broker account is larger than 20, connect the support for updated rules. You can use the `gcloud` command-line interface (CLI):
 +
 [,bash]
 ----
@@ -35,6 +35,18 @@ gcloud compute networks subnets create <subnet-name> \
     --purpose=PRIVATE_SERVICE_CONNECT
 ----
 +
+[,bash]
+----
+gcloud compute firewall-rules create redpanda-psc \
+  --description="Allow access to Redpanda PSC endpoints" \
+  --network="<vpc-name>" \
+  --project="<host-project-id>" \
+  --direction="INGRESS" \
+  --target-tags="redpanda-node" \
+  --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
+  --allow="tcp:30181,tcp:30282,tcp:30292,tcp:31004,tcp:31082-31101,tcp:31182-31201,tcp:31282-31301,tcp:32092-32111,tcp:32192-32211,tcp:32292-32311"
+----
++
 Provide your values for the following placeholders:
 +
 - `<subnet-name>`: The name of the NAT subnet.
@@ -43,9 +55,10 @@ Provide your values for the following placeholders:
 - `<region>`: The region of the Redpanda Cloud cluster.
 - `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
 +
-See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
+See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^]. 
 . For the accepted consumers list, you need the GCP project IDs from which incoming connections will be accepted.
 . It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Cluster settings** changes from **In progress** to **Enabled**.
+
 
 NOTE: For help with issues when enabling Private Service Connect, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 
@@ -86,7 +99,3 @@ include::networking:partial$private-links-test-connection.adoc[]
 == Disable endpoint service
 
 In **Cluster settings**, click **Disable**. Existing connections are closed after GCP Private Service Connect is disabled. To connect using Private Service Connect again, you must re-enable the service.
-
-include::shared:partial$suggested-reading.adoc[]
-
-* xref:networking:gcp-private-service-connect.adoc[]

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -4,7 +4,14 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
+[NOTE]
+====
+
+* This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
+* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+==== 
+
+
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because these connections are treated as their own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -16,14 +16,16 @@ Consider using the endpoint services if you have multiple VPCs and could benefit
 
 == Requirements
 
-* Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
+* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a client VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 * The client VPC must be in the same region as your Redpanda cluster.
 
 == Enable endpoint service for existing clusters
 
 . In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
 . Under Private Service Connect, click **Enable**. 
-. For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You also need to create VPC firewall rules to allow Private Service Connect traffic. The firewall rules support up to 20 Redpanda brokers. If the broker account is larger than 20, connect the support for updated rules. You can use the `gcloud` command-line interface (CLI):
+. For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You also need to create VPC firewall rules to allow Private Service Connect traffic. You can use the `gcloud` CLI:
++
+NOTE: The firewall rules support up to 20 Redpanda brokers. If you have more than 20 brokers, or for help enabling Private Service Connect, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 +
 [,bash]
 ----
@@ -39,8 +41,8 @@ gcloud compute networks subnets create <subnet-name> \
 ----
 gcloud compute firewall-rules create redpanda-psc \
   --description="Allow access to Redpanda PSC endpoints" \
-  --network="<vpc-name>" \
-  --project="<host-project-id>" \
+  --network="<network-name>" \
+  --project="<project>" \
   --direction="INGRESS" \
   --target-tags="redpanda-node" \
   --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
@@ -59,9 +61,6 @@ See the GCP documentation for https://cloud.google.com/vpc/docs/configure-privat
 . For the accepted consumers list, you need the GCP project IDs from which incoming connections will be accepted.
 . It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Cluster settings** changes from **In progress** to **Enabled**.
 
-
-NOTE: For help with issues when enabling Private Service Connect, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
-
 === Deploy consumer-side resources
 
 For each VPC network, you must complete the following steps to successfully connect to the service and use Kafka API and other Redpanda services such as HTTP Proxy.
@@ -72,14 +71,14 @@ For each VPC network, you must complete the following steps to successfully conn
 +
 [,bash]
 ----
-gcloud dns --project=<GCP Project ID> managed-zones create <DNS zone name> --description="<description>" --dns-name="<DNS Zone from the UI>" --visibility="private" --networks="<list of fully-qualified name of networks where the DNS zone will be visible>"
+gcloud dns --project=<gcp-project-id> managed-zones create <dns-zone-name> --description="<description>" --dns-name="<dns-zone-from-the-ui>" --visibility="private" --networks="<list-of-fully-qualified-names-of-networks-where-the-dns-zone-will-be-visible>"
 ----
 
 . In the newly-created DNS zone, create a wildcard DNS record using the cluster **DNS record** value. 
 +
 [,bash]
 ----
-gcloud dns --project=rp-byoc-juan-0e38 record-sets create '*.<DNS Zone from the UI>' --zone="<DNS zone name>" --type="A" --ttl="300" --rrdatas="<PSC endpoint IP>"
+gcloud dns --project=<gcp-project-id> record-sets create '*.<dns-zone-from-the-ui>' --zone="<dns-zone-name>" --type="A" --ttl="300" --rrdatas="<psc-endpoint-ip>"
 ----
 
 . Confirm that your GCP VPC firewall allows traffic to and from the Private Service Connect forwarding rule IP address, on the expected ports.

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -17,7 +17,7 @@ Consider using Private Service Connect if you have multiple VPCs and could benef
 * You control from which GCP projects connections are allowed.
 ====
 
-After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-a-new-byoc-cluster-with-private-service-connect,enable Private Service Connect when creating a new BYOC cluster>>, or you can <<enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster,enable Private Service Connect for an existing BYOC or BYOVPC cluster>>.
+After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-a-new-byovpc-cluster-with-private-service-connect,create a new BYOVPC cluster with Private Service Connect enabled>>, or you can <<enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster,enable Private Service Connect for an existing BYOC or BYOVPC cluster>>.
 
 == Requirements
 
@@ -58,8 +58,8 @@ Provide your values for the following placeholders:
 +
 - `<subnet-name>`: The name of the NAT subnet.
 - `<project>`: The **host** GCP project ID.
-- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
-- `<region>`: The region of the Redpanda Cloud cluster.
+- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster. The name is used to identify this network in the Cloud UI.
+- `<region>`: The GCP region of the Redpanda Cloud cluster.
 - `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
 +
 See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
@@ -109,8 +109,8 @@ curl -vv -X POST \
 Replace the following placeholder variables for the request body:
 +
 --
-- `<network-name>`: Provide a name for the network. The name is used to identify this network in the Cloud UI.
-- `<region>`: Choose a GCP region where the network will be created.
+- `<network-name>`: The name for the network. 
+- `<region>`: The GCP region where the network will be created.
 - `<byovpc-network-gcp-project-id>`: The ID of the GCP project where your VPC is created.
 - `<byovpc-network-name>`: The name of your VPC.
 - `<byovpc-management-bucket>`: The name of the Google Storage bucket you created for the cluster.

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -293,3 +293,22 @@ include::networking:partial$private-links-access-rp-services-through-vpc.adoc[]
 You can test the Private Service Connect connection from any VM or container in the consumer VPC. If configuring a client isn't possible right away, you can do these checks using `rpk` or curl:
 
 include::networking:partial$private-links-test-connection.adoc[]
+
+== Disable Private Service Connect
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster to disable Private Service Connect.
+
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+    "gcp_private_service_connect": {
+        "enabled": false,
+    }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+----

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -30,7 +30,7 @@ include::networking:partial$private-links-api-access-token.adoc[]
 
 == Configure BYOC with customer-managed resources
 
-For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with the *Purpose* set to `PRIVATE_SERVICE_CONNECT`. You can create the subnet using the `gcloud` command-line interface (CLI):
+For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You can create the subnet using the `gcloud` command-line interface (CLI):
 
 [,bash]
 ----
@@ -52,7 +52,7 @@ Provide your values for the following placeholders:
 
 See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
 
-== Create new BYOC cluster with Private Service Connect enabled
+== Create a new BYOVPC cluster with Private Service Connect enabled
 
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +
@@ -63,19 +63,19 @@ Copy and store the resource group ID (UUID) from the URL in the browser.
 export RESOURCE_GROUP_ID=<uuid>
 ----
 
-. Update the Redpanda Cloud Agent IAM role.
-+
-To allow the agent to create and manage Private Service Connect resources, add the following permissions to its IAM role:
+. Follow the BYOVPC steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[configure the service project] to configure IAM role, permissions, and firewall rules.
+
+. Create VPC firewall rules to allow Private Service Connect traffic. The firewall rules support up to 20 Redpanda brokers. If the broker account is larger than 20, connect the support for updated rules.
 +
 ```
-compute.forwardingRules.use
-compute.regionOperations.get
-compute.serviceAttachments.create
-compute.serviceAttachments.delete
-compute.serviceAttachments.get
-compute.serviceAttachments.list
-compute.serviceAttachments.update
-compute.subnetworks.use
+gcloud compute firewall-rules create redpanda-psc \
+  --description="Allow access to Redpanda PSC endpoints" \
+  --network="<vpc-name>" \
+  --project="<host-project-id>" \
+  --direction="INGRESS" \
+  --target-tags="redpanda-node" \
+  --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
+  --allow="tcp:30181,tcp:30282,tcp:30292,tcp:31004,tcp:31082-31101,tcp:31182-31201,tcp:31282-31301,tcp:32092-32111,tcp:32192-32211,tcp:32292-32311"
 ```
 
 . Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] endpoint to create a network.
@@ -202,21 +202,19 @@ CAUTION: As soon as Private Service Connect is available on your VPC, all commun
 CLUSTER_ID=<cluster-id>
 ----
 
-. Update the Redpanda Cloud Agent IAM role. This step is required only for BYOVPC clusters with xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[customer-managed resources].
+. For a *BYOC cluster*, run: 
 +
-To allow the agent to create and manage the service attachment, add the following permissions to its IAM role:
+```bash
+rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
+``` 
 +
-[,bash]
-----
-compute.forwardingRules.use
-compute.regionOperations.get
-compute.serviceAttachments.create
-compute.serviceAttachments.delete
-compute.serviceAttachments.get
-compute.serviceAttachments.list
-compute.serviceAttachments.update
-compute.subnetworks.use
-----
+For a *BYOVPC cluster*, first follow the steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[configure the service project] to configure IAM role, permissions, and firewall rules. Then run:
++
+```bash
+rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
+```
++
+
 
 . Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
 +
@@ -283,9 +281,3 @@ include::networking:partial$private-links-access-rp-services-through-vpc.adoc[]
 You can test the Private Service Connect connection from any VM or container in the consumer VPC. If configuring a client isn't possible right away, you can do these checks using `rpk` or curl:
 
 include::networking:partial$private-links-test-connection.adoc[]
-
-
-include::shared:partial$suggested-reading.adoc[]
-
-* xref:networking:dedicated/vpc-peering.adoc[]
-* xref:networking:byoc/gcp/vpc-peering-gcp.adoc[]

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -200,7 +200,7 @@ CAUTION: As soon as Private Service Connect is available on your VPC, all commun
 +
 [,bash]
 ----
-CLUSTER_ID=<cluster-id>
+export CLUSTER_ID=<cluster-id>
 ----
 
 . For a *BYOC cluster*, run `rpk cloud byoc gcp apply`:

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -8,7 +8,7 @@ include::shared:partial$feature-flag.adoc[]
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
-* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 ==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -47,8 +47,8 @@ export RESOURCE_GROUP_ID=<uuid>
 [,bash]
 ----
 gcloud compute networks subnets create <subnet-name> \
-    --project=<project> \
-    --network=<network-name> \
+    --project=<host-project-id> \
+    --network=<shared-vpc-name> \
     --region=<region> \
     --range=<subnet-range> \
     --purpose=PRIVATE_SERVICE_CONNECT
@@ -57,8 +57,8 @@ gcloud compute networks subnets create <subnet-name> \
 Provide your values for the following placeholders:
 +
 - `<subnet-name>`: The name of the NAT subnet.
-- `<project>`: The **host** GCP project ID.
-- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster. The name is used to identify this network in the Cloud UI.
+- `<host-project-id>`: The host GCP project ID.
+- `<shared-vpc-name>`: The name of the VPC being used for your Redpanda Cloud cluster. The name is used to identify this network in the Cloud UI.
 - `<region>`: The GCP region of the Redpanda Cloud cluster.
 - `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
 +
@@ -71,8 +71,8 @@ NOTE: The firewall rules support up to 20 Redpanda brokers. If you have more tha
 ```
 gcloud compute firewall-rules create redpanda-psc \
   --description="Allow access to Redpanda PSC endpoints" \
-  --network="<network-name>" \
-  --project="<project>" \
+  --network="<shared-vpc-name>" \
+  --project="<host-project-id>" \
   --direction="INGRESS" \
   --target-tags="redpanda-node" \
   --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
@@ -87,7 +87,7 @@ network_post_body=`cat << EOF
 {
     "cloud_provider": "CLOUD_PROVIDER_GCP",
     "cluster_type": "TYPE_BYOC",
-    "name": "<network-name>",
+    "name": "<shared-vpc-name>",
     "resource_group_id": "$RESOURCE_GROUP_ID",
     "region": "<region>",
     "customer_managed_resources": {
@@ -109,7 +109,7 @@ curl -vv -X POST \
 Replace the following placeholder variables for the request body:
 +
 --
-- `<network-name>`: The name for the network. 
+- `<shared-vpc-name>`: The name for the network. 
 - `<region>`: The GCP region where the network will be created.
 - `<byovpc-network-gcp-project-id>`: The ID of the GCP project where your VPC is created.
 - `<byovpc-network-name>`: The name of your VPC.
@@ -244,7 +244,7 @@ curl -v -X PATCH \
 +
 Replace the following placeholder:
 +
-`<psc-nat-subnet-name>`: The name of the Private Service Connect NAT subnet. Use the fully-qualified name, for example `"projects/<project>/regions/<region>/subnetworks/<subnet-name>"`.
+`<psc-nat-subnet-name>`: The name of the Private Service Connect NAT subnet. Use the fully-qualified name, for example `"projects/<host-project-id>/regions/<region>/subnetworks/<subnet-name>"`.
 
 . Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -4,7 +4,7 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] if you want to set up the endpoint service using the Redpanda Cloud UI.
+NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
@@ -17,42 +17,19 @@ Consider using Private Service Connect if you have multiple VPCs and could benef
 * You control from which GCP projects connections are allowed.
 ====
 
-After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-byoc-cluster-with-private-service-connect-enabled,enable Private Service Connect when creating a new BYOC cluster>>, or you can <<enable-private-service-connect-on-an-existing-byoc-cluster,enable Private Service Connect for existing BYOC clusters>>.
+After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-a-new-byoc-cluster-with-private-service-connect,enable Private Service Connect when creating a new BYOC cluster>>, or you can <<enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster,enable Private Service Connect for an existing BYOC or BYOVPC cluster>>.
 
 == Requirements
 
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
-* Use https://cloud.google.com/sdk/docs/install[gcloud^] to create the consumer-side resources, such as a VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
+* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
 
 == Get a Cloud API access token
 
 include::networking:partial$private-links-api-access-token.adoc[]
 
-== Configure BYOC with customer-managed resources
 
-For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You can create the subnet using the `gcloud` command-line interface (CLI):
-
-[,bash]
-----
-gcloud compute networks subnets create <subnet-name> \
-    --project=<project> \
-    --network=<network-name> \
-    --region=<region> \
-    --range=<subnet-range> \
-    --purpose=PRIVATE_SERVICE_CONNECT
-----
-
-Provide your values for the following placeholders:
-
-- `<subnet-name>`: The name of the NAT subnet.
-- `<project>`: The **host** GCP project ID.
-- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
-- `<region>`: The region of the Redpanda Cloud cluster.
-- `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
-
-See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
-
-== Create a new BYOVPC cluster with Private Service Connect enabled
+== Create a new BYOVPC cluster with Private Service Connect
 
 . In the https://cloud.redpanda.com/[Redpanda Cloud UI], go to **Resource groups** and select the resource group in which you want to create a cluster.
 +
@@ -65,13 +42,37 @@ export RESOURCE_GROUP_ID=<uuid>
 
 . Follow the BYOVPC steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[configure the service project] to configure IAM role, permissions, and firewall rules.
 
-. Create VPC firewall rules to allow Private Service Connect traffic. The firewall rules support up to 20 Redpanda brokers. If the broker account is larger than 20, connect the support for updated rules.
+. BYOVPC clusters need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You can create the subnet using the `gcloud` CLI:
++
+[,bash]
+----
+gcloud compute networks subnets create <subnet-name> \
+    --project=<project> \
+    --network=<network-name> \
+    --region=<region> \
+    --range=<subnet-range> \
+    --purpose=PRIVATE_SERVICE_CONNECT
+----
++
+Provide your values for the following placeholders:
++
+- `<subnet-name>`: The name of the NAT subnet.
+- `<project>`: The **host** GCP project ID.
+- `<network-name>`: The name of the VPC being used for your Redpanda Cloud cluster.
+- `<region>`: The region of the Redpanda Cloud cluster.
+- `<subnet-range>`: The CIDR range of the subnet. The mask should be at least `/29`. Each Private Service Connect connection takes up one IP address from the NAT subnet, so the CIDR must be able to accommodate all projects from which connections to the service attachment will be issued.
++
+See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^].
+
+. Create VPC firewall rules to allow Private Service Connect traffic. Use the `gcloud` CLI to create the firewall rules:  
++
+NOTE: The firewall rules support up to 20 Redpanda brokers. If you have more than 20 brokers, or for help enabling Private Service Connect, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 +
 ```
 gcloud compute firewall-rules create redpanda-psc \
   --description="Allow access to Redpanda PSC endpoints" \
-  --network="<vpc-name>" \
-  --project="<host-project-id>" \
+  --network="<network-name>" \
+  --project="<project>" \
   --direction="INGRESS" \
   --target-tags="redpanda-node" \
   --source-ranges="10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10" \
@@ -191,7 +192,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 - `<byovpc-tiered-storage-bucket>`: The name of the Google Storage bucket to use for Tiered Storage.
 --
 
-== Enable Private Service Connect on an existing BYOC cluster
+== Enable Private Service Connect on an existing BYOC or BYOVPC cluster
 
 CAUTION: As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports.
 
@@ -202,19 +203,23 @@ CAUTION: As soon as Private Service Connect is available on your VPC, all commun
 CLUSTER_ID=<cluster-id>
 ----
 
-. For a *BYOC cluster*, run: 
+. For a *BYOC cluster*, run `rpk cloud byoc gcp apply`:
 +
 ```bash
 rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
 ``` 
 +
-For a *BYOVPC cluster*, first follow the steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[configure the service project] to configure IAM role, permissions, and firewall rules. Then run:
+For a *BYOVPC cluster*:
++
+--
+- xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[Configure the service project] to configure the IAM role, permissions, and firewall rules.
+- Create a NAT subnet and firewall rules to allow Private Service Connect traffic. Follow steps 3 and 4 in <<Create a new BYOVPC cluster with Private Service Connect>>.
+- Run `rpk cloud byoc gcp apply`:
 +
 ```bash
 rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
-```
-+
-
+``` 
+--
 
 . Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
 +
@@ -263,7 +268,7 @@ Replace the following placeholder:
 +
 `<accept-list>`: a JSON list specifying the projects from which incoming connections will be accepted. All other sources. For example, `[{"source": "consumer-project-ID-1"},{"source": "consumer-project-ID-2"}]`.
 +
-Wait for the cluster to apply the new configuration (around 15 minutes). The Private Service Connect service attachment is available when the cluster update is complete. You can monitor the service attachment creation by running the following `gcloud` command and supplying the project ID:
+Wait for the cluster to apply the new configuration (around 15 minutes). The Private Service Connect service attachment is available when the cluster update is complete. To monitor the service attachment creation, run the following `gcloud` command with the project ID:
 +
 [,bash]
 ----

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -22,7 +22,7 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 == Requirements
 
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
-* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a VPC and forwarding rule, or modify existing resources to use the Private Service Connect service attachment created for your cluster.
+* Use the https://cloud.google.com/sdk/docs/install[gcloud^] command-line interface (CLI) to create the consumer-side resources, such as a VPC and forwarding rule, or to modify existing resources to use the Private Service Connect service attachment created for your cluster.
 
 == Get a Cloud API access token
 
@@ -213,7 +213,7 @@ For a *BYOVPC cluster*:
 +
 --
 - xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[Configure the service project] to configure the IAM role, permissions, and firewall rules.
-- Create a NAT subnet and firewall rules to allow Private Service Connect traffic. Follow steps 3 and 4 in <<Create a new BYOVPC cluster with Private Service Connect>>.
+- Create a NAT subnet and firewall rules to allow Private Service Connect traffic. To do this, follow steps 3 and 4 in <<Create a new BYOVPC cluster with Private Service Connect>>.
 - Run `rpk cloud byoc gcp apply`:
 +
 ```bash

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -4,9 +4,16 @@
 
 include::shared:partial$feature-flag.adoc[]
 
-NOTE: This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
+[NOTE]
+====
+
+* This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
+* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
+
+As of February 2025 ability to allow requests from Private Service Connect endpoints to stay within the same AZ, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 Consider using Private Service Connect if you have multiple VPCs and could benefit from a more simplified approach to network management.
 

--- a/modules/networking/partials/private-links-api-access-token.adoc
+++ b/modules/networking/partials/private-links-api-access-token.adoc
@@ -5,7 +5,7 @@
 export PUBLIC_API_ENDPOINT="https://api.cloud.redpanda.com"
 ----
 
-. In your organization in the Redpanda Cloud UI, go to https://cloud.redpanda.com/clients[**Clients**^]. If you don't have an existing client (also known as service account), you can create a new one by clicking **Add client**.
+. In your organization in the Redpanda Cloud UI, go to https://cloud.redpanda.com//organization-iam[**Organization IAM**^]. If you don't have an existing service account, you can create a new one.
 +
 Copy and store the client ID and secret.
 +


### PR DESCRIPTION
## Description
This pull request adds new permissions and firewall rules. Here are the most important changes:

### Permissions and Firewall Rules:
* Added new permissions to the `redpanda-agent.role` and `redpanda-gke.role` in `modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc`. [[1]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9R179) [[2]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9R212-R247) [[3]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9R442-R449)
* Added commands for creating firewall rules in `modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc` and `modules/networking/pages/gcp-private-service-connect.adoc`. [[1]](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56R38-R49) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L66-R78)

### Additional Content:
* Added new sections and commands for configuring private networking and IAM policies in `modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc`. [[1]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9R518-R529) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L205-R217)

### Minor Changes:
* Updated the description for creating a NAT subnet and VPC firewall rules in `modules/networking/pages/gcp-private-service-connect.adoc`. [[1]](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56L26-R26) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L33-R33)

### Documentation Updates:
* Updated file inclusions in multiple files to use `get-started:partial$no-access.adoc[]` instead of `partial$no-access.adoc[]`. [[1]](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL251-R251) [[2]](diffhunk://#diff-f5cfd5aa50fd526a9a9ced35995a2703c7285dce8a1a18ce84ca1bde5ab9bab3L47-R47) [[3]](diffhunk://#diff-a056c359f8c3c6ac1d52caa712bacb5d840e6f499d9e5180517c2a2a48b6d244L390-R390) [[4]](diffhunk://#diff-ab3280e96d3ffa280051aecc61f4c7f00de0e17b39e1d392895d15d6cd999dfaL147-R147) [[5]](diffhunk://#diff-83e23f48f04bb841f52bad086df6cddaf7be01927366dbe59f4644390c60a804L462-R462) [[6]](diffhunk://#diff-8865164e17fac88c9dd04d3e39b552892b06f071311c166510e919dd7d66fb3cL35-R35) [[7]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9L536-R597)

These updates ensure that the documentation is consistent and includes the necessary permissions and configurations for setting up BYOC clusters effectively.

Resolves https://redpandadata.atlassian.net/browse/DOC-1014
Review deadline: Feb 21

## Page previews

- [What's New](https://deploy-preview-204--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
- [Create a BYOVPC Cluster on GCP](https://deploy-preview-204--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/gcp/vpc-byo-gcp/)
- [Configure GCP Private Service Connect in the Cloud UI](https://deploy-preview-204--rp-cloud.netlify.app/redpanda-cloud/networking/configure-private-service-connect-in-cloud-ui/)
- [Configure GCP Private Service Connect with the Cloud API](https://deploy-preview-204--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)