### PR TITLE
DOC-1162 move BYOC arch

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 ** xref:get-started:cloud-overview.adoc[Introduction to Redpanda Cloud]
 *** xref:get-started:intro-to-events.adoc[]
 *** xref:get-started:architecture.adoc[]
+** xref:get-started:byoc-arch.adoc[]
 
 * xref:get-started:cluster-types/index.adoc[Deploy]
 ** xref:get-started:cluster-types/serverless.adoc[Serverless]

--- a/modules/get-started/pages/byoc-arch.adoc
+++ b/modules/get-started/pages/byoc-arch.adoc
@@ -1,0 +1,38 @@
+= BYOC Architecture
+:description: Learn about the control plane - data plane architecture in BYOC. 
+
+For high availability, Redpanda Cloud uses the following control plane - data plane architecture:
+
+image::shared:control_d_plane.png[Control plane and data plane]
+
+* *Control plane*: This is where most cluster management, operations, and maintenance takes place. The control plane enforces rules in the data plane. You can use role-based access control xref:security:authorization/rbac/rbac.adoc[(RBAC) in the control plane] to manage access to organization-level resources like clusters, resource groups, and networks. 
+
+* *Data plane*: This is where your cluster lives. The term _data plane_ is sometimes used interchangeably with _cluster_. The data plane is where you manage topics, consumer groups, connectors, and schemas. You can use xref:security:authorization/rbac/rbac_dp.adoc[RBAC in the data plane] to configure cluster-level permissions for provisioned users at scale. 
+
+* *Agent*: For BYOC, Redpanda uses an agent to manage the data plane from the control plane. The agent pulls cluster specifications from the control plane. IAM permissions allow the agent to access the the cloud provider API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary.
+
+Clusters are configured and maintained in the control plane, but they remain available even if the network connection to the control plane is lost. 
+
+TIP: In the Redpanda Cloud UI, you see a different side navigation in the control plane and the data plane. You're in the control plane when you first log in. You're at the organization (org) level, and you haven't yet selected a cluster. This is where you can select, create, and delete clusters, networks, and resource groups. You're in the data plane when you're at the cluster level working with topics, consumer groups, connectors, and schemas.
+
+== BYOC setup
+
+In a BYOC architecture, you deploy the data plane in your own VPC. All network connections into the data plane take place through either a public endpoint, or for private clusters, through Redpanda Cloud network connections such as VPC peering, AWS PrivateLink, Azure Private Link, or GCP Private Service Connect. Customer data never leaves the data plane.
+
+A BYOC cluster is initially set up from the control plane. This is a two-step process performed by `rpk cloud byoc apply`:
+
+. You bootstrap a virtual machine (VM) in your VPC. 
++
+This VM spins up the agent and the required infrastructure. Redpanda assigns the necessary IAM policies required to run the agent and configures workload identity. That is, it configures independent IAM roles for each workload, with only the permissions each workload requires. 
+
+. The agent communicates with the control plane to pull the cluster specifications. 
++
+After the agent is up and running, it connects to the control plane and starts dequeuing and applying cluster specifications that provision, configure, and maintain clusters. The agent is in constant communication with the control plane,
+receiving and applying cluster specifications and exchanging cluster metadata. Agents are authenticated and authorized through opaque and ephemeral tokens, and
+they have dedicated job queues in the control plane. Agents also manage VPC peering networks. 
++
+image::shared:byoc_apply.png[cloud_byoc_apply]
+
+NOTE: To create a Redpanda cluster in your virtual private cloud (VPC), follow the instructions in the Redpanda Cloud UI. The UI contains the parameters necessary to successfully run `rpk cloud byoc apply` with your cloud provider. 
+
+include::get-started:partial$no-access.adoc[]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -6,7 +6,7 @@
 
 Redpanda Cloud is a complete data streaming platform delivered as a fully-managed service with automated upgrades and patching, data and partition balancing, and 24x7 support. It continuously monitors and maintains your clusters along with the underlying infrastructure to meet strict performance, availability, reliability, and security requirements. All Redpanda Cloud clusters are deployed with an integrated glossterm:Redpanda Console[].
 
-TIP: For more detailed information about the Redpanda platform, see xref:get-started:intro-to-events.adoc[] and xref:get-started:architecture.adoc[].
+TIP: For more detailed information about the Redpanda platform, see xref:get-started:intro-to-events.adoc[], xref:get-started:architecture.adoc[], and xref:get-started:byoc-arch.adoc[].
 
 == Redpanda Cloud cluster types
 
@@ -45,7 +45,7 @@ include::get-started:partial$get-started-serverless.adoc[]
 === Bring Your Own Cloud (BYOC)
 
 With BYOC clusters, you deploy Redpanda in your own cloud (AWS, Azure, or GCP), and all data is
-contained in your own environment. This provides an additional layer of security and isolation. (See <<BYOC architecture>>.) When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
+contained in your own environment. This provides an additional layer of security and isolation. (See xref:get-started:byoc-arch.adoc[]) When you create a BYOC cluster, you select the supported xref:reference:tiers/byoc-tiers.adoc[tier] that meets your compute and storage needs. Redpanda handles provisioning, operations, and maintenance. 
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC or VNet, including subnetworks, IAM roles, and storage buckets/accounts. A Bring Your Own Virtual Private Cloud (BYOVPC) cluster allows you to deploy the Redpanda glossterm:data plane[] into your existing VPC/VNet and take full control of managing the networking lifecycle. Compared to standard BYOC, BYOVPC provides more security, but the configuration is more complex. See <<Shared responsibility model>>.
 
@@ -97,6 +97,12 @@ Consider BYOC or Dedicated if you need more control over the deployment or if yo
 * Ability to export metrics to a 3rd-party monitoring system
 * Kafka Connect
 * Higher limits and quotas. See xref:reference:tiers/byoc-tiers.adoc[BYOC usage tiers] and xref:reference:tiers/dedicated-tiers.adoc[Dedicated usage tiers] compared to xref:get-started:cluster-types/serverless.adoc#serverless-usage-limits[Serverless limits].
+
+== Redpanda Cloud architecture
+
+When you sign up for a Redpanda account, Redpanda creates an organization for you. Your organization contains all your Redpanda resources, including your clusters and networks. Within your organization, Redpanda creates a default resource group to contain your resources. You can rename this resource group, and you can create more resource groups. For example, you may want different resource groups for production and testing.
+
+For details about the control plane - data plane framework in BYOC, see xref:get-started:byoc-arch.adoc[BYOC Architecture].
 
 == Shared responsibility model
 
@@ -210,46 +216,6 @@ Dedicated::
 xref:develop:connect/about.adoc[Redpanda Connect] is integrated into Redpanda Cloud and available as a fully-managed service. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications from the Cloud UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
 
 xref:develop:managed-connectors/index.adoc[Kafka Connect] is automatically enabled on AWS and GCP clusters. With this, there is a node running for Kafka Connect even if connectors are not used. To enable Kafka Connect on Azure clusters, see xref:get-started:cluster-types/byoc/azure/create-byoc-cluster-azure.adoc#enable-kafka-connect[Enable Kafka Connect].
-
-== Redpanda Cloud architecture
-
-When you sign up for a Redpanda account, Redpanda creates an organization for you. Your organization contains all your Redpanda resources, including your clusters and networks. Within your organization, Redpanda creates a default resource group to contain your resources. You can rename this resource group, and you can create more resource groups. For example, you may want different resource groups for production and testing. 
-
-For high availability, Redpanda Cloud uses the following control plane - data plane architecture:
-
-image::shared:control_d_plane.png[Control plane and data plane]
-
-* *Control plane*: This is where most cluster management, operations, and maintenance takes place. The control plane enforces rules in the data plane. You can use role-based access control xref:security:authorization/rbac/rbac.adoc[(RBAC) in the control plane] to manage access to organization-level resources like clusters, resource groups, and networks. 
-
-* *Data plane*: This is where your cluster lives. The term _data plane_ is sometimes used interchangeably with _cluster_. The data plane is where you manage topics, consumer groups, connectors, and schemas. You can use xref:security:authorization/rbac/rbac_dp.adoc[RBAC in the data plane] to configure cluster-level permissions for provisioned users at scale. 
-
-* *Agent*: For BYOC, Redpanda uses an agent to manage the data plane from the control plane. The agent pulls cluster specifications from the control plane. IAM permissions allow the agent to access the the cloud provider API to create and manage cluster resources. The permissions follow the principle of least privilege, limiting access to only what is necessary.
-
-Clusters are configured and maintained in the control plane, but they remain available even if the network connection to the control plane is lost. 
-
-TIP: In the Redpanda Cloud UI, you see a different side navigation in the control plane and the data plane. You're in the control plane when you first log in. You're at the organization (org) level, and you haven't yet selected a cluster. This is where you can select, create, and delete clusters, networks, and resource groups. You're in the data plane when you're at the cluster level working with topics, consumer groups, connectors, and schemas.
-
-=== BYOC architecture
-
-In a BYOC architecture, you deploy the data plane in your own VPC. All network connections into the data plane take place through either a public endpoint, or for private clusters, through Redpanda Cloud network connections such as VPC peering, AWS PrivateLink, Azure Private Link, or GCP Private Service Connect. Customer data never leaves the data plane.
-
-include::get-started:partial$no-access.adoc[]
-
-A BYOC cluster is initially set up from the control plane. This is a two-step process performed by `rpk cloud byoc apply`:
-
-. You bootstrap a virtual machine (VM) in your VPC. 
-+
-This VM spins up the agent and the required infrastructure. Redpanda assigns the necessary IAM policies required to run the agent and configures workload identity. That is, it configures independent IAM roles for each workload, with only the permissions each workload requires. 
-
-. The agent communicates with the control plane to pull the cluster specifications. 
-+
-After the agent is up and running, it connects to the control plane and starts dequeuing and applying cluster specifications that provision, configure, and maintain clusters. The agent is in constant communication with the control plane,
-receiving and applying cluster specifications and exchanging cluster metadata. Agents are authenticated and authorized through opaque and ephemeral tokens, and
-they have dedicated job queues in the control plane. Agents also manage VPC peering networks. 
-+
-image::shared:byoc_apply.png[cloud_byoc_apply]
-
-NOTE: To create a Redpanda cluster in your virtual private cloud (VPC), follow the instructions in the Redpanda Cloud UI. The UI contains the parameters necessary to successfully run `rpk cloud byoc apply` with your cloud provider. 
 
 == Redpanda Cloud vs Self-Managed feature compatibility
 


### PR DESCRIPTION
## Description

This lifts the BYOC Architecture content into its own page for better visibility and SEO. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1162
Review deadline: April 2

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)