### PR TITLE
Update create-byoc-cluster-aws.adoc - move bullet outside of AWS credentials bullet

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -16,10 +16,9 @@ Before you deploy a BYOC cluster on AWS, check that the user creating the cluste
 --
 ** `AWS_PROFILE` or
 ** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-* Ensure that the AWS user authenticating to AWS has `AWSAdministratorAccess` access to create IAM policies specified in xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
-
 To verify access, you should be able to successfully run `aws sts get-caller-identity` for your region. See the https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html[AWS CLI reference^].
 --
+* Ensure that the AWS user authenticating to AWS has `AWSAdministratorAccess` access to create IAM policies specified in xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
 
 == Create a BYOC cluster
 


### PR DESCRIPTION
## Description

Typo on formatting on pre-requisites. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)