### PR TITLE
Update authN instructions with new UI

### DIFF
--- a/modules/manage/pages/api/cloud-api-authentication.adoc
+++ b/modules/manage/pages/api/cloud-api-authentication.adoc
@@ -28,8 +28,7 @@ curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
     -H "content-type: application/x-www-form-urlencoded" \
     -d "grant_type=client_credentials" \
     -d "client_id=<client-id>" \
-    -d "client_secret=<client-secret>" \
-    -d "audience=cloudv2-production.redpanda.cloud"
+    -d "client_secret=<client-secret>"
 ```
 +
 The request response provides an access token that remains valid for one hour.

--- a/modules/manage/pages/api/cloud-api-authentication.adoc
+++ b/modules/manage/pages/api/cloud-api-authentication.adoc
@@ -24,13 +24,12 @@ NOTE: Service accounts have administrative privileges by default. Cloud user rol
 . Make a POST request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
 +
 ```bash
-curl --request POST \
-    --url 'https://auth.prd.cloud.redpanda.com/oauth/token' \
-    --header 'content-type: application/x-www-form-urlencoded' \
-    --data grant_type=client_credentials \
-    --data client_id=<client-id> \
-    --data client_secret=<client-secret> \
-    --data audience=cloudv2-production.redpanda.cloud
+curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
+    -H "content-type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=<client-id>" \
+    -d "client_secret=<client-secret>" \
+    -d "audience=cloudv2-production.redpanda.cloud"
 ```
 +
 The request response provides an access token that remains valid for one hour.

--- a/modules/manage/pages/api/cloud-api-authentication.adoc
+++ b/modules/manage/pages/api/cloud-api-authentication.adoc
@@ -17,12 +17,21 @@ Users with administrative privileges in a Redpanda Cloud organization can create
 
 NOTE: Service accounts have administrative privileges by default. Cloud user roles are not applied for the API.
 
-// UI change not applied
-. On the https://cloud.redpanda.com/clients[Clients^] page in the Redpanda Cloud UI, click *Add client*. Enter a name and description.
+. On the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Service account^] tab in the Organization IAM page of the Redpanda Cloud UI, click *Create service account*. Enter a name and description.
 
-. Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
+. Copy and store the Client ID and Client Secret. These credentials cannot be viewed again after you close the dialog. 
 
-. Make a POST request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. To see code examples for getting a token, click the *Request an API token* link in the *Clients* page.
+. Make a POST request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
++
+```bash
+curl --request POST \
+    --url 'https://auth.prd.cloud.redpanda.com/oauth/token' \
+    --header 'content-type: application/x-www-form-urlencoded' \
+    --data grant_type=client_credentials \
+    --data client_id=<client-id> \
+    --data client_secret=<client-secret> \
+    --data audience=cloudv2-production.redpanda.cloud
+```
 +
 The request response provides an access token that remains valid for one hour.
 

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -13,7 +13,7 @@ The following steps describe how to authenticate with the Cloud API and create a
 BYOC or Dedicated::
 +
 --
-. In the Redpanda Cloud UI, create a https://cloud.redpanda.com/clients[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
+. In the Redpanda Cloud UI, create a https://cloud.redpanda.com/organization-iam?tab=service-accounts[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
 . Create a resource group by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`POST /v1beta2/resource-groups`] request.
 . Create a network by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] request. Note that this operation may be long-running.
 . Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] request.
@@ -41,7 +41,7 @@ rpk cloud byoc gcp apply --redpanda-id=<metadata.cluster_id> --project-id=<gcp-p
 Serverless::
 +
 --
-. In the Redpanda Cloud UI, create a https://cloud.redpanda.com/clients[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
+. In the Redpanda Cloud UI, create a https://cloud.redpanda.com/organization-iam?tab=service-accounts[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
 . Make a GET request to the `/v1beta2/resource-groups` endpoint to retrieve the default resource group ID.
 +
 [,bash]


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 24 Feb

This pull request includes updates to the documentation for creating and using service accounts in the Redpanda Cloud UI. The changes clarify the steps and update the UI references to reflect the current interface.

Documentation updates:

* [`modules/manage/pages/api/cloud-api-authentication.adoc`](diffhunk://#diff-41532e4093374254341a9d4160f5f37e109fc0f039f55b85f05fe492391fb44aL20-R34): Updated instructions for creating a service account and obtaining the client ID and secret, including a new example of making a POST request to get an API token.
* [`modules/manage/pages/api/cloud-api-quickstart.adoc`](diffhunk://#diff-16a138b2faf55645dfb47e7dcfdccc924f15c254f941eeb7d6c532813bc0d5e8L16-R16): Updated references to the location of service account creation in the Redpanda Cloud UI for both BYOC or Dedicated and Serverless sections. [[1]](diffhunk://#diff-16a138b2faf55645dfb47e7dcfdccc924f15c254f941eeb7d6c532813bc0d5e8L16-R16) [[2]](diffhunk://#diff-16a138b2faf55645dfb47e7dcfdccc924f15c254f941eeb7d6c532813bc0d5e8L44-R44)

## Page previews

[Cloud API Authentication > Request an access token](https://deploy-preview-208--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-api-authentication/#request-an-access-token)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)