### PR TITLE
DOC-1236 remove wasm quickstart from cloud

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -360,7 +360,6 @@
 ** xref:develop:http-proxy.adoc[]
 ** xref:develop:data-transforms/index.adoc[]
 *** xref:develop:data-transforms/how-transforms-work.adoc[Overview]
-*** xref:develop:data-transforms/run-transforms.adoc[Data Transforms Quickstart]
 *** xref:develop:data-transforms/build.adoc[Build]
 *** xref:develop:data-transforms/configure.adoc[Configure]
 *** xref:develop:data-transforms/deploy.adoc[Deploy]

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -2,6 +2,6 @@
 :description: Learn how to initialize a data transforms project and write transform functions in your chosen language.
 :page-categories: Development, Stream Processing, Data Transforms
 
-NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later. To enable data transforms, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
 
 include::ROOT:develop:data-transforms/build.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -2,4 +2,6 @@
 :description: Learn how to initialize a data transforms project and write transform functions in your chosen language.
 :page-categories: Development, Stream Processing, Data Transforms
 
+NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later. To enable data transforms, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+
 include::ROOT:develop:data-transforms/build.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -1,5 +1,6 @@
 = How Data Transforms Work
 :page-categories: Development, Stream Processing, Data Transforms
 :description: Learn how Redpanda data transforms work.
+:page-aliases: develop:data-transforms/run-transforms.adoc
 
 include::ROOT:develop:data-transforms/how-transforms-work.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -3,4 +3,6 @@
 :description: Learn how Redpanda data transforms work.
 :page-aliases: develop:data-transforms/run-transforms.adoc
 
+NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
+
 include::ROOT:develop:data-transforms/how-transforms-work.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/run-transforms.adoc
+++ b/modules/develop/pages/data-transforms/run-transforms.adoc
@@ -1,5 +1,0 @@
-= Data Transforms Quickstart
-:description: Learn how to build and deploy your first transform functio..
-:page-categories: Development, Stream Processing, Data Transforms
-
-include::ROOT:develop:data-transforms/run-transforms.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -27,7 +27,9 @@ Iceberg topics properties are available for clusters running Redpanda version 25
 
 === Data transforms: GA
 
-WebAssembly xref:develop:data-transforms/index.adoc[data transforms] is now generally available in Redpanda Cloud for BYOC and Dedicated clusters running Redpanda version 24.3 and later. Data transforms let you run common data streaming tasks within Redpanda, like filtering, scrubbing, and transcoding. 
+WebAssembly xref:develop:data-transforms/index.adoc[data transforms] are now generally available in Redpanda Cloud. Data transforms let you run common data streaming tasks within Redpanda, like filtering, scrubbing, and transcoding. 
+
+Data transforms are supported for BYOC and Dedicated clusters running Redpanda version 24.3 and later.
 
 === AI agents: beta
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -27,7 +27,7 @@ Iceberg topics properties are available for clusters running Redpanda version 25
 
 === Data transforms: GA
 
-WebAssembly xref:develop:data-transforms/index.adoc[data transforms] is now generally available in Redpanda Cloud for BYOC and Dedicated clusters. Data transforms let you run common data streaming tasks within Redpanda, like filtering, scrubbing, and transcoding. 
+WebAssembly xref:develop:data-transforms/index.adoc[data transforms] is now generally available in Redpanda Cloud for BYOC and Dedicated clusters running Redpanda version 24.3 and later. Data transforms let you run common data streaming tasks within Redpanda, like filtering, scrubbing, and transcoding. 
 
 === AI agents: beta
 

--- a/modules/manage/pages/audit-logging.adoc
+++ b/modules/manage/pages/audit-logging.adoc
@@ -3,4 +3,6 @@
 :page-categories: Management, Security
 :env-linux: true
 
+NOTE: Audit logging is supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later. To configure audit logging, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+
 include::ROOT:manage:audit-logging.adoc[tag=single-source]

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -1,9 +1,7 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties to enable and manage features.
 
-Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. 
-
-You can edit certain cluster configuration properties with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
+Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. You can edit certain cluster configuration properties with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
 
 == Limitations
 


### PR DESCRIPTION
## Description
This pull request includes several updates to the documentation for data transforms and audit logging. The most important changes include the removal of the Data Transforms Quickstart section, the addition of support notes for BYOC and Dedicated clusters, and the addition of a page alias.

Single-sourcing of updated text in the `docs` repo is done in https://github.com/redpanda-data/docs/pull/1079.

Documentation updates:

* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193L363): Removed the link to the Data Transforms Quickstart section.
* [`modules/develop/pages/data-transforms/how-transforms-work.adoc`](diffhunk://#diff-3e86940a8aa1d700365135b8974a6159439731807a9a0367d3b907f3c721ea22R4): Added a page alias for the removed Data Transforms Quickstart section.
* [`modules/develop/pages/data-transforms/run-transforms.adoc`](diffhunk://#diff-7ead89bc384c2f975eaa0dabac7a5ba27b5f3dfd7500806c896f2afeac06709bL1-L5): Removed the Data Transforms Quickstart section.
* [`modules/develop/pages/data-transforms/build.adoc`](diffhunk://#diff-bc31e7aa461888e20921d290ba696413a06db51554c2afe65d590dab2072b532R5-R6): Added a note about data transforms support on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
* [`modules/manage/pages/audit-logging.adoc`](diffhunk://#diff-5786238503c86fdc857e74929e0c16128b194deb90e4ed8900f4cdbe123aa692R6-R7): Added a note about audit logging support on BYOC and Dedicated clusters running Redpanda version 24.3 and later.

Resolves https://redpandadata.atlassian.net/browse/DOC-1236
Review deadline:

## Page previews
[Develop Data Transforms](https://deploy-preview-1079--redpanda-docs-preview.netlify.app/redpanda-cloud/develop/data-transforms/build/)
[Audit Logging](https://deploy-preview-259--rp-cloud.netlify.app/redpanda-cloud/manage/audit-logging/)
[What's New](https://deploy-preview-259--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#data-transforms-ga)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)