### PR TITLE
DOC-1088 update GCP IAM policies for PSC

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -21,7 +21,9 @@ With xref:security:authorization/rbac/rbac.adoc[RBAC in the control plane], you 
 
 === Improved Private Service Connect support with AZ affinity
 
-The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] service now provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The service is now fully supported (GA).
+The latest version of the Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. The service is now fully supported (GA). To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
+
+Deprecated: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 
 === Serverless Pro usage limits increased
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
-* The latest version of the Redpanda GCP Private Service Connect service (available Februrary, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
-* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+* The latest version of the Redpanda GCP Private Service Connect service (available Februrary, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
-* The latest version of the Redpanda GCP Private Service Connect service (available Februrary, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
-* As of Februrary 2025, the Redpanda GCP Private Service Connect service supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
+* The latest version of the Redpanda GCP Private Service Connect service (available Februrary, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -529,7 +529,7 @@ When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM 
 
 [NOTE]
 ====
-* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters] and cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
+* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters] and xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
 * No IAM permissions are required for Redpanda Cloud users. IAM policies do not grant user access to a cluster; rather, they grant the deployed Redpanda agent access, so that brokers can communicate with the BYOC clusters. 
 ====
 

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -529,7 +529,7 @@ When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM 
 
 [NOTE]
 ====
-* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. This _does not_ pertain to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
+* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. 
 * No IAM permissions are required for Redpanda Cloud users. IAM policies do not grant user access to a cluster; rather, they grant the deployed Redpanda agent access, so that brokers can communicate with the BYOC clusters. 
 ====
 

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -529,7 +529,7 @@ When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM 
 
 [NOTE]
 ====
-* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. This does _not_ pertain to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
+* This page lists the IAM permissions Redpanda requires to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. This does _not_ pertain to permissions for  xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
 * No IAM permissions are required for Redpanda Cloud users. IAM policies do not grant user access to a cluster; rather, they grant the deployed Redpanda agent access, so that brokers can communicate with the BYOC clusters. 
 ====
 

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -563,37 +563,37 @@ Redpanda cluster resources:
 | Allows a user to modify a specified firewall.
 
 | compute.forwardingRules.create
-|
+| Allows a user to create new forwarding rules within a project.
 
 | compute.forwardingRules.delete
-|
+| Allows a user to delete existing forwarding rules within a project.
 
 | compute.forwardingRules.get
-|
+| Allows a user to retrieve details about a specific forwarding rule within a project.
 
 | compute.forwardingRules.pscCreate
-|
+| Allows a user to create Private Service Connect forwarding rules within a project.
 
 | compute.forwardingRules.pscDelete
-|
+| Allows a user to delete Private Service Connect forwarding rules within a project.
 
 | compute.forwardingRules.pscSetLabels
-|
+| Allows a user to set or modify labels on Private Service Connect forwarding rules within a project.
 
 | compute.forwardingRules.pscSetTarget
-|
+| Allows a user to update the target service for a Private Service Connect forwarding rule.
 
 | compute.forwardingRules.pscUpdate
-|
+| Allows a user to update Private Service Connect forwarding rules within a project.
 
 | compute.forwardingRules.setLabels
-|
+| Allows a user to set, update, or remove labels on forwarding rules.
 
 | compute.forwardingRules.setTarget
-|
+| Allows a user to update the target of an existing forwarding rule.
 
 | compute.forwardingRules.use
-|
+| Allows a user to use a forwarding rule for traffic routing or other operations, without the ability to modify or delete it.
 
 | compute.globalOperations.get
 | Allows a user to retrieve information about a specific global operation in a GCP project.
@@ -644,7 +644,7 @@ Redpanda cluster resources:
 | Allows a user to modify a specified instance.
 
 | compute.instances.use
-|
+| Allows a user to use VM instances for operations, such as connecting to or interacting with the VM, but it does not grant the ability to modify or manage the instance itself.
 
 | compute.instanceTemplates.create
 | Allows a user to create an instance template.
@@ -671,40 +671,40 @@ Redpanda cluster resources:
 | Allows a user to update the configuration of existing GCP network resources.
 
 | compute.networks.use
-|
+| Allows a user to use a VPC network and its associated resources for tasks like launching instances or using network services, but it does not grant permission to modify the network itself.
 
 | compute.projects.get
 | Allows a user or service account to retrieve information (such as project metadata, quotas, and configuration settings) about a specific GCP project.
 
 | compute.regionBackendServices.create
-|
+| Allows a user to create backend services in a specific region for a regional load balancer.
 
 | compute.regionBackendServices.delete
-|
+| Allows a user to delete backend services within a specific region.
 
 | compute.regionBackendServices.get
-|
+| Allows a user to retrieve information about a backend service within a specific region.
 
 | compute.regionBackendServices.use
-|
+| Allows a user to use a backend service in a specific region for operations like routing traffic, but does not grant the ability to modify or delete the backend service.
 
 | compute.regionNetworkEndpointGroups.attachNetworkEndpoints
-|
+| Allows a user to attach network endpoints to a regional network endpoint group (NEG).
 
 | compute.regionNetworkEndpointGroups.create
-|
+| Allows a user to create a NEG within a specific region.
 
 | compute.regionNetworkEndpointGroups.delete
-|
+| Allows a user to delete a NEG in a specific region.
 
 | compute.regionNetworkEndpointGroups.detachNetworkEndpoints
-|
+| Allows a user to remove network endpoints from a regional NEG.
 
 | compute.regionNetworkEndpointGroups.get
-|
+| Allows a user to retrieve information about a specific NEG within a region.
 
 | compute.regionNetworkEndpointGroups.use
-|
+| Allows a user to use a NEG within a specific region, typically for traffic routing and load balancing operations, without granting the ability to modify or delete the NEG itself.
 
 | compute.regions.get
 | Allows a user to retrieve a specified region.
@@ -716,19 +716,19 @@ Redpanda cluster resources:
 | Allows a user to retrieve a specified router.
 
 | compute.serviceAttachments.create
-|
+| Allows a user to create service attachments for Google Cloud services within a specific project or region.
 
 | compute.serviceAttachments.delete
-|
+| Allows a user to delete service attachments that are configured in a project or region.
 
 | compute.serviceAttachments.get
-|
+| Allows a user to retrieve information about an existing service attachment in a project or region.
 
 | compute.serviceAttachments.list
-|
+| Allows a user to list all service attachments within a project or region.
 
 | compute.serviceAttachments.update
-|
+| Allows a user to update or modify a service attachment in a project or region.
 
 | compute.subnetworks.get
 | Allows a user to retrieve a specified subnetwork.
@@ -818,7 +818,7 @@ Redpanda cluster resources:
 | Allows a user or service account to retrieve metadata and configuration information about a particular service account within a project. This includes information such as the email address, display name, and IAM policies associated with the service account.
 
 | iam.serviceAccounts.getAccessToken
-|
+| Allows a user to obtain an access token on behalf of a service account.
 
 | iam.serviceAccounts.getIamPolicy
 | Allows a user to retrieve the IAM policy for a service account.
@@ -830,7 +830,7 @@ Redpanda cluster resources:
 | Allows a user to modify the service account for a project.
 
 | logging.logEntries.create
-| Allows user to write log entries.
+| Allows a user to write log entries.
 
 | resourcemanager.projects.get
 | Allows a user or service account to view project details, such as project ID, name, labels, and other project-level settings. This permission controls the ability to retrieve the metadata and configuration of a project in GCP using the Resource Manager API.

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -529,7 +529,7 @@ When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM 
 
 [NOTE]
 ====
-* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. 
+* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters] and cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
 * No IAM permissions are required for Redpanda Cloud users. IAM policies do not grant user access to a cluster; rather, they grant the deployed Redpanda agent access, so that brokers can communicate with the BYOC clusters. 
 ====
 

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -525,7 +525,7 @@ statement {
 endif::[]
 
 ifdef::env-gcp[]
-When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM permissions to the Redpanda Cloud agent. IAM permissions allow the agent to access the GCP API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary. IAM permissions are not required by Redpanda Cloud users.
+When you run `rpk cloud byoc gcp apply` to create a BYOC or BYOVPC cluster, you grant IAM permissions to the Redpanda Cloud agent. IAM permissions allow the agent to access the GCP API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary. IAM permissions are not required by Redpanda Cloud users.
 
 [NOTE]
 ====
@@ -819,6 +819,8 @@ Redpanda cluster resources:
 
 | iam.serviceAccounts.getAccessToken
 | Allows a user to obtain an access token on behalf of a service account.
+
+Note: BYOVPC only. This is not needed for BYOC.
 
 | iam.serviceAccounts.getIamPolicy
 | Allows a user to retrieve the IAM policy for a service account.

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -562,6 +562,39 @@ Redpanda cluster resources:
 | compute.firewalls.update
 | Allows a user to modify a specified firewall.
 
+| compute.forwardingRules.create
+|
+
+| compute.forwardingRules.delete
+|
+
+| compute.forwardingRules.get
+|
+
+| compute.forwardingRules.pscCreate
+|
+
+| compute.forwardingRules.pscDelete
+|
+
+| compute.forwardingRules.pscSetLabels
+|
+
+| compute.forwardingRules.pscSetTarget
+|
+
+| compute.forwardingRules.pscUpdate
+|
+
+| compute.forwardingRules.setLabels
+|
+
+| compute.forwardingRules.setTarget
+|
+
+| compute.forwardingRules.use
+|
+
 | compute.globalOperations.get
 | Allows a user to retrieve information about a specific global operation in a GCP project.
 
@@ -610,6 +643,9 @@ Redpanda cluster resources:
 | compute.instances.update
 | Allows a user to modify a specified instance.
 
+| compute.instances.use
+|
+
 | compute.instanceTemplates.create
 | Allows a user to create an instance template.
 
@@ -625,9 +661,6 @@ Redpanda cluster resources:
 | compute.networks.delete
 | Allows a user to delete a specified network.
 
-| compute.networks.get
-| Allows a user to retrieve a specified network.
-
 | compute.networks.getEffectiveFirewalls
 | Allows a user to retrieve the effective firewalls for a specified network.
 
@@ -637,8 +670,41 @@ Redpanda cluster resources:
 | compute.networks.updatePolicy
 | Allows a user to update the configuration of existing GCP network resources.
 
+| compute.networks.use
+|
+
 | compute.projects.get
 | Allows a user or service account to retrieve information (such as project metadata, quotas, and configuration settings) about a specific GCP project.
+
+| compute.regionBackendServices.create
+|
+
+| compute.regionBackendServices.delete
+|
+
+| compute.regionBackendServices.get
+|
+
+| compute.regionBackendServices.use
+|
+
+| compute.regionNetworkEndpointGroups.attachNetworkEndpoints
+|
+
+| compute.regionNetworkEndpointGroups.create
+|
+
+| compute.regionNetworkEndpointGroups.delete
+|
+
+| compute.regionNetworkEndpointGroups.detachNetworkEndpoints
+|
+
+| compute.regionNetworkEndpointGroups.get
+|
+
+| compute.regionNetworkEndpointGroups.use
+|
 
 | compute.regions.get
 | Allows a user to retrieve a specified region.
@@ -648,6 +714,21 @@ Redpanda cluster resources:
 
 | compute.routers.get
 | Allows a user to retrieve a specified router.
+
+| compute.serviceAttachments.create
+|
+
+| compute.serviceAttachments.delete
+|
+
+| compute.serviceAttachments.get
+|
+
+| compute.serviceAttachments.list
+|
+
+| compute.serviceAttachments.update
+|
 
 | compute.subnetworks.get
 | Allows a user to retrieve a specified subnetwork.
@@ -735,6 +816,9 @@ Redpanda cluster resources:
 
 | iam.serviceAccounts.get
 | Allows a user or service account to retrieve metadata and configuration information about a particular service account within a project. This includes information such as the email address, display name, and IAM policies associated with the service account.
+
+| iam.serviceAccounts.getAccessToken
+|
 
 | iam.serviceAccounts.getIamPolicy
 | Allows a user to retrieve the IAM policy for a service account.

--- a/modules/security/partials/iam-policies.adoc
+++ b/modules/security/partials/iam-policies.adoc
@@ -525,11 +525,11 @@ statement {
 endif::[]
 
 ifdef::env-gcp[]
-When you run `rpk cloud byoc gcp apply` to create a BYOC or BYOVPC cluster, you grant IAM permissions to the Redpanda Cloud agent. IAM permissions allow the agent to access the GCP API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary. IAM permissions are not required by Redpanda Cloud users.
+When you run `rpk cloud byoc gcp apply` to create a BYOC cluster, you grant IAM permissions to the Redpanda Cloud agent. IAM permissions allow the agent to access the GCP API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary. IAM permissions are not required by Redpanda Cloud users.
 
 [NOTE]
 ====
-* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters] and xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
+* This page lists the IAM permissions Redpanda needs to create xref:get-started:cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc[BYOC clusters]. This does _not_ pertain to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters]. 
 * No IAM permissions are required for Redpanda Cloud users. IAM policies do not grant user access to a cluster; rather, they grant the deployed Redpanda agent access, so that brokers can communicate with the BYOC clusters. 
 ====
 
@@ -816,11 +816,6 @@ Redpanda cluster resources:
 
 | iam.serviceAccounts.get
 | Allows a user or service account to retrieve metadata and configuration information about a particular service account within a project. This includes information such as the email address, display name, and IAM policies associated with the service account.
-
-| iam.serviceAccounts.getAccessToken
-| Allows a user to obtain an access token on behalf of a service account.
-
-Note: BYOVPC only. This is not needed for BYOC.
 
 | iam.serviceAccounts.getIamPolicy
 | Allows a user to retrieve the IAM policy for a service account.


### PR DESCRIPTION
## Description
This updates the GCP IAM policies with PSC v2. It adds permissions for forwarding rules, instances, networks, region backend services, and service attachments; and removes a permission for retrieving specified networks. It also adds deprecation notices for the original PSC service. 

Updates to permissions:

* Added multiple permissions related to `compute.forwardingRules`, including create, delete, get, and update operations.
* Added `compute.instances.use` permission.
* Removed `compute.networks.get` permission.
* Added permissions for `compute.regionBackendServices` and `compute.regionNetworkEndpointGroups`, including create, delete, get, and use operations.
* Added permissions for `compute.serviceAttachments`, including create, delete, get, list, and update operations.
* Added `iam.serviceAccounts.getAccessToken` permission.

Resolves https://redpandadata.atlassian.net/browse/DOC-1088
Review deadline: March 10

## Page previews
[GCP IAM Policies](https://deploy-preview-226--rp-cloud.netlify.app/redpanda-cloud/security/authorization/cloud-iam-policies-gcp/)
[What's New](https://deploy-preview-226--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#improved-private-service-connect-support-with-az-affinity)
[Configure PSC](https://deploy-preview-226--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/) 

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)