### PR TITLE
DOC-1130 Remove beta flag from postgres_cdc cloud docs

### DIFF
--- a/modules/develop/pages/connect/components/inputs/postgres_cdc.adoc
+++ b/modules/develop/pages/connect/components/inputs/postgres_cdc.adoc
@@ -1,5 +1,4 @@
 = postgres_cdc
 :page-aliases: develop:connect/components/inputs/pg_stream.adoc
-:page-beta: true
 
 include::redpanda-connect:components:inputs/postgres_cdc.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves DOC-1130
Review deadline: 19 March

This pull request removes the beta status from the `postgres_cdc` page.

## Page previews

[`postgres_cdc` input](https://deploy-preview-236--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/postgres_cdc/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)