### PR TITLE
Use Cloud API for RBAC

### DIFF
--- a/modules/develop/pages/connect/about.adoc
+++ b/modules/develop/pages/connect/about.adoc
@@ -1,5 +1,5 @@
 = Redpanda Connect in Redpanda Cloud
-:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--PipelineService
+:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--Redpanda-Connect-Pipeline
 :description: Learn about Redpanda Connect in Redpanda Cloud and its wide range of connectors.
 
 Redpanda Connect in Redpanda Cloud lets you quickly build and deploy streaming data pipelines on your clusters from a fully-integrated UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. 

--- a/modules/develop/pages/connect/configuration/resource-management.adoc
+++ b/modules/develop/pages/connect/configuration/resource-management.adoc
@@ -135,7 +135,7 @@ Data Plane API::
 +
 --
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API. 
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines[`GET /v1alpha2/redpanda-connect/pipelines`], which lists details of all pipelines on your cluster by ID. 
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1/redpanda-connect/pipelines[`GET /v1/redpanda-connect/pipelines`], which lists details of all pipelines on your cluster by ID. 
 +
 * Memory (`memory_shares`) is displayed in megabytes. For example, `1` task is `400M` or 400 MB.
 * CPU resources (`cpu_shares`) are displayed milliCPU. For example, `1` task is `100m` or 0.1 CPU.
@@ -163,8 +163,8 @@ Data Plane API::
 You can only update CPU resources using the Data Plane API. For every 0.1 CPU that you allocate, Redpanda Cloud automatically reserves 400 MB of memory for the exclusive use of the pipeline.
 
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API, if you haven't already.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1alpha2/redpanda-connect/pipelines/\{id}`], including the ID of the pipeline you want to update. You'll use the returned values in the next step.
-. Now make a request to xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}`], to update the pipeline resources:
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1/redpanda-connect/pipelines/-id-[`GET /v1/redpanda-connect/pipelines/\{id}`], including the ID of the pipeline you want to update. You'll use the returned values in the next step.
+. Now make a request to xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1/redpanda-connect/pipelines/-id-[`PUT /v1/redpanda-connect/pipelines/\{id}`], to update the pipeline resources:
 +
 * Reuse the values returned by your `GET` request to populate the request body. 
 * Replace the `cpu_shares` value with the resources you want to allocate, and enter any valid value for `memory_shares`.
@@ -173,7 +173,7 @@ This example allocates 0.2 CPU or 200 milliCPU to a data pipeline. For `cpu_shar
 +
 [,bash,role=“no-placeholders”]
 ----
-curl -X PUT "https://<data-plane-api-url>/v1alpha2/redpanda-connect/pipelines/xxx..." \
+curl -X PUT "https://<data-plane-api-url>/v1/redpanda-connect/pipelines/xxx..." \
  -H 'accept: application/json'\
  -H 'authorization: Bearer xxx...' \
  -H "content-type: application/json" \
@@ -188,6 +188,6 @@ curl -X PUT "https://<data-plane-api-url>/v1alpha2/redpanda-connect/pipelines/xx
 ----
 +
 A successful response shows the updated resource allocations with the `cpu_shares` value returned in milliCPU.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines[`GET /v1alpha2/redpanda-connect/pipelines`] to verify your pipeline resource updates.
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1/redpanda-connect/pipelines[`GET /v1/redpanda-connect/pipelines`] to verify your pipeline resource updates.
 --
 =====

--- a/modules/develop/pages/connect/configuration/secret-management.adoc
+++ b/modules/develop/pages/connect/configuration/secret-management.adoc
@@ -62,11 +62,11 @@ Data Plane API::
 You must use a Base64-encoded secret.
 
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/secrets[`POST /v1alpha2/secrets`].
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/secrets[`POST /v1/secrets`].
 +
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/secrets" \
+curl -X POST "https://<dataplane-api-url>/v1/secrets" \
  -H 'accept: application/json'\
  -H 'authorization: Bearer <token>'\
  -H 'content-type: application/json' \
@@ -127,11 +127,11 @@ Data Plane API::
 You must use a Base64-encoded secret.
 
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/secrets/-id-[`PUT /v1alpha2/secrets/\{id}`].
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1/secrets/-id-[`PUT /v1/secrets/\{id}`].
 +
 [,bash]
 ----
-curl -X PUT "https://<dataplane-api-url>/v1alpha2/secrets/<secret-name>" \
+curl -X PUT "https://<dataplane-api-url>/v1/secrets/<secret-name>" \
  -H 'accept: application/json'\
  -H 'authorization: Bearer <token>'\
  -H 'content-type: application/json' \
@@ -188,11 +188,11 @@ Data Plane API::
 --
 
 . xref:manage:api/cloud-api-quickstart.adoc#try-the-cloud-api[Authenticate and get the base URL] for the Data Plane API.
-. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#delete-/v1alpha2/secrets/-id-[`DELETE /v1alpha2/secrets/\{id}`].
+. Make a request to xref:api:ROOT:cloud-dataplane-api.adoc#delete-/v1/secrets/-id-[`DELETE /v1/secrets/\{id}`].
 +
 [,bash]
 ----
-curl -X DELETE "https://<dataplane-api-url>/v1alpha2/secrets/<secret-name>" \
+curl -X DELETE "https://<dataplane-api-url>/v1/secrets/<secret-name>" \
  -H 'accept: application/json'\
  -H 'authorization: Bearer <token>'\
 ----

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -1,7 +1,7 @@
 = Redpanda Cloud Overview
 :description: Learn about Redpanda Serverless Standard, Serverless Pro, Dedicated, and Bring Your Own Cloud (BYOC) clusters.
 :description: Learn about Redpanda Serverless, Dedicated, and Bring Your Own Cloud (BYOC) clusters.
-:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--PipelineService
+:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--Redpanda-Connect-Pipeline
 :page-aliases: cloud:dedicated-byoc.adoc, deploy:deployment-option/cloud/dedicated-byoc.adoc, deploy:deployment-option/cloud/cloud-overview.adoc
 
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -323,7 +323,6 @@ Features in beta are available for testing and feedback. They are not covered by
 The following features are currently in beta in Redpanda Cloud:
 
 * Redpanda Connect for Serverless
-* Cloud API
 * Redpanda Terraform provider
 * BYOVPC for AWS and Azure
 * Remote Read Replicas for AWS and GCP

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -155,7 +155,7 @@ EOF
 . Use the Cloud API to create the network and retrieve the network ID: 
 +
 ```bash
-export REDPANDA_NETWORK_ID=$(curl -X POST "https://api.redpanda.com/v1beta2/networks" \
+export REDPANDA_NETWORK_ID=$(curl -X POST "https://api.redpanda.com/v1/networks" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" \
@@ -170,7 +170,7 @@ The Create Network request returns a `resource_id`. For example:
    "operation":{
       "id":"cpas8k6r4up5li18auh0",
       "metadata":{
-         "@type":"type.googleapis.com/redpanda.api.controlplane.v1beta2.CreateNetworkMetadata",
+         "@type":"type.googleapis.com/redpanda.api.controlplane.v1.CreateNetworkMetadata",
          "network_id":"cpb338gekjj5i1cpj3t0"
       },
       "state":"STATE_IN_PROGRESS",
@@ -261,7 +261,7 @@ EOF
 . Use the Cloud API to deploy the cluster and retrieve its ID:
 +
 ```bash
-export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1beta2/clusters" \
+export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1/clusters" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" \
@@ -276,7 +276,7 @@ The create cluster request returns a `resource_id`, which is required in the nex
    "operation":{
       "id":"cpas8k6r4up5li18auhg",
       "metadata":{
-         "@type":"type.googleapis.com/redpanda.api.controlplane.v1beta2.CreateClusterMetadata",
+         "@type":"type.googleapis.com/redpanda.api.controlplane.v1.CreateClusterMetadata",
          "cluster_id":"cpb33c8ekjj5i1cpj3v0"
       },
       "state":"STATE_IN_PROGRESS",
@@ -356,7 +356,7 @@ Cluster creation is an example of an operation that can take a longer period of 
 Example using the operation ID returned from your create cluster command:
 
 ```bash
-curl -X GET "https://api.redpanda.com/v1beta2/operations/${REDPANDA_ID}" \
+curl -X GET "https://api.redpanda.com/v1/operations/${REDPANDA_ID}" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}"
@@ -365,7 +365,7 @@ curl -X GET "https://api.redpanda.com/v1beta2/operations/${REDPANDA_ID}" \
 Example retrieving cluster:
 
 ```bash
-curl -X GET "https://api.redpanda.com/v1beta2/clusters/${REDPANDA_ID}" \
+curl -X GET "https://api.redpanda.com/v1/clusters/${REDPANDA_ID}" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}"
@@ -376,7 +376,7 @@ curl -X GET "https://api.redpanda.com/v1beta2/clusters/${REDPANDA_ID}" \
 To delete the cluster, first send a DELETE request to the Cloud API, and retrieve the `resource_id` of the DELETE operation. Then run the `rpk` command to destroy the cluster identified by the `resource_id`.
 
 ```bash
-export REDPANDA_ID=$(curl -X DELETE "https://api.redpanda.com/v1beta2/clusters/${REDPANDA_ID}" \
+export REDPANDA_ID=$(curl -X DELETE "https://api.redpanda.com/v1/clusters/${REDPANDA_ID}" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" | jq -r '.operation.resource_id')

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -128,7 +128,7 @@ To enable xref:develop:managed-connectors/index.adoc[Kafka Connect] for clusters
 
 . Authenticate to the Redpanda Cloud API. Follow the steps in xref:manage:api/cloud-api-authentication.adoc[].
 
-. Enable Kafka Connect by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters`] request:
+. Enable Kafka Connect by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters`] request:
 +
 [,bash]
 ----

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -128,11 +128,11 @@ To enable xref:develop:managed-connectors/index.adoc[Kafka Connect] for clusters
 
 . Authenticate to the Redpanda Cloud API. Follow the steps in xref:manage:api/cloud-api-authentication.adoc[].
 
-. Enable Kafka Connect by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters`] request:
+. Enable Kafka Connect by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters`] request:
 +
 [,bash]
 ----
-curl -X PATCH "https://api.redpanda.com/v1beta2/clusters/<cluster-id>" \
+curl -X PATCH "https://api.redpanda.com/v1/clusters/<cluster-id>" \
  -H 'Accept: application/json' \
  -H 'Authorization: Bearer <token>' \
  -H 'Content-Type: application/json' \

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -326,7 +326,7 @@ EOF
 . Use the Cloud API to create the network and retrieve the network ID:
 +
 ```bash
-export REDPANDA_NETWORK_ID=$(curl -X POST "https://api.redpanda.com/v1beta2/networks" \
+export REDPANDA_NETWORK_ID=$(curl -X POST "https://api.redpanda.com/v1/networks" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" \
@@ -396,7 +396,7 @@ TIP: See the full list of zones and tiers available with each provider in the xr
 . Make a Cloud API call to create a Redpanda network and get the network ID from the response in JSON `.operation.metadata.network_id`.
 +
 ```bash
-export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1beta2/clusters" \
+export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1/clusters" \
  -H "accept: application/json"\ 
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" \
@@ -428,7 +428,7 @@ Cluster creation is an example of an operation that can take a longer period of 
 Example using the returned `operation_id`:
 
 ```bash
-curl -X GET "https://api.redpanda.com/v1beta2/operations/<operation_id of operation from previous step>" \
+curl -X GET "https://api.redpanda.com/v1/operations/<operation-id>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}"
@@ -437,7 +437,7 @@ curl -X GET "https://api.redpanda.com/v1beta2/operations/<operation_id of operat
 Example retrieving cluster:
 
 ```bash
-curl -X GET "https://api.redpanda.com/v1beta2/clusters/<resource_id of cluster from previous step>" \
+curl -X GET "https://api.redpanda.com/v1/clusters/<resource-id>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}"
@@ -448,7 +448,7 @@ curl -X GET "https://api.redpanda.com/v1beta2/clusters/<resource_id of cluster f
 To delete the cluster, first send a DELETE request to the Cloud API, and retrieve the `resource_id` of the DELETE operation. Then run the `rpk` command to destroy the cluster identified by the `resource_id`.
 
 ```bash
-export REDPANDA_ID=$(curl -X DELETE "https://api.redpanda.com/v1beta2/clusters/${REDPANDA_ID}" \
+export REDPANDA_ID=$(curl -X DELETE "https://api.redpanda.com/v1/clusters/${REDPANDA_ID}" \
  -H "accept: application/json"\
  -H "content-type: application/json" \
  -H "authorization: Bearer ${BEARER_TOKEN}" | jq -r '.operation.resource_id')

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -53,7 +53,7 @@ This should be done in the Terraform of the reader cluster.
 
 Add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:redpanda-cloud:manage:api/controlplane/index.adoc[Cloud Control Plane API]. For information on accessing the Cloud API, see xref:manage:api/cloud-api-authentication.adoc[].
 
-. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request. The full list of clusters is expected on every call. If an ID is removed from the list, it is removed as a reader cluster.
+. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request. The full list of clusters is expected on every call. If an ID is removed from the list, it is removed as a reader cluster.
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......
@@ -69,7 +69,7 @@ curl -X PATCH $API_HOST/v1/clusters/$SOURCE_CLUSTER_ID \
 EOF
 ```
 
-. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] request:
+. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`] request:
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -53,13 +53,13 @@ This should be done in the Terraform of the reader cluster.
 
 Add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:redpanda-cloud:manage:api/controlplane/index.adoc[Cloud Control Plane API]. For information on accessing the Cloud API, see xref:manage:api/cloud-api-authentication.adoc[].
 
-. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request. The full list of clusters is expected on every call. If an ID is removed from the list, it is removed as a reader cluster.
+. To update your source cluster to add one or more reader cluster IDs, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request. The full list of clusters is expected on every call. If an ID is removed from the list, it is removed as a reader cluster.
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......
 export READER_CLUSTER_ID=.......
 
-curl -X PATCH $API_HOST/v1beta2/clusters/$SOURCE_CLUSTER_ID \
+curl -X PATCH $API_HOST/v1/clusters/$SOURCE_CLUSTER_ID \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $API_TOKEN" \
 -d @- << EOF 
@@ -69,12 +69,12 @@ curl -X PATCH $API_HOST/v1beta2/clusters/$SOURCE_CLUSTER_ID \
 EOF
 ```
 
-. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`] request:
+. Optional: To see the list of reader clusters on a given source cluster, make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] request:
 +
 ```bash
 export SOURCE_CLUSTER_ID=.......
 
-curl -X GET $API_HOST/v1beta2/clusters/$SOURCE_CLUSTER_ID \
+curl -X GET $API_HOST/v1/clusters/$SOURCE_CLUSTER_ID \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $API_TOKEN"
 ```

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -1,6 +1,6 @@
 = What's New in Redpanda Cloud
 :description: Summary of new features in Redpanada Cloud.
-:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--PipelineService
+:tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--Redpanda-Connect-Pipeline
 :page-aliases: deploy:deployment-option/cloud/whats-new-cloud.adoc
 :page-toclevels: 1
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,12 @@ This page lists new features added in Redpanda Cloud.
 
 == March 2025
 
+=== Cloud API: GA
+
+The xref:manage:api/cloud-api-overview.adoc[Cloud API] is now generally available. It includes endpoints for xref:manage:api/cloud-serverless-controlplane-api.adoc[managing Serverless clusters], configuring RBAC in xref:manage:api/cloud-byoc-controlplane-api.adoc#manage-rbac[BYOC], xref:manage:api/cloud-serverless-controlplane-api.adoc#manage-rbac[Serverless], and xref:manage:api/cloud-dedicated-controlplane-api.adoc#manage-rbac[Dedicated] clusters, and xref:manage:api/cloud-dataplane-api.adoc#use-redpanda-connect[using Redpanda Connect]. 
+
+To get started, try the xref:manage:api/cloud-api-quickstart.adoc[Cloud API Quickstart], or see the full xref:api:ROOT:cloud-controlplane-api.adoc[Control Plane API] and xref:api:ROOT:cloud-dataplane-api.adoc[Data Plane API] reference documentation.
+
 === Support for additional regions
 
 xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters] on GCP now support the europe-southwest1 (Madrid) region.

--- a/modules/manage/pages/api/cloud-api-authentication.adoc
+++ b/modules/manage/pages/api/cloud-api-authentication.adoc
@@ -3,7 +3,6 @@
 :page-aliases: deploy:deployment-option/cloud/api/cloud-api-authentication.adoc
 :page-api: cloud
 :page-api-slot: auth
-:page-beta: true
 
 The Cloud API uses the Client Credentials Flow as defined in https://datatracker.ietf.org/doc/html/rfc6749#section-4.4O[Auth 2.0 RFC 6749, section 4.4^]. In Redpanda Cloud, you must first create a *service account* through which you can authenticate requests to the Cloud API. The service account is associated with your Redpanda Cloud organization. The service account acts as an OAuth 2.0 client that provides its credentials (client ID and client secret) to the API authentication server. The authentication server grants an access token in return. You can then include the access token in each request to the API.
 

--- a/modules/manage/pages/api/cloud-api-errors.adoc
+++ b/modules/manage/pages/api/cloud-api-errors.adoc
@@ -9,7 +9,7 @@ The Redpanda Cloud API uses HTTP codes to indicate the status of a request. The 
 Example request:
 
 ```
-curl https://api.redpanda.com/clusters/v1beta2 | jq
+curl https://api.redpanda.com/v1/clusters | jq
 ```
 
 Example response:

--- a/modules/manage/pages/api/cloud-api-errors.adoc
+++ b/modules/manage/pages/api/cloud-api-errors.adoc
@@ -2,7 +2,6 @@
 :description: Error and status codes you might encounter when using the Cloud API.
 :page-aliases: deploy:deployment-option/cloud/api/cloud-api-errors.adoc
 :page-api: cloud
-:page-beta: true
 
 The Redpanda Cloud API uses HTTP codes to indicate the status of a request. The response payload also includes <<error-codes-and-details,additional error codes and descriptions>> that provide more detail about why an operation failed.
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -3,7 +3,6 @@
 :page-aliases: deploy:deployment-option/cloud/api/cloud-api-overview.adoc
 :page-api: cloud
 :page-api-slot: overview
-:page-beta: true
 
 The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. You can call the API endpoints directly, or use tools like Terraform or Python scripts to automate cluster management and manage Redpanda Cloud resources.
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -45,10 +45,10 @@ When making requests to the Control Plane API endpoints, the request URL is the 
 
 [,bash]
 ----
-https://api.redpanda.com/v1beta2/clusters
+https://api.redpanda.com/v1/clusters
 ----
 
-The current Control Plane API version is *v1beta2*.
+The current Control Plane API version is *v1*.
 
 === Data Plane APIs URL
 
@@ -56,10 +56,10 @@ The Data Plane API base URL is unique to the individual target cluster. It is di
 
 [,bash]
 ----
-https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha2/users
+https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1/users
 ----
 
-The current Data Plane API version is *v1alpha2*.
+The current Data Plane API version is *v1*.
 
 == Pagination
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -55,10 +55,10 @@ The Data Plane API base URL is unique to the individual target cluster. It is di
 
 [,bash]
 ----
-https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1/users
+https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha2/users
 ----
 
-The current Data Plane API version is *v1*.
+The current Data Plane API version is *v1alpha2*.
 
 == Pagination
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -55,10 +55,10 @@ The Data Plane API base URL is unique to the individual target cluster. It is di
 
 [,bash]
 ----
-https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1alpha2/users
+https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1/users
 ----
 
-The current Data Plane API version is *v1alpha2*.
+The current Data Plane API version is *v1*.
 
 == Pagination
 

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -62,7 +62,7 @@ curl -H 'Content-Type: application/json' \
 -d '{
   "name": <serverless-cluster-name>,
   "resource_group_id": <resource-group-id>,
-  "serverless_region": "pro-us-east-1" 
+  "serverless_region": "us-east-1" 
 }' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 --

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -2,7 +2,6 @@
 :description: Learn how to quickly start using the Cloud API to manage clusters and other resources.
 :page-aliases: deploy:deployment-option/cloud/api/cloud-api-quickstart.adoc
 :page-api: cloud
-:page-beta: true
 
 The following steps describe how to authenticate with the Cloud API and create a new Redpanda cluster. For more information on the Cloud API, see the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API Overview].
 

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -13,9 +13,9 @@ BYOC or Dedicated::
 +
 --
 . In the Redpanda Cloud UI, create a https://cloud.redpanda.com/organization-iam?tab=service-accounts[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
-. Create a resource group by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`POST /v1/resource-groups`] request.
-. Create a network by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] request. Note that this operation may be long-running.
-. Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] request.
+. Create a resource group by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/resource-groups[`POST /v1/resource-groups`] request.
+. Create a network by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`] request. Note that this operation may be long-running.
+. Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] request.
 . For BYOC, run `rpk cloud byoc`, passing the `metadata.cluster_id` from the Create Cluster response as a flag:
 +
 AWS:

--- a/modules/manage/pages/api/cloud-api-quickstart.adoc
+++ b/modules/manage/pages/api/cloud-api-quickstart.adoc
@@ -14,9 +14,9 @@ BYOC or Dedicated::
 +
 --
 . In the Redpanda Cloud UI, create a https://cloud.redpanda.com/organization-iam?tab=service-accounts[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
-. Create a resource group by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`POST /v1beta2/resource-groups`] request.
-. Create a network by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] request. Note that this operation may be long-running.
-. Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] request.
+. Create a resource group by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`POST /v1/resource-groups`] request.
+. Create a network by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] request. Note that this operation may be long-running.
+. Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] request.
 . For BYOC, run `rpk cloud byoc`, passing the `metadata.cluster_id` from the Create Cluster response as a flag:
 +
 AWS:
@@ -42,19 +42,19 @@ Serverless::
 +
 --
 . In the Redpanda Cloud UI, create a https://cloud.redpanda.com/organization-iam?tab=service-accounts[service account (client)] and use the client ID and secret to request an API token. Use the token to xref:manage:api/cloud-api-authentication.adoc[authenticate to the API].
-. Make a GET request to the `/v1beta2/resource-groups` endpoint to retrieve the default resource group ID.
+. Make a GET request to the `/v1/resource-groups` endpoint to retrieve the default resource group ID.
 +
 [,bash]
 ----
-curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/resource-groups
+curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/resource-groups
 ----
-. Make a GET request to the `/v1beta2/serverless/regions` endpoint to see available regions.
+. Make a GET request to the `/v1/serverless/regions` endpoint to see available regions.
 +
 [,bash]
 ----
-curl -H "Authorization: Bearer <token>" 'https://api.redpanda.com/v1beta2/serverless/regions?cloud_provider=CLOUD_PROVIDER_AWS'
+curl -H "Authorization: Bearer <token>" 'https://api.redpanda.com/v1/serverless/regions?cloud_provider=CLOUD_PROVIDER_AWS'
 ----
-. Create a cluster by making a POST request to the `/v1beta2/serverless/clusters` endpoint.
+. Create a cluster by making a POST request to the `/v1/serverless/clusters` endpoint.
 +
 [,bash]
 ----
@@ -64,7 +64,7 @@ curl -H 'Content-Type: application/json' \
   "name": <serverless-cluster-name>,
   "resource_group_id": <resource-group-id>,
   "serverless_region": "pro-us-east-1" 
-}' -X POST https://api.redpanda.com/v1beta2/serverless/clusters
+}' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 --
 ======

--- a/modules/manage/pages/api/cloud-byoc-controlplane-api.adoc
+++ b/modules/manage/pages/api/cloud-byoc-controlplane-api.adoc
@@ -2,7 +2,6 @@
 :description: Use the Control Plane API to manage resources in your Redpanda Cloud BYOC environment.
 :page-aliases: deploy:deployment-option/cloud/api/cloud-controlplane-api.adoc
 :page-context-links: [{"name": "BYOC", "to": "manage:api/cloud-byoc-controlplane-api.adoc" },{"name": "Dedicated", "to": "manage:api/cloud-dedicated-controlplane-api.adoc" },{"name": "Serverless", "to": "manage:api/cloud-serverless-controlplane-api.adoc" } ]
-:page-beta: true
 :env-byoc: true
 
 include::manage:partial$controlplane-api.adoc[]

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -42,11 +42,11 @@ The response includes a `dataplane_api.url` value:
 
 === Create a user
 
-To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/users[`/v1alpha2/users`] endpoint, including the SASL mechanism, username, and password in the request body:
+To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/users[`/v1/users`] endpoint, including the SASL mechanism, username, and password in the request body:
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/users" \
+curl -X POST "https://<dataplane-api-url>/v1/users" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -69,11 +69,11 @@ The success response returns the newly-created username and SASL mechanism:
 
 === Create an ACL
 
-To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/acls[`POST /v1alpha2/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
+To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/acls[`POST /v1/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/acls" \
+curl -X POST "https://<dataplane-api-url>/v1/acls" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -89,11 +89,11 @@ The success response is empty, with a 201 status code.
 
 === Create a topic
 
-To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/topics[`/v1alpha2/topics`] endpoint:
+To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/topics[`/v1/topics`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
+curl -X POST "<dataplane-api-url>/v1/topics" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -108,38 +108,38 @@ NOTE: The Pipeline APIs for Redpanda Connect are supported in BYOC and Serverles
 
 ==== Get Redpanda Connect pipeline
 
-To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1alpha2/redpanda-connect/pipelines/\{id}]` request.
+To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1/redpanda-connect/pipelines/-id-[`GET /v1/redpanda-connect/pipelines/\{id}]` request.
 
 [,bash]
 ----
-curl "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>"
+curl "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>"
 ----
 
 ==== Stop a Redpanda Connect pipeline
 
-To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/stop[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/stop`] request.
+To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1/redpanda-connect/pipelines/-id-/stop[`PUT /v1/redpanda-connect/pipelines/\{id}/stop`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/stop"
+curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/stop"
 ----
 
 ==== Start a Redpanda Connect pipeline
 
-To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/start[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/start`] request.
+To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1/redpanda-connect/pipelines/-id-/start[`PUT /v1/redpanda-connect/pipelines/\{id}/start`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/start"
+curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/start"
 ----
 
 ==== Update a Redpanda Connect pipeline
 
-To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
+To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1/redpanda-connect/pipelines/-id-[`PUT /v1/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
 
 [,bash]
 ----
-curl -X PUT "https://api.redpanda.com/v1alpha2/redpanda-connect/pipelines/" \
+curl -X PUT "https://api.redpanda.com/v1/redpanda-connect/pipelines/" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"resources":{"cpu_shares":"8","memory_shares":"8G"}}' 
@@ -167,11 +167,11 @@ Kafka Connect cluster secret data must first be in JSON format, and then Base64-
 echo '{"secret.access.key": "<secret-access-key-value>"}' | base64
 ```
 
-. Use the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the Base64-encoded secret data:
+. Use the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/kafka-connect/clusters/-cluster_name-/secrets[Secrets API] to create a secret that stores the Base64-encoded secret data:
 +
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/secrets" \
+curl -X POST "https://<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/secrets" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"name":"<connector-name>","secret_data":"<secret-data-base64-encoded>"}' 
@@ -181,13 +181,13 @@ The response returns an `id` that you can use to <<create-a-kafka-connect-connec
 
 ==== Create a Kafka Connect connector
 
-To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
+To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/kafka-connect/clusters/-cluster_name-/connectors[`/v1/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
 The following example shows how to create an S3 sink connector with the name `my-connector`:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors" \
+curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -224,11 +224,11 @@ Example success response:
 
 ==== Restart a Kafka Connect connector
 
-To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
+To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
+curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -15,13 +15,13 @@ The xref:manage:api/cloud-api-overview.adoc#cloud-api-architecture[data plane] c
 BYOC or Dedicated::
 +
 --
-To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`].
+To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`].
 --
 
 Serverless::
 +
 --
-To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`].
+To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`].
 --
 ======
 

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -42,11 +42,11 @@ The response includes a `dataplane_api.url` value:
 
 === Create a user
 
-To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/users[`/v1/users`] endpoint, including the SASL mechanism, username, and password in the request body:
+To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/users[`/v1alpha2/users`] endpoint, including the SASL mechanism, username, and password in the request body:
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1/users" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/users" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -69,11 +69,11 @@ The success response returns the newly-created username and SASL mechanism:
 
 === Create an ACL
 
-To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/acls[`POST /v1/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
+To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/acls[`POST /v1alpha2/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1/acls" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/acls" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -89,11 +89,11 @@ The success response is empty, with a 201 status code.
 
 === Create a topic
 
-To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/topics[`/v1/topics`] endpoint:
+To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/topics[`/v1alpha2/topics`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1/topics" \
+curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -108,38 +108,38 @@ NOTE: The Pipeline APIs for Redpanda Connect are supported in BYOC and Serverles
 
 ==== Get Redpanda Connect pipeline
 
-To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1/redpanda-connect/pipelines/\{id}]` request.
+To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1alpha2/redpanda-connect/pipelines/\{id}]` request.
 
 [,bash]
 ----
-curl "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>"
+curl "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>"
 ----
 
 ==== Stop a Redpanda Connect pipeline
 
-To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/stop[`PUT /v1/redpanda-connect/pipelines/\{id}/stop`] request.
+To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/stop[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/stop`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/stop"
+curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/stop"
 ----
 
 ==== Start a Redpanda Connect pipeline
 
-To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/start[`PUT /v1/redpanda-connect/pipelines/\{id}/start`] request.
+To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/start[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/start`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/start"
+curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/start"
 ----
 
 ==== Update a Redpanda Connect pipeline
 
-To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
+To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
 
 [,bash]
 ----
-curl -X PUT "https://api.redpanda.com/v1/redpanda-connect/pipelines/" \
+curl -X PUT "https://api.redpanda.com/v1alpha2/redpanda-connect/pipelines/" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"resources":{"cpu_shares":"8","memory_shares":"8G"}}' 
@@ -171,7 +171,7 @@ echo '{"secret.access.key": "<secret-access-key-value>"}' | base64
 +
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/secrets" \
+curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/secrets" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"name":"<connector-name>","secret_data":"<secret-data-base64-encoded>"}' 
@@ -181,13 +181,13 @@ The response returns an `id` that you can use to <<create-a-kafka-connect-connec
 
 ==== Create a Kafka Connect connector
 
-To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1/kafka-connect/clusters/\{cluster_name}/connectors`]. 
+To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
 The following example shows how to create an S3 sink connector with the name `my-connector`:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors" \
+curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -224,11 +224,11 @@ Example success response:
 
 ==== Restart a Kafka Connect connector
 
-To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
+To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
+curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -1,7 +1,6 @@
 = Use the Data Plane APIs
 :description: Use the Data Plane APIs to manage your Redpanda Cloud clusters.
 :page-aliases: deploy:deployment-option/cloud/api/cloud-dataplane-api.adoc
-:page-beta: true
 
 The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. The Data Plane APIs enable you to programmatically manage the resources within your clusters, including topics, users, access control lists (ACLs), and connectors. You can call the API endpoints directly, or use tools like Terraform or Python scripts to automate resource management.
 

--- a/modules/manage/pages/api/cloud-dataplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dataplane-api.adoc
@@ -16,13 +16,13 @@ The xref:manage:api/cloud-api-overview.adoc#cloud-api-architecture[data plane] c
 BYOC or Dedicated::
 +
 --
-To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`].
+To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`].
 --
 
 Serverless::
 +
 --
-To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1beta2/serverless/clusters/\{id}`].
+To retrieve the Data Plane API URL of a cluster, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`].
 --
 ======
 
@@ -43,11 +43,11 @@ The response includes a `dataplane_api.url` value:
 
 === Create a user
 
-To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/users[`/v1alpha2/users`] endpoint, including the SASL mechanism, username, and password in the request body:
+To create a new user in your Redpanda cluster, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/users[`/v1/users`] endpoint, including the SASL mechanism, username, and password in the request body:
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/users" \
+curl -X POST "https://<dataplane-api-url>/v1/users" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -70,11 +70,11 @@ The success response returns the newly-created username and SASL mechanism:
 
 === Create an ACL
 
-To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/acls[`POST /v1alpha2/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
+To create a new ACL in your Redpanda cluster, make a xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/acls[`POST /v1/acls`] request. The following example ACL allows all operations on any Redpanda topic for a user with the name `payment-service`.
 
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/acls" \
+curl -X POST "https://<dataplane-api-url>/v1/acls" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -90,11 +90,11 @@ The success response is empty, with a 201 status code.
 
 === Create a topic
 
-To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/topics[`/v1alpha2/topics`] endpoint:
+To create a new Redpanda topic without specifying any further parameters, such as the desired topic-level configuration or partition count, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/topics[`/v1/topics`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/topics" \
+curl -X POST "<dataplane-api-url>/v1/topics" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -109,38 +109,38 @@ NOTE: The Pipeline APIs for Redpanda Connect are supported in BYOC and Serverles
 
 ==== Get Redpanda Connect pipeline
 
-To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1alpha2/redpanda-connect/pipelines/\{id}]` request.
+To get details of a specific pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#get-/v1alpha2/redpanda-connect/pipelines/-id-[`GET /v1/redpanda-connect/pipelines/\{id}]` request.
 
 [,bash]
 ----
-curl "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>"
+curl "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>"
 ----
 
 ==== Stop a Redpanda Connect pipeline
 
-To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/stop[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/stop`] request.
+To stop a running pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/stop[`PUT /v1/redpanda-connect/pipelines/\{id}/stop`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/stop"
+curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/stop"
 ----
 
 ==== Start a Redpanda Connect pipeline
 
-To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/start[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}/start`] request.
+To start a previously stopped pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-/start[`PUT /v1/redpanda-connect/pipelines/\{id}/start`] request.
 
 [,bash]
 ----
-curl -X PUT "https://<dataplane-url>/v1alpha2/redpanda-connect/pipelines/<pipeline-id>/start"
+curl -X PUT "https://<dataplane-url>/v1/redpanda-connect/pipelines/<pipeline-id>/start"
 ----
 
 ==== Update a Redpanda Connect pipeline
 
-To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1alpha2/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
+To update a pipeline, make a xref:api:ROOT:cloud-dataplane-api.adoc#put-/v1alpha2/redpanda-connect/pipelines/-id-[`PUT /v1/redpanda-connect/pipelines/\{id}`] request. You update a pipeline configuration to scale resources, for example the number of CPU cores and amount of memory allocated.
 
 [,bash]
 ----
-curl -X PUT "https://api.redpanda.com/v1alpha2/redpanda-connect/pipelines/" \
+curl -X PUT "https://api.redpanda.com/v1/redpanda-connect/pipelines/" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"resources":{"cpu_shares":"8","memory_shares":"8G"}}' 
@@ -172,7 +172,7 @@ echo '{"secret.access.key": "<secret-access-key-value>"}' | base64
 +
 [,bash]
 ----
-curl -X POST "https://<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/secrets" \
+curl -X POST "https://<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/secrets" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
  -d '{"name":"<connector-name>","secret_data":"<secret-data-base64-encoded>"}' 
@@ -182,13 +182,13 @@ The response returns an `id` that you can use to <<create-a-kafka-connect-connec
 
 ==== Create a Kafka Connect connector
 
-To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors`]. 
+To create a connector, make a POST request to xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors[`/v1/kafka-connect/clusters/\{cluster_name}/connectors`]. 
 
 The following example shows how to create an S3 sink connector with the name `my-connector`:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors" \
+curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json" \
  -H "content-type: application/json" \
@@ -225,11 +225,11 @@ Example success response:
 
 ==== Restart a Kafka Connect connector
 
-To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1alpha2/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
+To restart a connector, make a POST request to the xref:api:ROOT:cloud-dataplane-api.adoc#post-/v1alpha2/kafka-connect/clusters/-cluster_name-/connectors/-name-/restart[`/v1/kafka-connect/clusters/\{cluster_name}/connectors/\{name}/restart`] endpoint:
 
 [,bash]
 ----
-curl -X POST "<dataplane-api-url>/v1alpha2/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
+curl -X POST "<dataplane-api-url>/v1/kafka-connect/clusters/redpanda/connectors/my-connector/restart" \
  -H "Authorization: Bearer <token>" \
  -H "accept: application/json"\
  -H "content-type: application/json" \

--- a/modules/manage/pages/api/cloud-dedicated-controlplane-api.adoc
+++ b/modules/manage/pages/api/cloud-dedicated-controlplane-api.adoc
@@ -1,7 +1,6 @@
 = Use the Control Plane API with Dedicated Cloud
 :description: Use the Control Plane API to manage resources in your Redpanda Cloud Dedicated environment.
 :page-context-links: [{"name": "BYOC", "to": "manage:api/cloud-byoc-controlplane-api.adoc" },{"name": "Dedicated", "to": "manage:api/cloud-dedicated-controlplane-api.adoc" },{"name": "Serverless", "to": "manage:api/cloud-serverless-controlplane-api.adoc" } ]
-:page-beta: true
 :page-aliases: deploy:deployment-option/cloud/api/cloud-dedicated-controlplane-api.adoc
 :env-dedicated: true
 

--- a/modules/manage/pages/api/cloud-serverless-controlplane-api.adoc
+++ b/modules/manage/pages/api/cloud-serverless-controlplane-api.adoc
@@ -1,7 +1,6 @@
 = Use the Control Plane API with Serverless
 :description: Use the Control Plane API to manage resources in your Redpanda Serverless environment.
 :page-context-links: [{"name": "BYOC", "to": "manage:api/cloud-byoc-controlplane-api.adoc" },{"name": "Dedicated", "to": "manage:api/cloud-dedicated-controlplane-api.adoc" },{"name": "Serverless", "to": "manage:api/cloud-serverless-controlplane-api.adoc" } ]
-:page-beta: true
 :env-serverless: true
 :page-aliases: deploy:deployment-option/cloud/api/cloud-serverless-controlplane-api.adoc
 

--- a/modules/manage/pages/api/controlplane/index.adoc
+++ b/modules/manage/pages/api/controlplane/index.adoc
@@ -2,4 +2,3 @@
 :description: Use the Control Plane API to manage resources in your Redpanda Cloud organization.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/api/controlplane/index.adoc
-:page-beta: true

--- a/modules/manage/pages/api/index.adoc
+++ b/modules/manage/pages/api/index.adoc
@@ -2,5 +2,3 @@
 :description: Use REST APIs to manage Redpanda Cloud resources.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/api/index.adoc
-:page-beta: true
-//:page-categories: 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -396,7 +396,7 @@ curl "https://api.redpanda.com/v1/users/<user-account-id> \
 
 === Create role binding
 
-To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1/role-bindings`] endpoint. Specify the role and scope, which includes the specific resource ID and an optional resource type, in the request body.
+To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/role-bindings[`/v1/role-bindings`] endpoint. Specify the role and scope, which includes the specific resource ID and an optional resource type, in the request body.
 
 [,bash]
 ----

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -413,6 +413,8 @@ curl -X POST "https://api.redpanda.com/v1/role-bindings" \
          }'
 ----
 
+For `<role-name>`, use one of roles listed in xref:security:authorization/rbac/rbac.adoc#predefined-roles[Predefined roles] (`Reader`, `Writer`, `Admin`).
+
 === Create service account
 
 NOTE: Service accounts are assigned the Admin role for all resources in the organization.

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -372,7 +372,7 @@ To see roles assignments for a specific IAM account, make a GET request to the x
 
 [,bash]
 ----
-curl "https://api.redpanda.com/v1alpha1/role-bindings/<id> \
+curl "https://api.redpanda.com/v1alpha1/role-bindings/<role-binding-id> \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----
@@ -383,7 +383,7 @@ To see details of an IAM user account, make a GET request to the xref:api:ROOT:c
 
 [,bash]
 ----
-curl "https://api.redpanda.com/v1alpha1/users/<id> \
+curl "https://api.redpanda.com/v1alpha1/users/<user-account-id> \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -363,7 +363,7 @@ The endpoints for managing xref:security:authorization/rbac/rbac.adoc[RBAC confi
 
 === List role bindings
 
-To see role assignments for IAM user and service accounts, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings[`/v1/role-bindings`] endpoint.
+To see role assignments for IAM user and service accounts, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/role-bindings[`/v1/role-bindings`] endpoint.
 
 [,bash]
 ----
@@ -374,7 +374,7 @@ curl https://api.redpanda.com/v1/role-bindings?filter.role_name=<role-name>&filt
 
 === Get role binding
 
-To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1/role-bindings/\{id}`] endpoint, passing the role binding ID as a parameter.
+To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/role-bindings/-id-[`/v1/role-bindings/\{id}`] endpoint, passing the role binding ID as a parameter.
 
 [,bash]
 ----
@@ -385,7 +385,7 @@ curl "https://api.redpanda.com/v1/role-bindings/<role-binding-id> \
 
 === Get user
 
-To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1/users/\{id}`] endpoint, passing the user account ID as a parameter.
+To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/users/-id-[`/v1/users/\{id}`] endpoint, passing the user account ID as a parameter.
 
 [,bash]
 ----
@@ -419,7 +419,7 @@ For `<role-name>`, use one of roles listed in xref:security:authorization/rbac/r
 
 NOTE: Service accounts are assigned the Admin role for all resources in the organization.
 
-To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1/service-accounts`] endpoint, with a service account name and optional description in the request body.
+To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/service-accounts[`/v1/service-accounts`] endpoint, with a service account name and optional description in the request body.
 
 [,bash]
 ----

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -359,7 +359,7 @@ endif::[]
 
 == Manage RBAC
 
-The endpoints for managing xref:security:authorization/rbac/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
+You can also use the Control Plane API to manage xref:security:authorization/rbac/rbac.adoc[RBAC configurations].
 
 === List role bindings
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -351,6 +351,82 @@ The response contains the current state of the operation: `IN_PROGRESS`, `COMPLE
 
 endif::[]
 
+== Manage RBAC
+
+The available endpoints for managing xref:security:authorization/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
+
+=== List role bindings
+
+To see role assignments for IAM user and service accounts, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint.
+
+[,bash]
+----
+curl "https://api.redpanda.com/v1alpha1/role-bindings?filter.role_name=<role-name>&filter.scope.resource_type=SCOPE_RESOURCE_TYPE_CLUSTER" \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json"
+----
+
+=== Get role binding
+
+To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1alpha1/role-bindings/\{id}`] endpoint.
+
+[,bash]
+----
+curl "https://api.redpanda.com/v1alpha1/role-bindings/<id> \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json"
+----
+
+=== Get user
+
+To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1alpha1/users/\{id}`] endpoint.
+
+[,bash]
+----
+curl "https://api.redpanda.com/v1alpha1/users/<id> \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json"
+----
+
+=== Create role binding
+
+To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint. Specify the role and resource scope in the request body.
+
+[,bash]
+----
+curl -X POST "https://api.redpanda.com/v1alpha1/role-bindings" \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "role_name": "<role-name>",
+           "account_id": "<user-or-service-account-id>",
+           "scope": {
+             "resource_type": "SCOPE_RESOURCE_TYPE_CLUSTER",
+             "resource_id": "<resource-id>"
+           }
+         }'
+----
+
+=== Create service account
+
+NOTE: Service accounts are assigned the Admin role for all resources in the organization.
+
+To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1alpha1/service-accounts`] endpoint.
+
+[,bash]
+----
+curl -X POST "https://api.redpanda.com/v1alpha1/service-accounts" \
+     -H "Authorization: Bearer <token>" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "service_account": {
+              "name": "<service-account-name>",
+              "description": "<service-account-description>"
+           }
+         }'
+----
+
+
 == Next steps
 
 - xref:./cloud-dataplane-api.adoc[]

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -37,7 +37,7 @@ ifndef::env-serverless[]
 [[lro]]
 == Long-running operations
 
-Some endpoints do not directly return the resource itself, but instead return an operation. The following is an example response of xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /clusters`]:
+Some endpoints do not directly return the resource itself, but instead return an operation. The following is an example response of xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /clusters`]:
 
 [,bash,role=no-copy]
 ----
@@ -45,7 +45,7 @@ Some endpoints do not directly return the resource itself, but instead return an
     "operation": {
         "id": "cqfc6vdmvio001r4vu4",
         "metadata": {
-            "@type": "type.googleapis.com/redpanda.api.controlplane.v1beta2.CreateClusterMetadata",
+            "@type": "type.googleapis.com/redpanda.api.controlplane.v1.CreateClusterMetadata",
             "cluster_id": "cqg168balf4e4pm8ptu"
         },
         "state": "STATE_IN_PROGRESS",
@@ -60,7 +60,7 @@ The response object represents the long-running operation of creating a cluster.
 
 === Check operation state
 
-To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
+To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
 
 ```bash
 curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/operations/<operation-id>
@@ -83,7 +83,7 @@ To create a new cluster, first create a resource group and network, if you have 
 
 === Create a resource group 
 
-Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
+Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
 
 [,bash]
 ----
@@ -98,7 +98,7 @@ A resource group ID is returned. Pass this ID later when you call the Create Clu
 
 === Create a network
 
-Create a network by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`].
+Create a network by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`].
 
 Choose a xref:networking:cidr-ranges.adoc[CIDR range] that does not overlap with your existing VPCs or your Redpanda network.
 
@@ -119,7 +119,7 @@ This endpoint returns a <<lro,long-running operation>>.
 
 === Create a new cluster
 
-After the network is created, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] with the resource group ID and network ID in the request body. 
+After the network is created, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] with the resource group ID and network ID in the request body. 
 
 [,bash]
 ----
@@ -138,10 +138,10 @@ curl -d \
     "us-west1-b",
     "us-west1-c"
     ]
-  }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1beta2/clusters
+  }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
 ----
 
-The Create Cluster endpoint returns a <<lro,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`], and passing the cluster ID as a parameter.
+The Create Cluster endpoint returns a <<lro,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`], and passing the cluster ID as a parameter.
 
 ifdef::env-byoc[]
 ==== Additional steps to create a BYOC cluster
@@ -183,15 +183,15 @@ To create a new serverless cluster, you can use the default resource group, or c
 
 [NOTE]
 ====
-This step is optional. Serverless includes a default resource group. To retrieve the default resource group ID, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint:
+This step is optional. Serverless includes a default resource group. To retrieve the default resource group ID, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/resource-groups[`/v1/resource-groups`] endpoint:
 
 ```bash
-curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/resource-groups
+curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/resource-groups
 ```
 
 ====
 
-Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
+Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
 
 [,bash]
 ----
@@ -199,14 +199,14 @@ curl -H 'Content-Type: application/json' \
 -H "Authorization: Bearer <token>" \
 -d '{
   "name": "<serverless-resource-group-name>"
-}' -X POST https://api.redpanda.com/v1beta2/resource-groups
+}' -X POST https://api.redpanda.com/v1/resource-groups
 ----
 
 A resource group ID is returned. Pass this ID later when you call the Create Serverless Cluster endpoint.
 
 === Choose a region
 
-To see the available regions for Redpanda Serverless, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/regions[`/v1/serverless/regions`] endpoint. You can specify a cloud provider in your request. Serverless currently only supports AWS.
+To see the available regions for Redpanda Serverless, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/serverless/regions[`/v1/serverless/regions`] endpoint. You can specify a cloud provider in your request. Serverless currently only supports AWS.
 
 [,bash]
 ----
@@ -247,7 +247,7 @@ TIP: When using a shell substitution variable for the token, use double quotes t
 
 === Create a new serverless cluster
 
-Create a Serverless cluster by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/serverless/clusters[`POST /v1/serverless/clusters`] with the resource group ID and serverless region name in the request body. 
+Create a Serverless cluster by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/serverless/clusters[`POST /v1/serverless/clusters`] with the resource group ID and serverless region name in the request body. 
 
 [,bash]
 ----
@@ -260,7 +260,7 @@ curl -H 'Content-Type: application/json' \
 }' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 
-The Create Serverless Cluster endpoint returns a <<lro-serverless,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`], and passing the cluster ID as a parameter.
+The Create Serverless Cluster endpoint returns a <<lro-serverless,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`], and passing the cluster ID as a parameter.
 
 endif::[]
 
@@ -268,7 +268,7 @@ endif::[]
 
 ifndef::env-serverless[]
 
-To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/clusters/-id-[`DELETE /v1/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro,long-running operation>>.
+To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1/clusters/-id-[`DELETE /v1/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro,long-running operation>>.
 
 ```bash
 curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1/clusters/<cluster_id>
@@ -277,7 +277,7 @@ curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1/cl
 ifdef::env-byoc[]
 === Additional steps to delete a BYOC cluster
 
-. Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] to check the state of the cluster. Wait until the state is `STATE_DELETING_AGENT`.
+. Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`] to check the state of the cluster. Wait until the state is `STATE_DELETING_AGENT`.
 . After the state changes to `STATE_DELETING_AGENT`, run `rpk cloud byoc` to destroy the agent.
 +
 [tabs]
@@ -305,26 +305,26 @@ rpk cloud byoc gcp destroy --redpanda-id=<cluster-id> --project-id=<gcp-project-
 --
 ====
 
-. When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/networks/-id-[`/v1/networks/\{id}`] endpoint to delete the network. This is a long running operation.
-. Optional: After the network is deleted, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`DELETE /v1/resource-groups/\{id}`] to delete the resource group. 
+. When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1/networks/-id-[`/v1/networks/\{id}`] endpoint to delete the network. This is a long running operation.
+. Optional: After the network is deleted, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1/resource-groups/-id-[`DELETE /v1/resource-groups/\{id}`] to delete the resource group. 
 
 endif::[]
 endif::[]
 
 ifdef::env-serverless[]
 
-To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/serverless/clusters/-id-[`DELETE /v1/serverless/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro-serverless,long-running operation>>.
+To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1/serverless/clusters/-id-[`DELETE /v1/serverless/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro-serverless,long-running operation>>.
 
 ```bash
 curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1/serverless/clusters/<cluster-id>
 ```
 
-Optional: When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`/v1/resource-groups/\{id}`] endpoint to delete the resource group. 
+Optional: When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1/resource-groups/-id-[`/v1/resource-groups/\{id}`] endpoint to delete the resource group. 
 
 [[lro-serverless]]
 == Long-running operations
 
-Some endpoints do not directly return the resource itself, but instead return an operation. The following is an example response of xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/serverless/clusters[`POST /serverless/clusters`]:
+Some endpoints do not directly return the resource itself, but instead return an operation. The following is an example response of xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/serverless/clusters[`POST /serverless/clusters`]:
 
 [,bash,role=no-copy]
 ----
@@ -347,7 +347,7 @@ The response object represents the long-running operation of creating a cluster.
 
 === Check operation state
 
-To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
+To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
 
 ```bash
 curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/operations/<operation-id>
@@ -359,7 +359,7 @@ endif::[]
 
 == Manage RBAC
 
-The endpoints for managing xref:security:authorization/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
+The endpoints for managing xref:security:authorization/rbac/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
 
 === List role bindings
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -1,9 +1,12 @@
-:tag-clusters: api:ROOT:cloud-controlplane-api.adoc#tag--ClusterService
-:tag-networks: api:ROOT:cloud-controlplane-api.adoc#tag--NetworkService
-:tag-operations: api:ROOT:cloud-controlplane-api.adoc#tag--OperationService
-:tag-resource-groups: api:ROOT:cloud-controlplane-api.adoc#tag--ResourceGroupService
-:tag-serverless-regions: api:ROOT:cloud-controlplane-api.adoc#tag--ServerlessRegionService
-:tag-serverless-clusters: api:ROOT:cloud-controlplane-api.adoc#tag--ServerlessClusterService
+:tag-clusters: api:ROOT:cloud-controlplane-api.adoc#tag--Clusters
+:tag-networks: api:ROOT:cloud-controlplane-api.adoc#tag--Networks
+:tag-operations: api:ROOT:cloud-controlplane-api.adoc#tag--Operations
+:tag-resource-groups: api:ROOT:cloud-controlplane-api.adoc#tag--Resource-Groups
+:tag-serverless-regions: api:ROOT:cloud-controlplane-api.adoc#tag--Serverless-Regions
+:tag-serverless-clusters: api:ROOT:cloud-controlplane-api.adoc#tag--Serverless-Clusters
+:tag-role-bindings: api:ROOT:cloud-controlplane-api.adoc#tag--Control-Plane-Role-Bindings
+:tag-users: api:ROOT:cloud-controlplane-api.adoc#tag--Control-Plane-Users
+:tag-service-accounts: api:ROOT:cloud-controlplane-api.adoc#tag--Control-Plane-Service-Accounts
 
 The Redpanda Cloud API is a collection of REST APIs that allow you to interact with different parts of Redpanda Cloud. The Control Plane API enables you to programmatically manage your organization's Redpanda infrastructure outside of the Cloud UI. You can call the API endpoints directly, or use tools like Terraform or Python scripts to automate cluster management.
 
@@ -13,18 +16,21 @@ See xref:api:ROOT:cloud-controlplane-api.adoc[Control Plane API] for the full AP
 
 The Control Plane API is one central API that allows you to provision clusters, networks, and resource groups.
 
-The Control Plane API consists of the following endpoints:
+The Control Plane API consists of the following endpoint groups:
 
 ifndef::env-serverless[]
-* pass:a,m[xref:{tag-clusters}[ClusterService\]]
-* pass:a,m[xref:{tag-networks}[NetworkService\]]
+* pass:a,m[xref:{tag-clusters}[Clusters\]]
+* pass:a,m[xref:{tag-networks}[Networks\]]
 endif::[]
-* pass:a,m[xref:{tag-operations}[OperationService\]]
-* pass:a,m[xref:{tag-resource-groups}[ResourceGroupService\]]
+* pass:a,m[xref:{tag-operations}[Operations\]]
+* pass:a,m[xref:{tag-resource-groups}[Resource Groups\]]
 ifdef::env-serverless[]
-* pass:a,m[xref:{tag-serverless-clusters}[ServerlessClusterService\]]
-* pass:a,m[xref:{tag-serverless-regions}[ServerlessRegionService\]]
+* pass:a,m[xref:{tag-serverless-clusters}[Serverless Clusters\]]
+* pass:a,m[xref:{tag-serverless-regions}[Serverless Regions\]]
 endif::[]
+* pass:a,m[xref:{tag-role-bindings}[Control Plane Role Bindings\]]
+* pass:a,m[xref:{tag-users}[Control Plane Users\]]
+* pass:a,m[xref:{tag-service-accounts}[Control Plane Service Accounts\]]
 
 // For serverless, show this section at the end of the doc
 ifndef::env-serverless[]
@@ -353,7 +359,7 @@ endif::[]
 
 == Manage RBAC
 
-The available endpoints for managing xref:security:authorization/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
+The endpoints for managing xref:security:authorization/rbac.adoc[RBAC configurations], for example assigning xref:security:authorization/rbac.adoc#predefined-roles[roles] to a users and service accounts in the control plane, contain the version string `v1alpha1` in the path. 
 
 === List role bindings
 
@@ -361,14 +367,14 @@ To see role assignments for IAM user and service accounts, make a GET request to
 
 [,bash]
 ----
-curl "https://api.redpanda.com/v1alpha1/role-bindings?filter.role_name=<role-name>&filter.scope.resource_type=SCOPE_RESOURCE_TYPE_CLUSTER" \
+curl https://api.redpanda.com/v1alpha1/role-bindings?filter.role_name=<role-name>&filter.scope.resource_type=SCOPE_RESOURCE_TYPE_CLUSTER \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----
 
 === Get role binding
 
-To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1alpha1/role-bindings/\{id}`] endpoint.
+To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1alpha1/role-bindings/\{id}`] endpoint, passing the role binding ID as a parameter.
 
 [,bash]
 ----
@@ -379,7 +385,7 @@ curl "https://api.redpanda.com/v1alpha1/role-bindings/<role-binding-id> \
 
 === Get user
 
-To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1alpha1/users/\{id}`] endpoint.
+To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1alpha1/users/\{id}`] endpoint, passing the user account ID as a parameter.
 
 [,bash]
 ----
@@ -390,7 +396,7 @@ curl "https://api.redpanda.com/v1alpha1/users/<user-account-id> \
 
 === Create role binding
 
-To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint. Specify the role and resource scope in the request body.
+To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint. Specify the role and scope, which includes the specific resource ID and an optional resource type, in the request body.
 
 [,bash]
 ----
@@ -411,7 +417,7 @@ curl -X POST "https://api.redpanda.com/v1alpha1/role-bindings" \
 
 NOTE: Service accounts are assigned the Admin role for all resources in the organization.
 
-To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1alpha1/service-accounts`] endpoint.
+To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1alpha1/service-accounts`] endpoint, with a service account name and optional description in the request body.
 
 [,bash]
 ----

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -63,7 +63,7 @@ The response object represents the long-running operation of creating a cluster.
 To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
 
 ```bash
-curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/operations/<operation-id>
+curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/operations/<operation-id>
 ```
 
 TIP: When using a shell substitution variable for the token, use double quotes to wrap the header value.
@@ -83,7 +83,7 @@ To create a new cluster, first create a resource group and network, if you have 
 
 === Create a resource group 
 
-Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1beta2/resource-groups`] endpoint. Pass a name for your resource group in the request body.
+Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
 
 [,bash]
 ----
@@ -91,14 +91,14 @@ curl -H 'Content-Type: application/json' \
 -H "Authorization: Bearer <token>" \
 -d '{
   "name": "<resource-group-name>"
-}' -X POST https://api.redpanda.com/v1beta2/resource-groups
+}' -X POST https://api.redpanda.com/v1/resource-groups
 ----
 
 A resource group ID is returned. Pass this ID later when you call the Create Cluster endpoint.
 
 === Create a network
 
-Create a network by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`].
+Create a network by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`].
 
 Choose a xref:networking:cidr-ranges.adoc[CIDR range] that does not overlap with your existing VPCs or your Redpanda network.
 
@@ -112,14 +112,14 @@ curl -d \
   "name": "<network-name>",
   "resource_group_id": "<resource-group-id>",
   "region": "us-west1"
-}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1beta2/networks 
+}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
 ----
 
 This endpoint returns a <<lro,long-running operation>>. 
 
 === Create a new cluster
 
-After the network is created, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] with the resource group ID and network ID in the request body. 
+After the network is created, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] with the resource group ID and network ID in the request body. 
 
 [,bash]
 ----
@@ -141,7 +141,7 @@ curl -d \
   }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1beta2/clusters
 ----
 
-The Create Cluster endpoint returns a <<lro,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`], and passing the cluster ID as a parameter.
+The Create Cluster endpoint returns a <<lro,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`], and passing the cluster ID as a parameter.
 
 ifdef::env-byoc[]
 ==== Additional steps to create a BYOC cluster
@@ -183,7 +183,7 @@ To create a new serverless cluster, you can use the default resource group, or c
 
 [NOTE]
 ====
-This step is optional. Serverless includes a default resource group. To retrieve the default resource group ID, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/resource-groups[`/v1beta2/resource-groups`] endpoint:
+This step is optional. Serverless includes a default resource group. To retrieve the default resource group ID, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint:
 
 ```bash
 curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/resource-groups
@@ -191,7 +191,7 @@ curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/resourc
 
 ====
 
-Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1beta2/resource-groups`] endpoint. Pass a name for your resource group in the request body.
+Create a resource group by making a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/resource-groups[`/v1/resource-groups`] endpoint. Pass a name for your resource group in the request body.
 
 [,bash]
 ----
@@ -206,11 +206,11 @@ A resource group ID is returned. Pass this ID later when you call the Create Ser
 
 === Choose a region
 
-To see the available regions for Redpanda Serverless, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/regions[`/v1beta2/serverless/regions`] endpoint. You can specify a cloud provider in your request. Serverless currently only supports AWS.
+To see the available regions for Redpanda Serverless, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/regions[`/v1/serverless/regions`] endpoint. You can specify a cloud provider in your request. Serverless currently only supports AWS.
 
 [,bash]
 ----
-curl -H "Authorization: Bearer <token>" 'https://api.redpanda.com/v1beta2/serverless/regions?cloud_provider=CLOUD_PROVIDER_AWS'
+curl -H "Authorization: Bearer <token>" 'https://api.redpanda.com/v1/serverless/regions?cloud_provider=CLOUD_PROVIDER_AWS'
 ----
 
 TIP: When using a shell substitution variable for the token, use double quotes to wrap the header value.
@@ -247,7 +247,7 @@ TIP: When using a shell substitution variable for the token, use double quotes t
 
 === Create a new serverless cluster
 
-Create a Serverless cluster by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/serverless/clusters[`POST /v1beta2/serverless/clusters`] with the resource group ID and serverless region name in the request body. 
+Create a Serverless cluster by making a request to xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/serverless/clusters[`POST /v1/serverless/clusters`] with the resource group ID and serverless region name in the request body. 
 
 [,bash]
 ----
@@ -257,10 +257,10 @@ curl -H 'Content-Type: application/json' \
   "name": <serverless-cluster-name>,
   "resource_group_id": <resource-group-id>,
   "serverless_region": "pro-us-east-1"
-}' -X POST https://api.redpanda.com/v1beta2/serverless/clusters
+}' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 
-The Create Serverless Cluster endpoint returns a <<lro-serverless,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1beta2/serverless/clusters/\{id}`], and passing the cluster ID as a parameter.
+The Create Serverless Cluster endpoint returns a <<lro-serverless,long-running operation>>. When the operation completes, you can retrieve cluster details by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/serverless/clusters/-id-[`GET /v1/serverless/clusters/\{id}`], and passing the cluster ID as a parameter.
 
 endif::[]
 
@@ -268,16 +268,16 @@ endif::[]
 
 ifndef::env-serverless[]
 
-To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/clusters/-id-[`DELETE /v1beta2/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro,long-running operation>>.
+To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/clusters/-id-[`DELETE /v1/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro,long-running operation>>.
 
 ```bash
-curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1beta2/clusters/<cluster_id>
+curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1/clusters/<cluster_id>
 ```
 
 ifdef::env-byoc[]
 === Additional steps to delete a BYOC cluster
 
-. Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`] to check the state of the cluster. Wait until the state is `STATE_DELETING_AGENT`.
+. Make a request to xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] to check the state of the cluster. Wait until the state is `STATE_DELETING_AGENT`.
 . After the state changes to `STATE_DELETING_AGENT`, run `rpk cloud byoc` to destroy the agent.
 +
 [tabs]
@@ -305,21 +305,21 @@ rpk cloud byoc gcp destroy --redpanda-id=<cluster-id> --project-id=<gcp-project-
 --
 ====
 
-. When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/networks/-id-[`/v1beta2/networks/\{id}`] endpoint to delete the network. This is a long running operation.
-. Optional: After the network is deleted, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`DELETE /v1beta2/resource-groups/\{id}`] to delete the resource group. 
+. When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/networks/-id-[`/v1/networks/\{id}`] endpoint to delete the network. This is a long running operation.
+. Optional: After the network is deleted, make a request to xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`DELETE /v1/resource-groups/\{id}`] to delete the resource group. 
 
 endif::[]
 endif::[]
 
 ifdef::env-serverless[]
 
-To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/serverless/clusters/-id-[`DELETE /v1beta2/serverless/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro-serverless,long-running operation>>.
+To delete a cluster, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/serverless/clusters/-id-[`DELETE /v1/serverless/clusters/\{id}`] endpoint, passing the cluster ID as a parameter. This is a <<lro-serverless,long-running operation>>.
 
 ```bash
-curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1beta2/serverless/clusters/<cluster-id>
+curl -H "Authorization: Bearer <token>" -X DELETE https://api.redpanda.com/v1/serverless/clusters/<cluster-id>
 ```
 
-Optional: When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`/v1beta2/resource-groups/\{id}`] endpoint to delete the resource group. 
+Optional: When the cluster is deleted, the delete operation’s state changes to `STATE_COMPLETED`. At this point, you may make a DELETE request to the xref:api:ROOT:cloud-controlplane-api.adoc#delete-/v1beta2/resource-groups/-id-[`/v1/resource-groups/\{id}`] endpoint to delete the resource group. 
 
 [[lro-serverless]]
 == Long-running operations
@@ -350,7 +350,7 @@ The response object represents the long-running operation of creating a cluster.
 To check the progress of an operation, make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /operations/\{id}`] endpoint using the operation ID as a parameter: 
 
 ```bash
-curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1beta2/operations/<operation-id>
+curl -H "Authorization: Bearer <token>" https://api.redpanda.com/v1/operations/<operation-id>
 ```
 
 The response contains the current state of the operation: `IN_PROGRESS`, `COMPLETED`, or `FAILED`.
@@ -363,44 +363,44 @@ The endpoints for managing xref:security:authorization/rbac.adoc[RBAC configurat
 
 === List role bindings
 
-To see role assignments for IAM user and service accounts, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint.
+To see role assignments for IAM user and service accounts, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings[`/v1/role-bindings`] endpoint.
 
 [,bash]
 ----
-curl https://api.redpanda.com/v1alpha1/role-bindings?filter.role_name=<role-name>&filter.scope.resource_type=SCOPE_RESOURCE_TYPE_CLUSTER \
+curl https://api.redpanda.com/v1/role-bindings?filter.role_name=<role-name>&filter.scope.resource_type=SCOPE_RESOURCE_TYPE_CLUSTER \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----
 
 === Get role binding
 
-To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1alpha1/role-bindings/\{id}`] endpoint, passing the role binding ID as a parameter.
+To see roles assignments for a specific IAM account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/role-bindings/-id-[`/v1/role-bindings/\{id}`] endpoint, passing the role binding ID as a parameter.
 
 [,bash]
 ----
-curl "https://api.redpanda.com/v1alpha1/role-bindings/<role-binding-id> \
+curl "https://api.redpanda.com/v1/role-bindings/<role-binding-id> \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----
 
 === Get user
 
-To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1alpha1/users/\{id}`] endpoint, passing the user account ID as a parameter.
+To see details of an IAM user account, make a GET request to the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1alpha1/users/-id-[`/v1/users/\{id}`] endpoint, passing the user account ID as a parameter.
 
 [,bash]
 ----
-curl "https://api.redpanda.com/v1alpha1/users/<user-account-id> \
+curl "https://api.redpanda.com/v1/users/<user-account-id> \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json"
 ----
 
 === Create role binding
 
-To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1alpha1/role-bindings`] endpoint. Specify the role and scope, which includes the specific resource ID and an optional resource type, in the request body.
+To assign a role to an IAM user or service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/role-bindings[`/v1/role-bindings`] endpoint. Specify the role and scope, which includes the specific resource ID and an optional resource type, in the request body.
 
 [,bash]
 ----
-curl -X POST "https://api.redpanda.com/v1alpha1/role-bindings" \
+curl -X POST "https://api.redpanda.com/v1/role-bindings" \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{
@@ -417,11 +417,11 @@ curl -X POST "https://api.redpanda.com/v1alpha1/role-bindings" \
 
 NOTE: Service accounts are assigned the Admin role for all resources in the organization.
 
-To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1alpha1/service-accounts`] endpoint, with a service account name and optional description in the request body.
+To create a new service account, make a POST request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1alpha1/service-accounts[`/v1/service-accounts`] endpoint, with a service account name and optional description in the request body.
 
 [,bash]
 ----
-curl -X POST "https://api.redpanda.com/v1alpha1/service-accounts" \
+curl -X POST "https://api.redpanda.com/v1/service-accounts" \
      -H "Authorization: Bearer <token>" \
      -H "Content-Type: application/json" \
      -d '{

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -39,7 +39,7 @@ Copy and store the resource group ID (UUID) from the URL in the browser.
 export RESOURCE_GROUP_ID=<uuid>
 ----
 
-. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] to create a network.
+. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] to create a network.
 +
 Make sure to supply your own values in the following example request. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
@@ -67,14 +67,14 @@ EOF`
 NETWORK_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/networks | jq .metadata.network_id`
+    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1/networks | jq .metadata.network_id`
 
 echo $NETWORK_ID
 ----
 +
-Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1beta2/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
+Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
 
-. Create a new cluster with the endpoint service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`].
+. Create a new cluster with the endpoint service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`].
 +
 In the example below, make sure to set your own values for the following fields:
 +
@@ -111,12 +111,12 @@ EOF`
 CLUSTER_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters | jq -r .operation.metadata.cluster_id`
+    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters | jq -r .operation.metadata.cluster_id`
 
 echo $CLUSTER_ID
 ----
 +
-**BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+**BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster:
 +
@@ -136,7 +136,7 @@ CAUTION: As soon as PrivateLink is available on your VPC, all communication on e
 CLUSTER_ID=<cluster_id>
 ----
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
 +
 In the example below, make sure to set your own value for the following field:
 +
@@ -160,19 +160,19 @@ EOF`
 curl -vv -X PATCH \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AUTH_TOKEN" \
-  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 
-. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
+. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
 
-. Check the service state by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`]. The `service_state` in the `aws_private_link.status` response object must be `Available` for you to <<access-redpanda-services-through-vpc-endpoint,connect to the service>>.
+. Check the service state by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`]. The `service_state` in the `aws_private_link.status` response object must be `Available` for you to <<access-redpanda-services-through-vpc-endpoint,connect to the service>>.
 +
 [,bash]
 ----
 curl -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq '.cluster.aws_private_link.status | {service_name, service_state}'
+    $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID | jq '.cluster.aws_private_link.status | {service_name, service_state}'
 ----
 
 == Configure PrivateLink connection to Redpanda Cloud
@@ -199,7 +199,7 @@ The service name is required to <<create-vpc-endpoint,create VPC private endpoin
 PL_SERVICE_NAME=`curl -X GET \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AUTH_TOKEN" \
-  $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq -r .cluster.aws_private_link.status.service_name`
+  $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID | jq -r .cluster.aws_private_link.status.service_name`
 ----
 
 === Create client VPC

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -39,7 +39,7 @@ Copy and store the resource group ID (UUID) from the URL in the browser.
 export RESOURCE_GROUP_ID=<uuid>
 ----
 
-. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] to create a network.
+. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`] to create a network.
 +
 Make sure to supply your own values in the following example request. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
@@ -72,9 +72,9 @@ NETWORK_ID=`curl -vv -X POST \
 echo $NETWORK_ID
 ----
 +
-Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
+Wait for the network to be ready before creating the cluster in the next step. You can check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
 
-. Create a new cluster with the endpoint service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`].
+. Create a new cluster with the endpoint service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`].
 +
 In the example below, make sure to set your own values for the following fields:
 +
@@ -116,7 +116,7 @@ CLUSTER_ID=`curl -vv -X POST \
 echo $CLUSTER_ID
 ----
 +
-**BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+**BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster:
 +
@@ -136,7 +136,7 @@ CAUTION: As soon as PrivateLink is available on your VPC, all communication on e
 CLUSTER_ID=<cluster_id>
 ----
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the Redpanda Private Link Endpoint Service enabled.
 +
 In the example below, make sure to set your own value for the following field:
 +
@@ -163,9 +163,9 @@ curl -vv -X PATCH \
   -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 
-. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
+. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from Update Cluster call. When the state is `STATE_READY`, proceed to the next step.
 
-. Check the service state by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`]. The `service_state` in the `aws_private_link.status` response object must be `Available` for you to <<access-redpanda-services-through-vpc-endpoint,connect to the service>>.
+. Check the service state by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`]. The `service_state` in the `aws_private_link.status` response object must be `Available` for you to <<access-redpanda-services-through-vpc-endpoint,connect to the service>>.
 +
 [,bash]
 ----

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -62,7 +62,7 @@ Copy and store the resource group ID (UUID) from the URL in the browser.
 export RESOURCE_GROUP_ID=<uuid>
 ----    
 
-. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] to create a Redpanda Cloud network for the cluster.
+. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] to create a Redpanda Cloud network for the cluster.
 +
 Make sure to supply your own values in the following example request. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
@@ -91,14 +91,14 @@ EOF`
 NETWORK_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/networks | jq .metadata.network_id`
+    -d "$NETWORK_POST_BODY" $PUBLIC_API_ENDPOINT/v1/networks | jq .metadata.network_id`
 
 echo $NETWORK_ID
 ----
 +
-Wait for the network to be ready before creating the cluster in the next step. Check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1beta2/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
+Wait for the network to be ready before creating the cluster in the next step. Check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
 
-. Create a new cluster with the Private Link service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`].
+. Create a new cluster with the Private Link service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`].
 +
 In the following example, make sure to set your own values for the following fields:
 +
@@ -138,7 +138,7 @@ CLUSTER_ID=`curl -vv -X POST \
 echo $CLUSTER_ID
 ----
 
-. **BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+. **BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster with Private Link enabled:
 +
@@ -160,7 +160,7 @@ CAUTION: As soon as Private Link is available on your virtual network, all commu
 CLUSTER_ID=<cluster_id>
 ----
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster with the service enabled.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the service enabled.
 +
 [,bash]
 ----
@@ -177,33 +177,33 @@ EOF`
 curl -vv -X PATCH \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AUTH_TOKEN" \
-  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+  -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 
-. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1beta2/operations/\{id}`], and passing the operation ID returned from the Update Cluster call. When the state is `STATE_READY`, continue to <<configure-azure-private-link-connection-to-redpanda-cloud,configure the Private Link connection to Redpanda>>.
+. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Update Cluster call. When the state is `STATE_READY`, continue to <<configure-azure-private-link-connection-to-redpanda-cloud,configure the Private Link connection to Redpanda>>.
 
 == Configure Azure Private Link connection to Redpanda Cloud
 
 . In the Redpanda Cloud UI, go to https://cloud.redpanda.com/users?tab=users[**Users**^] and create a new user to authenticate the Private Link endpoint connections with the service. You will need the username and password to <<connect-to-redpanda-services-through-private-link-endpoints,access Redpanda services>> or <<test-the-connection,test the connection>> using `rpk` or cURL.
 
-. Call the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1beta2/clusters/\{id}`] endpoint to check the service status and retrieve the service ID, DNS name, and Redpanda Console URL to use.
+. Call the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] endpoint to check the service status and retrieve the service ID, DNS name, and Redpanda Console URL to use.
 +
 [,bash]
 ----
 DNS_RECORD=`curl -s -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-  $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq -r ".cluster.azure_private_link.status.dns_a_record"`
+  $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID | jq -r ".cluster.azure_private_link.status.dns_a_record"`
 
 PRIVATE_SERVICE_ID=`curl -s -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-  $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq -r ".cluster.azure_private_link.status.service_id"`
+  $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID | jq -r ".cluster.azure_private_link.status.service_id"`
 
 CONSOLE_URL=`curl -s -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-  $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID | jq -r ".cluster.redpanda_console.url"`
+  $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID | jq -r ".cluster.redpanda_console.url"`
 
 echo $DNS_RECORD
 echo $PRIVATE_SERVICE_ID

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -62,7 +62,7 @@ Copy and store the resource group ID (UUID) from the URL in the browser.
 export RESOURCE_GROUP_ID=<uuid>
 ----    
 
-. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] to create a Redpanda Cloud network for the cluster.
+. Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`] to create a Redpanda Cloud network for the cluster.
 +
 Make sure to supply your own values in the following example request. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
@@ -96,9 +96,9 @@ NETWORK_ID=`curl -vv -X POST \
 echo $NETWORK_ID
 ----
 +
-Wait for the network to be ready before creating the cluster in the next step. Check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
+Wait for the network to be ready before creating the cluster in the next step. Check the state of the network creation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/networks/-id-[`GET /v1/networks/\{id}`]. You can create the cluster when the state is `STATE_READY`.
 
-. Create a new cluster with the Private Link service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`].
+. Create a new cluster with the Private Link service enabled by calling xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`].
 +
 In the following example, make sure to set your own values for the following fields:
 +
@@ -133,12 +133,12 @@ EOF`
 CLUSTER_ID=`curl -vv -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $AUTH_TOKEN" \
-    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters | jq -r .operation.metadata.cluster_id`
+    -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters | jq -r .operation.metadata.cluster_id`
 
 echo $CLUSTER_ID
 ----
 
-. **BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
+. **BYOC clusters:** Check that the cluster operation is completed by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Create Cluster call.
 +
 When the Create Cluster operation is completed (`STATE_COMPLETED`), run the following `rpk cloud` command to finish setting up your BYOC cluster with Private Link enabled:
 +
@@ -160,7 +160,7 @@ CAUTION: As soon as Private Link is available on your virtual network, all commu
 CLUSTER_ID=<cluster_id>
 ----
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the service enabled.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster with the service enabled.
 +
 [,bash]
 ----
@@ -180,13 +180,13 @@ curl -vv -X PATCH \
   -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 
-. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Update Cluster call. When the state is `STATE_READY`, continue to <<configure-azure-private-link-connection-to-redpanda-cloud,configure the Private Link connection to Redpanda>>.
+. Before proceeding, check the state of the Update Cluster operation by calling xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /v1/operations/\{id}`], and passing the operation ID returned from the Update Cluster call. When the state is `STATE_READY`, continue to <<configure-azure-private-link-connection-to-redpanda-cloud,configure the Private Link connection to Redpanda>>.
 
 == Configure Azure Private Link connection to Redpanda Cloud
 
 . In the Redpanda Cloud UI, go to https://cloud.redpanda.com/users?tab=users[**Users**^] and create a new user to authenticate the Private Link endpoint connections with the service. You will need the username and password to <<connect-to-redpanda-services-through-private-link-endpoints,access Redpanda services>> or <<test-the-connection,test the connection>> using `rpk` or cURL.
 
-. Call the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1beta2/clusters/-id-[`GET /v1/clusters/\{id}`] endpoint to check the service status and retrieve the service ID, DNS name, and Redpanda Console URL to use.
+. Call the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /v1/clusters/\{id}`] endpoint to check the service status and retrieve the service ID, DNS name, and Redpanda Console URL to use.
 +
 [,bash]
 ----

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -84,7 +84,7 @@ gcloud compute firewall-rules create redpanda-psc \
   --allow="tcp:30181,tcp:30282,tcp:30292,tcp:31004,tcp:31082-31101,tcp:31182-31201,tcp:31282-31301,tcp:32092-32111,tcp:32192-32211,tcp:32292-32311"
 ```
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1beta2/networks`] endpoint to create a network.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] endpoint to create a network.
 +
 [,bash]
 ----
@@ -108,7 +108,7 @@ EOF`
 curl -vv -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$network_post_body" $PUBLIC_API_ENDPOINT/v1beta2/networks
+-d "$network_post_body" $PUBLIC_API_ENDPOINT/v1/networks
 ----
 +
 Replace the following placeholder variables for the request body:
@@ -129,7 +129,7 @@ Replace the following placeholder variables for the request body:
 export NETWORK_ID=<metadata.network_id>
 ----
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1beta2/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled.
 +
 [,bash]
 ----
@@ -172,7 +172,7 @@ EOF`
 curl -vv -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters
+-d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters
 ----
 +
 Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[customer-managed resources] that should have been created previously:
@@ -226,7 +226,7 @@ rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-proj
 ``` 
 --
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
 +
 [,bash]
 ----
@@ -244,14 +244,14 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 +
 Replace the following placeholder:
 +
 `<psc-nat-subnet-name>`: The name of the Private Service Connect NAT subnet. Use the fully-qualified name, for example `"projects/<host-project-id>/regions/<region>/subnetworks/<subnet-name>"`.
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
 +
 [,bash]
 ----
@@ -266,7 +266,7 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 +
 Replace the following placeholder:
@@ -294,7 +294,7 @@ include::networking:partial$private-links-test-connection.adoc[]
 
 == Disable Private Service Connect
 
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to update the cluster to disable Private Service Connect.
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to disable Private Service Connect.
 
 [,bash]
 ----
@@ -308,5 +308,5 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1beta2/clusters/$CLUSTER_ID
+-d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -84,7 +84,7 @@ gcloud compute firewall-rules create redpanda-psc \
   --allow="tcp:30181,tcp:30282,tcp:30292,tcp:31004,tcp:31082-31101,tcp:31182-31201,tcp:31282-31301,tcp:32092-32111,tcp:32192-32211,tcp:32292-32311"
 ```
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/networks[`POST /v1/networks`] endpoint to create a network.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`] endpoint to create a network.
 +
 [,bash]
 ----
@@ -129,7 +129,7 @@ Replace the following placeholder variables for the request body:
 export NETWORK_ID=<metadata.network_id>
 ----
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1beta2/clusters[`POST /v1/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled.
 +
 [,bash]
 ----
@@ -226,7 +226,7 @@ rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-proj
 ``` 
 --
 
-. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
+. Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] endpoint to update the cluster to include the newly-created Private Service Connect NAT subnet.
 +
 [,bash]
 ----
@@ -251,7 +251,7 @@ Replace the following placeholder:
 +
 `<psc-nat-subnet-name>`: The name of the Private Service Connect NAT subnet. Use the fully-qualified name, for example `"projects/<host-project-id>/regions/<region>/subnetworks/<subnet-name>"`.
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to enable Private Service Connect.
 +
 [,bash]
 ----
@@ -294,7 +294,7 @@ include::networking:partial$private-links-test-connection.adoc[]
 
 == Disable Private Service Connect
 
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to disable Private Service Connect.
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to update the cluster to disable Private Service Connect.
 
 [,bash]
 ----

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -104,7 +104,7 @@ Redpanda Cloud supports mTLS authentication for the Kafka API.
 . Create a service account in your organization, if you have not already done so. Go to the https://cloud.redpanda.com/clients[Clients^] page in the Redpanda Cloud UI and click *Add client* to create a service account. Enter a name and description.
 . Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
 . Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1beta2/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
 
 The following code block shows a request for an access token, followed by a request to enable mTLS:
 
@@ -132,7 +132,7 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1beta2/clusters/<cluster-id>`
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
 
 Make sure to replace the following variables:

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -104,7 +104,7 @@ Redpanda Cloud supports mTLS authentication for the Kafka API.
 . Create a service account in your organization, if you have not already done so. Go to the https://cloud.redpanda.com/clients[Clients^] page in the Redpanda Cloud UI and click *Add client* to create a service account. Enter a name and description.
 . Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
 . Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1beta2/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
 
 The following code block shows a request for an access token, followed by a request to enable mTLS:
 


### PR DESCRIPTION
.## Description

This pull request adds new documentation for managing RBAC (Role-Based Access Control) in the control plane. The changes include instructions for listing role bindings, getting role bindings, getting user details, creating role bindings, and creating service accounts.

New RBAC management documentation:

* Added a section on managing RBAC configurations, including assigning roles to users and service accounts.
* Provided examples of API requests for listing role bindings, getting role bindings, and getting user details.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 27 Feb 2025

## Page previews

[Use Control Plane API with BYOC > Manage RBAC](https://deploy-preview-211--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-byoc-controlplane-api/#manage-rbac)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)