### PR TITLE
DOC-1148 add Serverless trial link

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -38,17 +38,11 @@ Redpanda offers four types of fully-managed cloud clusters. All products have ac
 
 Serverless is the fastest and easiest way to start data streaming. With Serverless clusters, you host your data in Redpanda's VPC, and Redpanda handles automatic scaling, provisioning, operations, and maintenance. This is a production-ready deployment option with a cluster available instantly, and with pay-as-you-go billing after the free trial, you only pay for what you consume. You can view detailed billing activity for each cluster and edit payment methods on the *Billing* page. 
 
+NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#serverless-usage-limits[usage limits].
+
 ==== Sign up for Serverless
 
-The easiest way to get started with Serverless is with a free trial. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
-
-You can also subscribe to Redpanda Cloud through https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda Sales^]. By subscribing through Redpanda Sales, you get immediate access to Enterprise support. 
-
-Alternatively, you can subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] and quickly provision Serverless clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
-
-With AWS Marketplace sign up, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. 
-
-NOTE: Serverless is currently in a limited availability (LA) release with xref:get-started:cluster-types/serverless.adoc#serverless-usage-limits[usage limits]. 
+include::get-started:partial$get-started-serverless.adoc[] 
 
 === Dedicated Cloud
 
@@ -57,9 +51,23 @@ When you create a Dedicated cluster, you select the supported xref:reference:tie
 
 ==== Sign up for Dedicated
 
-Subscribe to Redpanda Cloud on the xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] to quickly provision Dedicated clusters. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
+[tabs]
+=====
+Redpanda Sales::
++
+--
+To request a private offer with possible discounts for monthly or annual committed use, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]. With a usage-based billing commitment, you sign up for a minimum spend amount through xref:billing:aws-commit.adoc[AWS Marketplace], xref:billing:azure-commit.adoc[Azure Marketplace], or xref:billing:gcp-commit.adoc[Google Cloud Marketplace]. You can then provision Dedicated clusters in Redpanda Cloud, and you can view invoices and manage your subscription in the marketplace.
 
-Alternatively, you can contact https://redpanda.com/try-redpanda?section=enterprise-trial[Redpanda sales^] to request a private offer with possible discounts for monthly or annual committed use. With a usage-based billing commitment, you sign up for a monthly or an annual minimum spend amount through xref:billing:aws-commit.adoc[AWS Marketplace], xref:billing:azure-commit.adoc[Azure Marketplace], or xref:billing:gcp-commit.adoc[Google Cloud Marketplace]. You can then provision Dedicated clusters in Redpanda Cloud, and you can view invoices and manage your subscription in the marketplace.
+Redpanda creates a cloud organization for you and sends you a welcome email.
+--
+AWS Marketplace::
++
+--
+New subscriptions to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
+
+Redpanda creates a cloud organization for you and sends you a welcome email. 
+--
+=====
 
 === Bring Your Own Cloud (BYOC)
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -29,36 +29,7 @@ NOTE: The partition limit is the number of logical partitions before replication
 
 == Get started with Serverless
 
-[tabs]
-=====
-Free trial::
-+
---
-A trial is the fastest way to get started with Serverless, and it comes with a `welcome` cluster. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
-
-When either the 100 credits expire or the 14 days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a seven-day grace period following the end of the trial. After that, the data is permanently deleted. 
-
-* To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel.
-* For information about billing after the trial ends, see xref:billing:billing.adoc[].
-
---
-Redpanda Sales::
-+
---
-To request a private offer with possible discounts, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]. When you subscribe to Serverless through Redpanda Sales, you get immediate access to Enterprise support. 
-
-Redpanda creates a cloud organization for you and sends you a welcome email. 
---
-AWS Marketplace::
-+
---
-To start using Serverless, subscribe to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace]. New subscriptions receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
-
-NOTE: When you subscribe to Redpanda through AWS Marketplace, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. To access Enterprise support, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]
-
-Redpanda creates a cloud organization for you and sends you a welcome email. 
---
-=====
+include::get-started:partial$get-started-serverless.adoc[]
 
 == Explore your trial cluster
 

--- a/modules/get-started/partials/get-started-serverless.adoc
+++ b/modules/get-started/partials/get-started-serverless.adoc
@@ -5,7 +5,7 @@ Free trial::
 --
 A https://www.redpanda.com/try-redpanda[free trial^] is the fastest way to get started with Serverless, and it comes with a `welcome` cluster. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
 
-When either the 100 credits expire or the 14 days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a seven-day grace period following the end of the trial. After that, the data is permanently deleted. 
+When either the credits expire or the days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a seven-day grace period following the end of the trial. After that, the data is permanently deleted. 
 
 * To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel.
 * For information about billing after the trial ends, see xref:billing:billing.adoc[].

--- a/modules/get-started/partials/get-started-serverless.adoc
+++ b/modules/get-started/partials/get-started-serverless.adoc
@@ -3,7 +3,7 @@
 Free trial::
 +
 --
-A https://www.redpanda.com/try-redpanda[free trial^] is the fastest way to get started with Serverless, and it comes with a `welcome` cluster. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
+A https://www.redpanda.com/try-redpanda[free trial^] is the fastest way to get started with Serverless, and it comes with a `welcome` cluster. Each customer qualifies for a trial with $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
 
 When either the credits expire or the days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a seven-day grace period following the end of the trial. After that, the data is permanently deleted. 
 
@@ -14,7 +14,7 @@ When either the credits expire or the days in the trial expire, the clusters mov
 Redpanda Sales::
 +
 --
-To request a private offer with possible discounts for annual committed use, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]. When you subscribe to Serverless through Redpanda Sales, you get immediate access to Enterprise support. 
+To request a private offer with possible discounts for annual committed use, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]. When you subscribe to Serverless through Redpanda Sales, you gain immediate access to Enterprise support. 
 
 Redpanda creates a cloud organization for you and sends you a welcome email. 
 --
@@ -23,7 +23,7 @@ AWS Marketplace::
 --
 New subscriptions to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
 
-NOTE: When you subscribe to Redpanda through AWS Marketplace, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. To access Enterprise support, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]
+NOTE: When you subscribe to Redpanda through AWS Marketplace, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. For Enterprise support, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]
 
 Redpanda creates a cloud organization for you and sends you a welcome email. 
 --

--- a/modules/get-started/partials/get-started-serverless.adoc
+++ b/modules/get-started/partials/get-started-serverless.adoc
@@ -1,0 +1,30 @@
+[tabs]
+=====
+Free trial::
++
+--
+A https://www.redpanda.com/try-redpanda[free trial^] is the fastest way to get started with Serverless, and it comes with a `welcome` cluster. New trials receive $100 (USD) in free credits to spend in the first 14 days. This should be enough to run Redpanda with reasonable throughput. No credit card is required. To continue using Serverless after your trial expires, you can enter a credit card and pay as you go. Any remaining credit balance is used before you are charged. 
+
+When either the 100 credits expire or the 14 days in the trial expire, the clusters move into a suspended state, and you won't be able to access your data in either the Redpanda Cloud UI or with the Kafka API. There is a seven-day grace period following the end of the trial. After that, the data is permanently deleted. 
+
+* To ask questions about the trial, use the *#serverless* https://redpandacommunity.slack.com/[Community Slack^] channel.
+* For information about billing after the trial ends, see xref:billing:billing.adoc[].
+
+--
+Redpanda Sales::
++
+--
+To request a private offer with possible discounts for annual committed use, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]. When you subscribe to Serverless through Redpanda Sales, you get immediate access to Enterprise support. 
+
+Redpanda creates a cloud organization for you and sends you a welcome email. 
+--
+AWS Marketplace::
++
+--
+New subscriptions to Redpanda Cloud through xref:billing:aws-pay-as-you-go.adoc[AWS Marketplace] receive $300 (USD) in free credits to spend in the first 30 days. AWS Marketplace charges for anything beyond $300, unless you cancel the subscription. After your free credits have been used, you can continue using your cluster without any commitment, only paying for what you consume and canceling anytime. 
+
+NOTE: When you subscribe to Redpanda through AWS Marketplace, you do not have immediate access to Enterprise support, only the https://redpandacommunity.slack.com/[Community Slack^] channel. To access Enterprise support, contact https://www.redpanda.com/price-estimator[Redpanda Sales^]
+
+Redpanda creates a cloud organization for you and sends you a welcome email. 
+--
+=====


### PR DESCRIPTION
## Description
This pull request adds a link to the Serverless trial, extracts Serverless sign-up details into a partial file for reuse, and adds similar tabs for Dedicated cluster sign-up options.

Improvements to Serverless sign-up information:

* [`modules/get-started/pages/cloud-overview.adoc`](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL41-R45): Removed detailed Serverless sign-up instructions and replaced them with a reference to a partial file.
* [`modules/get-started/pages/cluster-types/serverless.adoc`](diffhunk://#diff-b9ada45e986054dd3c87aefcc43f539e63aff7eb5e016458549138ad6445ac73L32-R32): Replaced detailed Serverless sign-up instructions with an inclusion of the partial file containing the sign-up details.
* [`modules/get-started/partials/get-started-serverless.adoc`](diffhunk://#diff-3f39ba9c197784bf8362410062438fc32f4e6b7c102a4882483bbdb3ae33c2a1R1-R30): Created a new partial file with a tabbed interface for different Serverless sign-up options, including Free trial, Redpanda Sales, and AWS Marketplace.

Enhancements to Dedicated cluster sign-up information:

* [`modules/get-started/pages/cloud-overview.adoc`](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL60-R70): Added a tabbed interface for Dedicated cluster sign-up options.

Resolves https://redpandadata.atlassian.net/browse/DOC-1148
Review deadline: March 26

## Page previews
[RP Cloud Overview](https://deploy-preview-241--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#serverless)
[Serverless](https://deploy-preview-241--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#get-started-with-serverless)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)