### PR TITLE
DOC-774 doc best practices with private link

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -24,6 +24,8 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 * In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps below to <<get-an-access-token,get an access token>>.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI^] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
+TIP: In Kafka clients, set `connections.max.idle.ms` to a value less than 350 seconds. 
+
 == Get a Cloud API access token
 
 include::networking:partial$private-links-api-access-token.adoc[]

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -15,6 +15,8 @@ Consider using Private Link if you have multiple virtual networks and require mo
 
 After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-cluster-with-private-link-service-enabled,enable Private Link when creating a new cluster>>, or you can <<enable-private-link-service-for-existing-clusters,enable Private Link for existing clusters>>.
 
+To learn more about Azure Private Link, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
+
 == Requirements
 
 * Install xref:manage:rpk/rpk-install.adoc[`rpk`].
@@ -22,7 +24,7 @@ After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create
 * You will use the https://learn.microsoft.com/en-us/cli/azure/[Azure CLI^] to authenticate with Azure and configure resources in your Azure account.
 * You will use the xref:deploy:deployment-option/cloud/api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda Private Link service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 
-To learn more about Azure Private Link, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
+TIP: In Kafka clients, set `connections.max.idle.ms` to a value less than 240 seconds. 
 
 == Set up Redpanda Private Link Service
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -17,6 +17,8 @@ Consider using the endpoint service if you have multiple VPCs and could benefit 
 * Your Redpanda cluster and VPC must be in the same region.
 * Use the https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[AWS CLI] to create a new client VPC or modify an existing one to use the PrivateLink endpoint.
 
+TIP: In Kafka clients, set `connections.max.idle.ms` to a value less than 350 seconds. 
+
 == Enable endpoint service for existing clusters
 
 . In the Redpanda Cloud UI, select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Cluster settings* page.


### PR DESCRIPTION
## Description
This pull request includes documentation updates for optimizing Kafka client configurations when using PrivateLink services in AWS and Azure. The changes provide additional tips for setting the `connections.max.idle.ms` parameter to improve client stability.

Documentation updates:

* [`modules/networking/pages/configure-privatelink-in-cloud-ui.adoc`](diffhunk://#diff-c251c8951879bdb57e77fa5fda3a50ec9e7b4f77790279dd23e9bbe8f96d5284R20-R21): Added a tip to set `connections.max.idle.ms` to less than 350 seconds for Kafka clients.
* [`modules/networking/pages/aws-privatelink.adoc`](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acR27-R28): Added a tip to set `connections.max.idle.ms` to less than 350 seconds for Kafka clients.
* [`modules/networking/pages/azure-private-link.adoc`](diffhunk://#diff-44fa14256b425a599042395c62f8d8e0babfbbe79846b452a328bfcd989efd02R18-R27): Moved the Azure Private Link documentation link and added a tip to set `connections.max.idle.ms` to less than 240 seconds for Kafka clients.

Resolves https://redpandadata.atlassian.net/browse/DOC-774
Review deadline: April 1

## Page previews
[AWS UI](https://deploy-preview-247--rp-cloud.netlify.app/redpanda-cloud/networking/configure-privatelink-in-cloud-ui/#requirements)
[AWS API](https://deploy-preview-247--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/#requirements)
[Azure API](https://deploy-preview-247--rp-cloud.netlify.app/redpanda-cloud/networking/azure-private-link/#requirements)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)