### PR TITLE
DOC-1128 Remove beta flags mongodb_cdc and mysql_cdc cloud docs

### DIFF
--- a/modules/develop/pages/connect/components/inputs/mongodb_cdc.adoc
+++ b/modules/develop/pages/connect/components/inputs/mongodb_cdc.adoc
@@ -1,5 +1,4 @@
 = mongodb_cdc
 :page-aliases: components:inputs/mongodb_cdc.adoc
-:page-beta: true
 
 include::redpanda-connect:components:inputs/mongodb_cdc.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/inputs/mysql_cdc.adoc
+++ b/modules/develop/pages/connect/components/inputs/mysql_cdc.adoc
@@ -1,5 +1,4 @@
 = mysql_cdc
 :page-aliases: components:inputs/mysql_cdc.adoc
-:page-beta: true
 
 include::redpanda-connect:components:inputs/mysql_cdc.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1128](https://redpandadata.atlassian.net/browse/DOC-1128)
Review deadline: 18 March

## Page previews

[`mongodb_cdc` input](https://deploy-preview-235--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/mongodb_cdc/)
[`mysql_cdc` input](https://deploy-preview-235--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/mysql_cdc/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1128]: https://redpandadata.atlassian.net/browse/DOC-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ