### PR TITLE
DOC-1064 remove LA for PSC

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -314,7 +314,6 @@ The following features are currently in limited availability in Redpanda Cloud:
 * Serverless Standard and Serverless Pro
 * Dedicated and BYOC for Azure
 * BYOVPC for GCP
-* GCP Private Service Connect
 * Azure Private Link
 
 == Features in beta

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -15,7 +15,7 @@ With xref:security:authorization/rbac/rbac.adoc[RBAC in the control plane], you 
 
 === Improved Private Service Connect support with AZ affinity
 
-xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] now provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] service now provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The service is now fully supported (GA).
 
 === Serverless Pro usage limits increased
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -2,8 +2,6 @@
 :description: Set up GCP Private Service Connect in the Redpanda Cloud UI.
 :page-aliases: deploy:deployment-option/cloud/configure-private-service-connect-in-cloud-ui.adoc
 
-include::shared:partial$feature-flag.adoc[]
-
 [NOTE]
 ====
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -2,8 +2,6 @@
 :description: Set up GCP Private Service Connect to securely access Redpanda Cloud.
 :page-aliases: deploy:deployment-option/cloud/gcp-private-service-connect.adoc
 
-include::shared:partial$feature-flag.adoc[]
-
 [NOTE]
 ====
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -211,7 +211,7 @@ export CLUSTER_ID=<cluster-id>
 . For a *BYOC cluster*, run `rpk cloud byoc gcp apply`:
 +
 ```bash
-rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
+rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-project-id>'
 ``` 
 +
 For a *BYOVPC cluster*:
@@ -222,7 +222,7 @@ For a *BYOVPC cluster*:
 - Run `rpk cloud byoc gcp apply`:
 +
 ```bash
-rpk cloud byoc gcp apply --redpanda-id='<redpanda-id>' --project-id='<service-project-id>'
+rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-project-id>'
 ``` 
 --
 


### PR DESCRIPTION
## Description
This pull request removes GCP Private Service Connect from the list of limited availability features and removes the feature flag admonition from PSC doc files.

Changes to documentation:

* [`modules/get-started/pages/cloud-overview.adoc`](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL317): Removed GCP Private Service Connect from the list of features in limited availability.

* [`modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc`](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56L5-L6): Removed the feature flag include statement.

* [`modules/networking/pages/gcp-private-service-connect.adoc`](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L5-L6): Removed the feature flag include statement.

Resolves https://redpandadata.atlassian.net/browse/DOC-1064
Review deadline: Feb 26

## Page previews

- [Features in LA](https://deploy-preview-217--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#features-in-limited-availability)
- [PCS in UI](https://deploy-preview-217--rp-cloud.netlify.app/redpanda-cloud/networking/configure-private-service-connect-in-cloud-ui/)
- [PCS in API](https://deploy-preview-217--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)