### PR TITLE
DOC-1056 Serverless not multi-az

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -30,7 +30,7 @@ Redpanda offers fully-managed cloud clusters for Serverless, BYOC, and Dedicated
 
 * The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of three.
 * Enterprise support is staffed by streaming experts around the clock Monday through Friday, plus immediate escalation for production outages 24/7.
-* See also: <<Serverless vs BYOC/Dedicated>>.
+* See also: <<Serverless vs BYOC/Dedicated>>
 ==== 
 
 === Serverless

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -10,7 +10,7 @@ TIP: For more detailed information about the Redpanda platform, see xref:get-sta
 
 == Redpanda Cloud cluster types
 
-Redpanda offers fully-managed cloud clusters for Serverless, BYOC, and Dedicated. All products have access to unlimited storage and 280+ data connectors with xref:develop:connect/about.adoc[Redpanda Connect].
+Redpanda offers fully-managed cloud clusters for Serverless, BYOC, and Dedicated. All products have access to unlimited storage and 300+ data connectors with xref:develop:connect/about.adoc[Redpanda Connect].
 |===
 | <<Serverless>> | <<Bring Your Own Cloud (BYOC)>> | <<Dedicated>>
 
@@ -30,6 +30,7 @@ Redpanda offers fully-managed cloud clusters for Serverless, BYOC, and Dedicated
 
 * The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of three.
 * Enterprise support is staffed by streaming experts around the clock Monday through Friday, plus immediate escalation for production outages 24/7.
+* See also: <<Serverless vs BYOC/Dedicated>>.
 ==== 
 
 === Serverless
@@ -97,7 +98,7 @@ With Serverless (and for Dedicated when procured through the AWS Marketplace), y
 Consider BYOC or Dedicated if you need more control over the deployment or if you have workloads with consistently-high throughput. BYOC and Dedicated clusters offer the following features:
 
 * Private networking
-* Single-zone or multi-zone availability. A multi-zone cluster provides higher resiliency in the event of a failure in one of the zones. 
+* Multiple availability zones (AZs). A multi-AZ cluster provides higher resiliency in the event of a failure in one of the zones. 
 * Ability to export metrics to a 3rd-party monitoring system
 * Kafka Connect
 * Higher limits and quotas. See xref:reference:tiers/byoc-tiers.adoc[BYOC usage tiers] and xref:reference:tiers/dedicated-tiers.adoc[Dedicated usage tiers] compared to xref:get-started:cluster-types/serverless.adoc#serverless-usage-limits[Serverless limits].

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -91,7 +91,7 @@ Not all features included in BYOC clusters are available in Serverless. For exam
 
 * HTTP Proxy API
 * Schema Registry UI (API is supported)
-* Metrics endpoints
+* Ability to export metrics to a 3rd-party monitoring system
 * Kafka Connect 
 * Private networking (VPC peering or AWS PrivateLink)
 * Multiple availability zones (AZs)

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -91,7 +91,7 @@ Not all features included in BYOC clusters are available in Serverless. For exam
 
 * HTTP Proxy API
 * Schema Registry UI (API is supported)
-* Ability to export metrics to a 3rd-party monitoring system
+* Ability to export metrics to a third-party monitoring system
 * Kafka Connect 
 * Private networking (VPC peering or AWS PrivateLink)
 * Multiple availability zones (AZs)


### PR DESCRIPTION
## Description

This pull request improves terminology, updates numerical data, and adds cross-references for better navigation.
FYI: Serverless functionality is documented [here](https://deploy-preview-264--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#serverless-vs-byocdedicated) and [here](https://deploy-preview-264--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#unsupported-features). 

### Content updates for clarity and accuracy:

* Updated the number of data connectors from "280+" to "300+" to reflect the latest offering. (`modules/get-started/pages/cloud-overview.adoc`, [modules/get-started/pages/cloud-overview.adocL13-R13](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL13-R13))
* Replaced "Single-zone or multi-zone availability" with "Multiple availability zones (AZs)" for improved terminology and clarity about resiliency features. (`modules/get-started/pages/cloud-overview.adoc`, [modules/get-started/pages/cloud-overview.adocL100-R101](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL100-R101))

### Navigation improvements:

* Added a cross-reference to "Serverless vs BYOC/Dedicated" for easier comparison between cluster types. (`modules/get-started/pages/cloud-overview.adoc`, [modules/get-started/pages/cloud-overview.adocR33](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bR33))

Resolves https://redpandadata.atlassian.net/browse/DOC-1056
Review deadline: April 24

## Page previews
https://deploy-preview-264--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the stated number of available Redpanda Connect data connectors from "280+" to "300+".
  - Added a cross-reference link to the "Serverless vs BYOC/Dedicated" section regarding partition limits and enterprise support.
  - Clarified terminology by replacing "Single-zone or multi-zone availability" with "Multiple availability zones (AZs)" and updated related explanations for improved clarity.
  - Revised the description of unsupported features in Serverless clusters to specify the inability to export metrics to third-party monitoring systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->