### PR TITLE
DOC-1051 Add elasticsearch_v8 to cloud docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-1051_Replacement_elasticsearchv8_output
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-1051_Replacement_elasticsearchv8_output
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -145,6 +145,7 @@
 **** xref:develop:connect/components/outputs/cache.adoc[]
 **** xref:develop:connect/components/outputs/drop.adoc[]
 **** xref:develop:connect/components/outputs/drop_on.adoc[]
+**** xref:develop:connect/components/outputs/elasticsearch_v8.adoc[]
 **** xref:develop:connect/components/outputs/fallback.adoc[]
 **** xref:develop:connect/components/outputs/gcp_bigquery.adoc[]
 **** xref:develop:connect/components/outputs/gcp_cloud_storage.adoc[]

--- a/modules/develop/pages/connect/components/outputs/elasticsearch_v8.adoc
+++ b/modules/develop/pages/connect/components/outputs/elasticsearch_v8.adoc
@@ -1,0 +1,4 @@
+= elasticsearch_v8
+:page-aliases: components:outputs/elasticsearch_v8.adoc
+
+include::redpanda-connect:components:outputs/elasticsearch_v8.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1051](https://redpandadata.atlassian.net/browse/DOC-1051)
Review deadline: 5th March

## Page previews

[`elasticsearch_v8` output](https://deploy-preview-224--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/elasticsearch_v8/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1051]: https://redpandadata.atlassian.net/browse/DOC-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ