### PR TITLE
Update gcp-private-service-connect.adoc - Add more steps for BYOC

### DIFF
--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -208,11 +208,18 @@ CAUTION: As soon as Private Service Connect is available on your VPC, all commun
 export CLUSTER_ID=<cluster-id>
 ----
 
-. For a *BYOC cluster*, run `rpk cloud byoc gcp apply`:
-+
+. For a *BYOC cluster*
++ 
+---
+- Issue `rpk cloud byoc gcp apply` to ensure that the PSC subnets are created in your BYOC cluster. 
 ```bash
-rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-project-id>'
+rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-project-id>'
 ``` 
+- Issue `gcloud compute networks subnets list` to find the newly created Private Service Connect NAT subnet name. 
+```bash
+gcloud compute networks subnets list --filter psc2-nat --format="value(name)"
+```
+---
 +
 For a *BYOVPC cluster*:
 +
@@ -222,7 +229,7 @@ For a *BYOVPC cluster*:
 - Run `rpk cloud byoc gcp apply`:
 +
 ```bash
-rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-project-id>'
+rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-project-id>'
 ``` 
 --
 
@@ -230,13 +237,12 @@ rpk cloud byoc gcp apply --redpanda-id='$CLUSTER_ID' --project-id='<service-proj
 +
 [,bash]
 ----
-export ACCEPT_LIST='[]'
 export PSC_NAT_SUBNET_NAME='<psc-nat-subnet-name>'
 export CLUSTER_PATCH_BODY=`cat << EOF
 {
     "customer_managed_resources": {
         "gcp": {
-            "psc_nat_subnet_name": "$PSC_NAT_SUBNET_NAME"
+            "psc_nat_subnet_name": "${PSC_NAT_SUBNET_NAME}"
         }
     }
 }

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -215,7 +215,7 @@ export CLUSTER_ID=<cluster-id>
 ```bash
 rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-project-id>'
 ``` 
-- Issue `gcloud compute networks subnets list` to find the newly created Private Service Connect NAT subnet name. 
+- Run `gcloud compute networks subnets list` to find the newly-created Private Service Connect NAT subnet name. 
 ```bash
 gcloud compute networks subnets list --filter psc2-nat --format="value(name)"
 ```

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -208,7 +208,7 @@ CAUTION: As soon as Private Service Connect is available on your VPC, all commun
 export CLUSTER_ID=<cluster-id>
 ----
 
-. For a *BYOC cluster*
+. For a *BYOC cluster*:
 + 
 ---
 - Issue `rpk cloud byoc gcp apply` to ensure that the PSC subnets are created in your BYOC cluster. 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -210,7 +210,7 @@ export CLUSTER_ID=<cluster-id>
 
 . For a *BYOC cluster*:
 + 
----
+--
 - Run `rpk cloud byoc gcp apply` to ensure that the PSC subnets are created in your BYOC cluster. 
 ```bash
 rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-project-id>'
@@ -219,7 +219,7 @@ rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-pr
 ```bash
 gcloud compute networks subnets list --filter psc2-nat --format="value(name)"
 ```
----
+--
 +
 For a *BYOVPC cluster*:
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -211,7 +211,7 @@ export CLUSTER_ID=<cluster-id>
 . For a *BYOC cluster*:
 + 
 ---
-- Issue `rpk cloud byoc gcp apply` to ensure that the PSC subnets are created in your BYOC cluster. 
+- Run `rpk cloud byoc gcp apply` to ensure that the PSC subnets are created in your BYOC cluster. 
 ```bash
 rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<service-project-id>'
 ``` 


### PR DESCRIPTION
## Description

Still testing BYOC, and will need to test BYOVPC as well. In general, we should try to use curly braces around SHELL variables as described here: https://stackoverflow.com/questions/8748831/when-do-we-need-curly-braces-around-shell-variables. Removed one env variable in the subnet configure step, as the accept list is in the next step. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)