### PR TITLE
DOC-1224 specify PL and peering not supported in Serverless

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -93,7 +93,8 @@ Not all features included in BYOC clusters are available in Serverless. For exam
 * Schema Registry UI (API is supported)
 * Metrics endpoints
 * Kafka Connect 
-* Private networking and multiple availability zones (AZs)
+* Private networking (VPC peering or AWS PrivateLink)
+* Multiple availability zones (AZs)
 * RBAC in the data plane and mTLS authentication for Kafka API clients
 
 == Next steps


### PR DESCRIPTION
## Description
This pull request includes changes to the `modules/get-started/pages/cluster-types/serverless.adoc` file:

* Updated the description for private networking to specify "VPC peering or AWS PrivateLink" instead of a general statement.
* Separated the feature of multiple availability zones (AZs) into its own bullet point for clarity.

Resolves [https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>](https://redpandadata.atlassian.net/browse/DOC-1224)
Review deadline:

## Page previews
https://deploy-preview-256--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#supported-features

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)