### PR TITLE
DOC-1150 Resource allocation for GPU-enabled pipelines

### DIFF
--- a/modules/develop/pages/connect/configuration/resource-management.adoc
+++ b/modules/develop/pages/connect/configuration/resource-management.adoc
@@ -92,7 +92,10 @@ Server resources are charged at an xref:billing:billing.adoc#redpanda-connect-pi
 
 |===
 
-NOTE: For pipelines with embedded Ollama AI components, one GPU is automatically allocated to the pipeline, which is equivalent to 30 compute units, or 3.0 CPU (`3000m`) and 12 GB of memory (`12000M`).
+[NOTE]
+====
+A GPU machine is automatically assigned to each pipeline that contains embedded Ollama AI components. By default, GPU-enabled pipelines are allocated eight compute units. For larger workloads, you can scale them up to a maximum of 30 compute units.
+====
 
 === Set an initial resource limit
 


### PR DESCRIPTION
## Description

Resolves: [DOC-1150](https://redpandadata.atlassian.net/browse/DOC-1150)
Review deadline: 3rd April

Documentation updates:

* [`modules/develop/pages/connect/configuration/resource-management.adoc`](diffhunk://#diff-e665243a6d556e5429e893a4d5f672166b8bbbaa9dd26ecb5241c345e1600963L95-R98): Updated the note to specify that GPU-enabled pipelines are allocated eight compute units by default and can be scaled up to a maximum of 30 compute units.

## Page previews

Manage pipeline resources


## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)