### PR TITLE
Clarify AWS/GCP account/project requires for remote read replicas

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -10,9 +10,9 @@ Redpanda Cloud supports remote read replicas with ephemeral BYOC clusters. Ephem
 == Prerequisites
 
 * A BYOC source cluster in Ready state.
-* A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization and the same cloud provider account as the source cluster.
-** AWS: The reader cluster must be in the same region as the source cluster.
-** GCP: The reader cluster can be in the same or a different region as the source cluster.
+* A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization as the source cluster.
+** AWS: The reader cluster must be in the same region as the source cluster. The reader cluster must be in the same account as the source cluster.
+** GCP: The reader cluster can be in the same or a different region as the source cluster. The reader cluster must be in the same project as the source cluster.
 ** Azure: Remote read replicas are not supported.
 
 === BYOVPC: Grant storage permissions


### PR DESCRIPTION
## Description

The word 'account' is associated with AWS and not GCP. This may have caused confusion.

## Page previews

https://deploy-preview-223--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/remote-read-replicas/

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)