### PR TITLE
DOC-514 Add mongodb_cdc to cloud-docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-514_mongo_cdc_connector
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-514_mongo_cdc_connector
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -104,6 +104,7 @@
 **** xref:develop:connect/components/inputs/inproc.adoc[]
 **** xref:develop:connect/components/inputs/kafka.adoc[]
 **** xref:develop:connect/components/inputs/kafka_franz.adoc[]
+**** xref:develop:connect/components/inputs/mongodb_cdc.adoc[]
 **** xref:develop:connect/components/inputs/mqtt.adoc[]
 **** xref:develop:connect/components/inputs/mysql_cdc.adoc[]
 **** xref:develop:connect/components/inputs/nats.adoc[]

--- a/modules/develop/pages/connect/components/inputs/mongodb_cdc.adoc
+++ b/modules/develop/pages/connect/components/inputs/mongodb_cdc.adoc
@@ -1,0 +1,5 @@
+= mongodb_cdc
+:page-aliases: components:inputs/mongodb_cdc.adoc
+:page-beta: true
+
+include::redpanda-connect:components:inputs/mongodb_cdc.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-514](https://redpandadata.atlassian.net/browse/DOC-514)
Review deadline: 7th March

## Page previews

[mongodb_cdc](https://deploy-preview-227--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/mongodb_cdc/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-514]: https://redpandadata.atlassian.net/browse/DOC-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ