### PR TITLE
DOC-1067 Direct BYOVPC to sales instead of support

### DIFF
--- a/modules/shared/partials/feature-flag-rpcn.adoc
+++ b/modules/shared/partials/feature-flag-rpcn.adoc
@@ -1,6 +1,6 @@
 [IMPORTANT]
 ====
 
-* BYOVPC is an add-on feature that may require an additional purchase. To unlock this feature for your account, contact https://www.redpanda.com/price-estimator[Redpanda Sales^].  
+* BYOVPC is an add-on feature that may require an additional purchase. To unlock this feature for your account, contact your Redpanda account team or https://www.redpanda.com/price-estimator[Redpanda Sales^]. 
 * Redpanda Connect is not available for BYOVPC clusters. 
 ==== 

--- a/modules/shared/partials/feature-flag-rpcn.adoc
+++ b/modules/shared/partials/feature-flag-rpcn.adoc
@@ -1,6 +1,6 @@
 [IMPORTANT]
 ====
 
-* BYOVPC is an add-on feature that may require an additional purchase. To unlock this feature for your account, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
+* BYOVPC is an add-on feature that may require an additional purchase. To unlock this feature for your account, contact https://www.redpanda.com/price-estimator[Redpanda Sales^].  
 * Redpanda Connect is not available for BYOVPC clusters. 
 ==== 


### PR DESCRIPTION
## Description
This pull request includes a small change to the `modules/shared/partials/feature-flag-rpcn.adoc` file. The change updates the contact link for unlocking the BYOVPC feature from Redpanda Support to Redpanda Sales.

* [`modules/shared/partials/feature-flag-rpcn.adoc`](diffhunk://#diff-c4260561e4716470d26f9108a713b6b990906a7c753fe824ea62f0d72da0c1fcL4-R4): Updated the contact link for unlocking the BYOVPC feature to point to Redpanda Sales.

Resolves https://redpandadata.atlassian.net/browse/DOC-1067
Review deadline: Feb 27

## Page previews
BYOVPC on [AWS](https://deploy-preview-218--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/vpc-byo-aws/), [Azure](https://deploy-preview-218--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/azure/vnet-azure/), [GCP](https://deploy-preview-218--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/gcp/vpc-byo-gcp/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)