### PR TITLE
DOC-1082 add BYOC GCP europe-southwest1

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added in Redpanda Cloud.
 
 === Support for additional regions
 
-For xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters], Redpanda added support for the GPC europe-southwest1 region (Madrid).
+xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters] on GCP now support the europe-southwest1 (Madrid) region.
 
 == February 2025
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -7,6 +7,12 @@
 
 This page lists new features added in Redpanda Cloud.
 
+== March 2025
+
+=== Support for additional regions
+
+For xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters], Redpanda added support for the GPC europe-southwest1 region (Madrid).
+
 == February 2025
 
 === Role-based access control (RBAC) 

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -42,6 +42,7 @@ Google Cloud Platform (GCP)::
 | asia-south1 
 | asia-southeast1
 | australia-southeast1
+| europe-southwest1
 | europe-west1
 | europe-west2
 | europe-west3


### PR DESCRIPTION
## Description
This add a new supported region for BYOC clusters on GCP.

Documentation updates:

* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R10-R15): Added an entry for March 2025 mentioning the support for the GPC europe-southwest1 region (Madrid) for BYOC clusters.
* [`modules/reference/partials/tiers.adoc`](diffhunk://#diff-4a284041e150b37b311c93863e20d3d09c6fa62c1c3a3832c72f9c3469a6d867R45): Updated the list of supported regions to include europe-southwest1.

Resolves https://redpandadata.atlassian.net/browse/DOC-1082
Review deadline:

## Page previews
https://deploy-preview-225--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)