### PR TITLE
DOC-1154 update supported features in Serverless

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -87,10 +87,14 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 
 === Unsupported features
 
-* Data transforms
-* Redpanda Admin API 
+Not all features included in BYOC clusters are available in Serverless. For example, the following features are not supported:
+
 * HTTP Proxy API
-* Kafka Connect
+* Schema Registry UI (API is supported)
+* Metrics endpoints
+* Kafka Connect (Redpanda Connect is supported in beta)
+* Private networking and multiple availability zones (AZs)
+* RBAC in the data plane and mTLS authentication for Kafka API clients
 
 == Next steps
 


### PR DESCRIPTION
## Description

* Clarify that not all features included in BYOC clusters are available in Serverless clusters.
* Added the following unsupported features:
  * Schema Registry UI (API is supported)
  * Metrics endpoints
  * Kafka Connect (Redpanda Connect is supported in beta)
  * Private networking and multiple availability zones (AZs)
  * RBAC in the data plane and mTLS authentication for Kafka API clients

Resolves https://redpandadata.atlassian.net/browse/DOC-1154
Review deadline: March 28

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)