### PR TITLE
DOC-821 create upgrades page for Cloud

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -353,6 +353,7 @@
 ** xref:develop:transactions.adoc[]
 
 * xref:manage:index.adoc[Manage]
+** xref:manage:maintenance.adoc[]
 ** xref:manage:monitor-cloud.adoc[]
 ** xref:manage:mountable-topics.adoc[]
 ** xref:manage:rpk/index.adoc[Redpanda CLI]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -217,14 +217,6 @@ xref:develop:connect/about.adoc[Redpanda Connect] is integrated into Redpanda Cl
 
 xref:develop:managed-connectors/index.adoc[Kafka Connect] is automatically enabled on AWS and GCP clusters. With this, there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
 
-== Maintenance windows
-
-Redpanda runs maintenance and upgrade operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
-
-By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
-
-TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
-
 == Redpanda Cloud architecture
 
 When you sign up for a Redpanda account, Redpanda creates an organization for you. Your organization contains all your Redpanda resources, including your clusters and networks. Within your organization, Redpanda creates a default resource group to contain your resources. You can rename this resource group, and you can create more resource groups. For example, you may want different resource groups for production and testing. 
@@ -329,6 +321,7 @@ The following features are currently in beta in Redpanda Cloud:
 * Remote Read Replicas for AWS and GCP
 
 == Next steps
+* xref:manage:maintenance.adoc[Learn about upgrades and maintenance]
 * xref:get-started:cluster-types/serverless.adoc[Create a Serverless Standard Cluster]
 * xref:get-started:cluster-types/serverless-pro.adoc[Create a Serverless Pro Cluster]
 * xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster-aws.adoc[Create a Dedicated Cloud Cluster]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -84,7 +84,7 @@ The xref:manage:terraform-provider.adoc[Redpanda Terraform provider] lets you cr
 
 === Schedule maintenance windows
 
-Redpanda Cloud now offers greater flexibility to schedule upgrades to your cluster. By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and xref:get-started:cloud-overview.adoc#maintenance-windows[schedule a maintenance window], which requires Redpanda Cloud to run operations on your specified day and time. 
+Redpanda Cloud now offers greater flexibility to schedule upgrades to your cluster. By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and * xref:manage:maintenance.adoc#maintenance-windows[schedule a maintenance window], which requires Redpanda Cloud to run operations on your specified day and time. 
 
 === Redpanda Connect: LA for BYOC, beta for Serverless
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -3,7 +3,7 @@
 
 As a fully-managed service, the Redpanda Cloud glossterm:control plane[] handles all maintenance operations, such as upgrades to your software and infrastructure.
 
-Redpanda runs maintenance operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
+Redpanda runs maintenance operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes triggers client connections to be restarted. All mainstream client libraries support automatic reconnections when a restart occurs.
 
 == Maintenance windows
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -1,0 +1,12 @@
+= Upgrades and Maintenance
+:description: Learn how Redpanda Cloud manages upgrades and maintenance.
+
+The Redpanda Cloud glossterm:control plane[] handles automatic scaling, provisioning, maintenance, and upgrades.
+
+== Maintenance windows
+
+Redpanda runs maintenance and upgrade operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
+
+By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
+
+TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -11,6 +11,6 @@ Redpanda Cloud may run maintenance operations on any day at any time. You can ov
 
 If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations commence during the maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 
-TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
+TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled for maintenance on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 
 See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -1,13 +1,15 @@
 = Upgrades and Maintenance
-:description: Learn how Redpanda Cloud manages upgrades and maintenance.
+:description: Learn how Redpanda Cloud manages maintenance operations.
 
-The Redpanda Cloud glossterm:control plane[] handles automatic scaling, provisioning, maintenance, and upgrades.
+As a fully-managed service, the Redpanda Cloud glossterm:control plane[] handles all maintenance operations, such as upgrades to your software and infrastructure.
+
+Redpanda runs maintenance operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
 
 == Maintenance windows
 
-Redpanda runs maintenance and upgrade operations on clusters in a rolling fashion, accompanied by a series of health checks, so there is no disruption to the availability of your service. As part of the Kafka protocol, recycling nodes cause client connections to be restarted. All mainstream client libraries support automatic reconnections for this.
+Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
 
-By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
+If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -9,7 +9,7 @@ Redpanda runs maintenance operations on clusters in a rolling fashion, accompani
 
 Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
 
-If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
+If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations commence during the maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -10,3 +10,5 @@ Redpanda runs maintenance and upgrade operations on clusters in a rolling fashio
 By default, Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on the *Cluster settings* page. A *Scheduled* maintenance window requires Redpanda Cloud to run operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during the maintenance window, but some operations may complete after the window ends. All times are in Coordinated Universal Time (UTC).
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
+
+See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]


### PR DESCRIPTION
## Description

* Creates a new file `modules/manage/pages/maintenance.adoc` with info on how Redpanda Cloud handles upgrades and maintenance, including scheduling maintenance windows and the default maintenance cycle.
* Moves the maintenance windows section from `modules/get-started/pages/cloud-overview.adoc` into the new maintenance page.
* Adds a new reference to the maintenance documentation in the navigation file `modules/ROOT/nav.adoc`.
* Adds a link to the new maintenance documentation in the "Next steps" section of `modules/get-started/pages/cloud-overview.adoc`.
* Updates the link to schedule a maintenance window in `modules/get-started/pages/whats-new-cloud.adoc` to point to the new maintenance documentation.

Resolves https://redpandadata.atlassian.net/browse/DOC-821
Review deadline: Feb 28

## Page previews
[Upgrades and Maintenance](https://deploy-preview-219--rp-cloud.netlify.app/redpanda-cloud/manage/maintenance/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)