### PR TITLE
DOC-1110 call out PSC deprecation

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -23,7 +23,7 @@ With xref:security:authorization/rbac/rbac.adoc[RBAC in the control plane], you 
 
 The latest version of the Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. The service is now fully supported (GA). To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
 
-Deprecated: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+IMPORTANT: Deprecated: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 
 === Serverless Pro usage limits increased
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
-* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. NOTE: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
-* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. NOTE: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1110
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)