### PR TITLE
DOC-121 add BYOC requirements

### DIFF
--- a/modules/billing/pages/azure-commit.adoc
+++ b/modules/billing/pages/azure-commit.adoc
@@ -40,4 +40,4 @@ You can now create resource groups, clusters, and networks in your organization.
 
 == Next steps
 
-* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster.adoc[]
+* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster.adoc[Create a Dedicated Cluster]

--- a/modules/billing/pages/azure-commit.adoc
+++ b/modules/billing/pages/azure-commit.adoc
@@ -40,4 +40,4 @@ You can now create resource groups, clusters, and networks in your organization.
 
 == Next steps
 
-* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster.adoc[Create a Dedicated Cluster]
+* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster.adoc[Create a Dedicated cluster]

--- a/modules/billing/pages/gcp-commit.adoc
+++ b/modules/billing/pages/gcp-commit.adoc
@@ -44,4 +44,4 @@ You can now create resource groups, clusters, and networks in your organization.
 
 == Next steps
 
-* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster-aws.adoc[Create a Dedicated Cluster]
+* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster-aws.adoc[Create a Dedicated cluster]

--- a/modules/billing/pages/gcp-commit.adoc
+++ b/modules/billing/pages/gcp-commit.adoc
@@ -44,4 +44,4 @@ You can now create resource groups, clusters, and networks in your organization.
 
 == Next steps
 
-* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster-aws.adoc[]
+* xref:get-started:cluster-types/dedicated/create-dedicated-cloud-cluster-aws.adoc[Create a Dedicated Cluster]

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -12,6 +12,7 @@ Before you deploy a BYOC cluster on AWS, check that the user creating the cluste
 
 * A minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
 * The user authenticating to AWS has `AWSAdministratorAccess` access to create the IAM policies specified in xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
+
 * The user has the AWS variables necessary to authenticate. Use either:
 +
 --
@@ -42,7 +43,10 @@ Optionally, click *Advanced settings* to specify up to five key-value custom tag
 . Click *Next*.
 . On the Deploy page, follow the steps to log in to Redpanda Cloud and deploy the agent.
 +
-As part of agent deployment, Redpanda assigns the permission required to run the agent. For details about these permissions, see xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
+As part of agent deployment:
++
+** Redpanda assigns the permission required to run the agent. For details about these permissions, see xref:security:authorization/cloud-iam-policies.adoc[AWS IAM policies].
+** Redpanda allocates one Elastic IP (EIP) address in AWS for each BYOC cluster. 
 
 include::get-started:partial$no-access.adoc[]
 

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -22,6 +22,7 @@ The https://github.com/redpanda-data/cloud-examples/tree/main/customer-managed/a
 
 * Access to an AWS project in which you create your cluster.
 * Minimum permissions in that AWS project. For the actions required by the user who will create the cluster with `rpk cloud byoc aws apply`, see https://github.com/redpanda-data/cloud-examples/blob/main/customer-managed/aws/terraform/iam_rpk_user.tf[`iam_rpk_user.tf`^].
+* Each BYOVPC cluster requires one allocated Elastic IP (EIP) address in AWS.
 * Familiarity with the Redpanda Cloud API. For example, you should be familiar with how to use the Cloud API to xref:redpanda-cloud:manage:api/cloud-api-authentication.adoc[authenticate] and xref:redpanda-cloud:manage:api/cloud-byoc-controlplane-api.adoc[create a cluster].
 * https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli[Terraform^] version 1.8.5 or later.
 * https://jqlang.org/download/[jq^], which is used to parse JSON values from API responses.


### PR DESCRIPTION
## Description
This pull request adds information about Elastic IP (EIP) allocation for BYOC clusters.

### Updates to AWS deployment prerequisites:

* Added a note specifying that the user must have the necessary AWS variables for authentication when creating a BYOC cluster. (`modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc`, [modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adocR15](diffhunk://#diff-f5cfd5aa50fd526a9a9ced35995a2703c7285dce8a1a18ce84ca1bde5ab9bab3R15))
* Documented that each BYOVPC cluster requires one allocated Elastic IP (EIP) address in AWS. (`modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc`, [modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adocR25](diffhunk://#diff-a056c359f8c3c6ac1d52caa712bacb5d840e6f499d9e5180517c2a2a48b6d244R25))

### Updates to deployment process:

* Expanded the agent deployment section to include details about Elastic IP (EIP) allocation for each BYOC cluster, alongside the existing permissions information. (`modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc`, [modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adocL45-R49](diffhunk://#diff-f5cfd5aa50fd526a9a9ced35995a2703c7285dce8a1a18ce84ca1bde5ab9bab3L45-R49))

Resolves https://redpandadata.atlassian.net/browse/DOC-121
Review deadline: Tues April 22

## Page previews
[BYOVPC on AWS prereqs](https://deploy-preview-261--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/vpc-byo-aws/#prerequisites)
[Deploy a BYOC cluster on AWS (step 7)](https://deploy-preview-261--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/create-byoc-cluster-aws/#create-a-byoc-cluster)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added explicit link labels "Create a Dedicated Cluster" to cross-references for improved clarity.
	- Clarified agent deployment steps in AWS BYOC cluster documentation with a detailed bulleted list.
	- Added a prerequisite note about required Elastic IP (EIP) addresses for AWS BYOVPC clusters.
	- Improved formatting and readability in prerequisites sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->