### PR TITLE
Fix minor typos in AWS BYOVPC documentation

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -128,23 +128,23 @@ To create the Redpanda network:
 cat > redpanda-network.json <<EOF
 {
     "name":"sample-redpanda-network",
-    "resource_group_id": ${REDPANDA_RG_ID},
+    "resource_group_id": "${REDPANDA_RG_ID}",
     "cloud_provider":"CLOUD_PROVIDER_AWS",
-    "region": ${AWS_REGION},
+    "region": "${AWS_REGION}",
     "cluster_type":"TYPE_BYOC",
     "customer_managed_resources": {
       "aws": {
         "management_bucket": {
-          "arn": ${AWS_MANAGEMENT_BUCKET}
+          "arn": "${AWS_MANAGEMENT_BUCKET}"
         },
         "dynamodb_table": {
-          "arn": ${AWS_DYNAMODB_TABLE}
+          "arn": "${AWS_DYNAMODB_TABLE}"
         },
         "private_subnets": {
-          "arns": ${AWS_PRIVATE_SUBNETS}
+          "arns": "${AWS_PRIVATE_SUBNETS}"
         },
         "vpc": {
-          "arn": ${AWS_VPC}
+          "arn": "${AWS_VPC}"
         }
       }
    }
@@ -253,7 +253,7 @@ cat > redpanda-cluster.json <<EOF
         "arn": "<permissions_boundary_policy_arn from terraform outputs>"
       }
     }
-  },
+  }
 }
 EOF
 ```


### PR DESCRIPTION
## Description

Some of these fields should be surrounded by quotes, as in the below create cluster example as well.

Removed an extra trailing comma that is invalid.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)