### PR TITLE
DOC-1036 new Serverless Pro limits

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -18,9 +18,9 @@ Redpanda offers four types of fully-managed cloud clusters. All products have ac
 
 | For starter projects and applications with low or variable traffic. | For an enterprise-level version of Serverless, supporting moderate, sustained traffic. | For production clusters requiring expert cloud hosting, higher throughput, and extra isolation. | For production clusters requiring data sovereignty, the highest throughput, and added security.
 | Multi-tenant on AWS | Multi-tenant on AWS | Single-tenant on AWS, Azure, or GCP | In your cloud on AWS, Azure, or GCP 
-| 1 MB/s max write throughput | 10 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
-| 3 MB/s max read throughput | 30 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
-| 100 partitions | 500 partitions | 22,800 partitions | 112,500 partitions
+| 1 MB/s max write throughput | 100 MB/s max write throughput | 400 MB/s max write throughput | 2 GB/s max write throughput
+| 3 MB/s max read throughput | 300 MB/s max read throughput | 800 MB/s max read throughput | 4 GB/s max read throughput 
+| 100 partitions | 5000 partitions | 22,800 partitions | 112,500 partitions
 | 99.5% SLA | 99.5% SLA | 99.99% SLA | 99.99% SLA 
 | Public networking | Public networking | Public or private networking | Public or private networking
 | SSO (GitHub, Google), Kafka ACLs | SSO (GitHub, Google), Kafka ACLs | SSO (GitHub, Google, OIDC), RBAC, audit logs  | SSO (GitHub, Google, OIDC), RBAC, audit logs 

--- a/modules/get-started/pages/cluster-types/serverless-pro.adoc
+++ b/modules/get-started/pages/cluster-types/serverless-pro.adoc
@@ -13,10 +13,10 @@ Make sure you have the latest version of `rpk`. See xref:get-started:rpk-install
 
 Each Serverless Pro cluster has the following limits:
 
-* Ingress: 10 MBps
-* Egress: 30 MBps
-* Partitions: 500 
-* Topics: 300
+* Ingress: 100 MBps
+* Egress: 300 MBps
+* Partitions: 5000 
+* Topics: 3000
 * Message size: 20 MB
 * Retention: unlimited
 * Storage: unlimited

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added in Redpanda Cloud.
 
 == February 2025
 
+=== Serverless Pro usage limits increased
+
+xref:get-started:cluster-types/serverless-pro.adoc[Usage limits for Serverless Pro] clusters increased to: ingress = 100 MBps, egress = 300 MBps, partitions = 5000, and topics = 3000.
+
 === Role-based access control (RBAC): beta
 
 With xref:security:authorization/rbac.adoc[RBAC], you can assign users access to specific resources in your Redpanda Cloud organization. For example, you could grant all users with a certain job title read access on the entire organization while limiting write access to only the non-production resource group. This alleviates the process of manually maintaining and verifying a set of ACLs for a large number of users.  


### PR DESCRIPTION
## Description
This pull request increases the throughput and partition limits for Serverless Pro clusters.

Changes to throughput and partition limits:

* [`modules/get-started/pages/cloud-overview.adoc`](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL21-R23): Increased the max write throughput from 10 MB/s to 100 MB/s, the max read throughput from 30 MB/s to 300 MB/s, and the partition limit from 500 to 5000 for Serverless Pro clusters.
* [`modules/get-started/pages/cluster-types/serverless-pro.adoc`](diffhunk://#diff-615b10a951b12e2feada2739516a97073df5038ec68aa04efa46a26a43aaefebL16-R19): Updated the ingress limit from 10 MBps to 100 MBps, the egress limit from 30 MBps to 300 MBps, and the partition limit from 500 to 5000 for Serverless Pro clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1036
Review deadline: Feb 24

## Page previews
[Cloud overview](https://deploy-preview-210--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/)
[Serverless Pro](https://deploy-preview-210--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless-pro/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)