### PR TITLE
DOC-1238 Add slack_post output

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-1238_slack_post_output
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-1238_slack_post_output
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -179,6 +179,7 @@
 **** xref:develop:connect/components/outputs/retry.adoc[]
 **** xref:develop:connect/components/outputs/schema_registry.adoc[]
 **** xref:develop:connect/components/outputs/sftp.adoc[]
+**** xref:develop:connect/components/outputs/slack_post.adoc[]
 **** xref:develop:connect/components/outputs/snowflake_put.adoc[]
 **** xref:develop:connect/components/outputs/snowflake_streaming.adoc[]
 **** xref:develop:connect/components/outputs/splunk_hec.adoc[]

--- a/modules/develop/pages/connect/components/outputs/slack_post.adoc
+++ b/modules/develop/pages/connect/components/outputs/slack_post.adoc
@@ -1,0 +1,5 @@
+= slack_post
+:page-aliases: components:outputs/slack_post.adoc
+:page-beta: true
+
+include::redpanda-connect:components:outputs/slack_post.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/slack_post.adoc
+++ b/modules/develop/pages/connect/components/outputs/slack_post.adoc
@@ -1,5 +1,4 @@
 = slack_post
 :page-aliases: components:outputs/slack_post.adoc
-:page-beta: true
 
 include::redpanda-connect:components:outputs/slack_post.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1238](https://redpandadata.atlassian.net/browse/DOC-1238)
Review deadline: 24th April

This pull request introduces documentation updates related to the new Slack Post output feature in the Redpanda Connect project. The changes include updating the Antora playbook to use a specific branch, adding a new navigation entry, and creating a new page for the Slack Post output.

### Documentation Updates for Slack Post Output:

* **Antora Playbook Update**:
  - Updated the `branches` field for the `rp-connect-docs` repository in `local-antora-playbook.yml` to use the `DOC-1238_slack_post_output` branch.

* **Navigation Update**:
  - Added a new navigation entry in `modules/ROOT/nav.adoc` for the Slack Post output documentation.

* **New Documentation Page**:
  - Created a new page `modules/develop/pages/connect/components/outputs/slack_post.adoc` for the Slack Post output, marked as beta, and included content from a single source.


## Page previews

[`slack_post` output](https://deploy-preview-265--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/slack_post/)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1238]: https://redpandadata.atlassian.net/browse/DOC-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added documentation for the Slack Post output component, marked as a beta feature.
- **Documentation**
  - Updated the navigation to include the new Slack Post output component under Redpanda Connect outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->