### PR TITLE
DOC-1239 Add slack_users input

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-1239_slack_users_input
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-1239_slack_users_input
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -125,6 +125,7 @@
 **** xref:develop:connect/components/inputs/schema_registry.adoc[]
 **** xref:develop:connect/components/inputs/sequence.adoc[]
 **** xref:develop:connect/components/inputs/sftp.adoc[]
+**** xref:develop:connect/components/inputs/slack_users.adoc[]
 **** xref:develop:connect/components/inputs/spicedb_watch.adoc[]
 **** xref:develop:connect/components/inputs/splunk.adoc[]
 **** xref:develop:connect/components/inputs/sql_raw.adoc[]

--- a/modules/develop/pages/connect/components/inputs/slack_users.adoc
+++ b/modules/develop/pages/connect/components/inputs/slack_users.adoc
@@ -1,5 +1,4 @@
 = slack_users
 :page-aliases: components:inputs/slack_users.adoc
-:page-beta: true
 
 include::redpanda-connect:components:inputs/slack_users.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/inputs/slack_users.adoc
+++ b/modules/develop/pages/connect/components/inputs/slack_users.adoc
@@ -1,0 +1,5 @@
+= slack_users
+:page-aliases: components:inputs/slack_users.adoc
+:page-beta: true
+
+include::redpanda-connect:components:inputs/slack_users.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1239](https://redpandadata.atlassian.net/browse/DOC-1239)
Review deadline: 30th April

This pull request introduces support for a new `slack_users` input component in the documentation. The changes include updates to the playbook configuration, navigation, and the addition of a new documentation file for the component.

### Updates related to the new `slack_users` input component:

* **Playbook configuration update**:
  - Updated the `branches` field in the `local-antora-playbook.yml` file to include the `DOC-1239_slack_users_input` branch for the `rp-connect-docs` repository.

* **Navigation update**:
  - Added a new navigation entry in `modules/ROOT/nav.adoc` to link to the `slack_users` input component documentation.

* **New documentation file**:
  - Created `modules/develop/pages/connect/components/inputs/slack_users.adoc` to document the `slack_users` input component. This file includes metadata, marks the page as beta, and references shared content using `include`.

## Page previews

[`slack_users` input](https://deploy-preview-266--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/slack_users/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1239]: https://redpandadata.atlassian.net/browse/DOC-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new documentation page for the Slack Users input component.
  - Updated navigation to include a link to the new Slack Users input component documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->