### PR TITLE
DOC-1191 publish upgrade policy

### DIFF
--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -32,7 +32,7 @@ During your defined maintenance window, Redpanda Cloud runs minor upgrades. Mino
 * Upgrade Redpanda to a fully backward-compatible version. 
 
 | Frequency
-| Frequent: minor upgrades could happen multiple times a day.
+| Minor upgrades could happen multiple times a day.
 
 | Communication
 | Prior communication happens only if necessary. +

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -9,13 +9,13 @@ Redpanda runs maintenance operations on clusters in a rolling fashion, accompani
 
 Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
 
-If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations commence during the maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
+If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations commence during your maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled for maintenance on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 
 == Minor upgrades
 
-Multiple minor upgrades could happen within the defined maintenance window. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+Multiple minor upgrades could happen within your defined maintenance window. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
 
 
 [cols="1,3"]
@@ -34,10 +34,10 @@ Multiple minor upgrades could happen within the defined maintenance window. Mino
 | Communication
 | Prior communication happens only if necessary. 
 
-There could be email notifications, updated documentation, release notes, or communication from Sales and Support.
+There could be email notifications, updated documentation, release notes, or communication from your Redpanda account team.
 
 | Timing
-| 100% at Redpanda's discretion within the maintenance window.
+| 100% at Redpanda's discretion within your defined maintenance window.
 |===
 
 == Major upgrades
@@ -62,7 +62,7 @@ A major upgrade could prevent use of the service without code or configuration c
 | Communication
 | Email notifications may be sent to registered users with details about the change and available options.
 
-There could be updated documentation, release notes, and communication from Sales and Support.
+There could be updated documentation, release notes, and communication from your Redpanda account team.
 
 | Timing
 | Major upgrades may be coordinated with customers, but the final date set by Redpanda is not negotiable.
@@ -90,7 +90,7 @@ If you depend on this service, the deprecation could prevent use of service.
 | Communication
 | Email notifications may be sent to registered users with details about the change and available alternatives.
 
-There could be updated documentation, release notes, and communication from Sales and Support.
+There could be updated documentation, release notes, and communication from your Redpanda account team.
 
 | Timing
 | 100% at Redpanda's discretion.

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -115,6 +115,6 @@ See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 |===
 | Deprecated in | Feature | Details
 
-| March, 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
-| February, 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
+| March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
+| February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
 |===

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -102,7 +102,7 @@ a|
 There could be updated documentation, release notes, and communication from your Redpanda account team.
 
 | Timing
-| 100% at Redpanda's discretion.
+| At Redpanda's discretion.
 |===
 
 See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -55,7 +55,7 @@ Major upgrades may require code changes to customer applications, such as Kafka 
 | Impact
 | Potentially large.
 
-Major upgrades could require code changes to customer applications or could problematically alter the performance profile. 
+Major upgrades could require code changes to customer applications or could affect the performance profile. 
 
 | Examples
 | * Upgrade Kafka to a version that is not fully backward-compatible with the previous version. +

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -13,4 +13,90 @@ If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operati
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled for maintenance on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 
+== Minor upgrades
+
+During your maintenance window, Redpanda Cloud runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+
+[cols="1,3"]
+|===
+| Impact
+| Minimal
+
+| Examples
+| * Redpanda cluster roll +
+* Upgrade Redpanda to a fully backward-compatible version +
+* Add new features
+
+| Frequency
+| Minor upgrades could happen multiple times each day.
+
+| Communication
+| Prior communication happens only if necessary. 
+
+There could be email notifications, updated documentation, release notes, or communication from Sales and Support.
+
+| Timing
+| 100% at Redpanda's discretion within the maintenance window.
+|===
+
+== Major upgrades
+
+Major upgrades require code changes to customer applications, such as Kafka clients, and API integrations.
+
+[cols="1,3"]
+|===
+| Impact
+| Large
+
+A major upgrade could prevent use of the service without code or configuration changes, or it could problematically alter the performance profile.
+
+| Examples
+| * Upgrade Kafka to a version that is not fully backward-compatible with the previous version +
+* Update an API version +
+* Security update that materially changes cluster or client throughput
+
+| Frequency
+| Approximately three times per year to coincide with major releases of Redpanda, and at least once per year for Kubernetes upgrades.
+
+| Communication
+| Guaranteed
+
+Multiple email notifications are sent to all registered users—starting at least 180 days before the upgrade date—with details about the change and available options.
+
+There could be updated documentation, release notes, and communication from Sales and Support.
+
+| Timing
+| Major upgrades may be coordinated with customers, but the final date set by Redpanda is not negotiable.
+|===
+
+== Deprecations
+
+Deprecations include any removal of customer-usable functionality from Redpanda Cloud services. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
+
+[cols="1,3"]
+|===
+| Impact
+| Potentially large
+
+If you depend on this service, the deprecation could prevent use of service.
+
+| Examples
+| * Remove a feature from the UI +
+  * Shut down an API version +
+  * Remove a connector as an option
+
+| Frequency
+| Rare
+
+| Communication
+| Guaranteed
+
+Multiple email notifications are sent to all registered users—starting at least 180 days before the deprecation date—with details about the change and available alternatives.
+
+There could be updated documentation, release notes, and communication from Sales and Support.
+
+| Timing
+| 100% at Redpanda's discretion.
+|===
+
 See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -40,7 +40,7 @@ During your defined maintenance window, Redpanda Cloud runs minor upgrades. Mino
 There could be email notifications, updated documentation, release notes, or communication from your Redpanda account team.
 
 | Timing
-| 100% at Redpanda's discretion during your defined maintenance window.
+| At Redpanda's discretion during your defined maintenance window.
 |===
 
 == Major upgrades

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -27,7 +27,8 @@ During your defined maintenance window, Redpanda Cloud runs minor upgrades. Mino
 | Minimal.
 
 | Examples
-| * Patches to known issues. +
+a|
+* Patches to known issues. +
 * Cluster rolling restart.  +
 * Upgrade Redpanda to a fully backward-compatible version. 
 
@@ -55,11 +56,10 @@ Major upgrades may require code changes to customer applications, such as Kafka 
 | Impact
 | Potentially large.
 
-Major upgrades could require code changes to customer applications or could affect the performance profile. 
-
 | Examples
-| * Upgrade Kafka to a version that is not fully backward-compatible with the previous version. +
-* Update an API version. +
+a|
+* Upgrade Kafka to a version that is not fully backward-compatible with the previous version.
+* Update an API version.
 * Security update that materially changes cluster or client throughput.
 
 | Frequency
@@ -76,7 +76,8 @@ There could be updated documentation, release notes, and communication from your
 
 == Deprecations
 
-Deprecations indicate future removal of customer-usable functionality from Redpanda Cloud services. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
+Deprecations indicate future removal of features that you can currently use. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
+
 
 [cols="1,4", options="header"]
 |===
@@ -87,9 +88,10 @@ Deprecations indicate future removal of customer-usable functionality from Redpa
 | Potentially large, if you depend on the feature being deprecated.
 
 | Examples
-| * Remove a feature from the UI. +
-  * Shut down an API version. +
-  * Remove a connector as an option.
+a|
+* Remove a feature from the UI. +
+* Shut down an API version. +
+* Remove a connector as an option.
 
 | Frequency
 | Rare.
@@ -109,7 +111,7 @@ See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 === Deprecated features
 
 
-[cols="1,2,3"]
+[cols="1,2,3", options="header"]
 |===
 | Deprecated in | Feature | Details
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -21,12 +21,12 @@ Multiple minor upgrades could happen within your defined maintenance window. Min
 [cols="1,3"]
 |===
 | Impact
-| Minimal
+| Minimal.
 
 | Examples
-| New features +
-* Cluster rolling restart  +
-* Upgrade Redpanda to a fully backward-compatible version +
+| * Patches to known issues. +
+* Cluster rolling restart.  +
+* Upgrade Redpanda to a fully backward-compatible version. +
 
 | Frequency
 | Frequent: minor upgrades could happen multiple times a day.
@@ -47,17 +47,17 @@ Major upgrades may require code changes to customer applications, such as Kafka 
 [cols="1,3"]
 |===
 | Impact
-| Large
+| Potentially large.
 
-A major upgrade could prevent use of the service without code or configuration changes, or it could problematically alter the performance profile. 
+Major upgrades could require code changes to customer applications or could problematically alter the performance profile. 
 
 | Examples
-| * Upgrade Kafka to a version that is not fully backward-compatible with the previous version +
-* Update an API version +
-* Security update that materially changes cluster or client throughput
+| * Upgrade Kafka to a version that is not fully backward-compatible with the previous version. +
+* Update an API version. +
+* Security update that materially changes cluster or client throughput.
 
 | Frequency
-| Approximately three times a year to coincide with major releases of Redpanda, and at least once a year for Kubernetes upgrades.
+| Rare.
 
 | Communication
 | Email notifications may be sent to registered users with details about the change and available options.
@@ -78,9 +78,9 @@ Deprecations indicate future removal of customer-usable functionality from Redpa
 | Potentially large, if you depend on the feature being deprecated.
 
 | Examples
-| * Remove a feature from the UI +
-  * Shut down an API version +
-  * Remove a connector as an option
+| * Remove a feature from the UI. +
+  * Shut down an API version. +
+  * Remove a connector as an option.
 
 | Frequency
 | Rare

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -70,7 +70,7 @@ There could be updated documentation, release notes, and communication from your
 
 == Deprecations
 
-Deprecations include any removal of customer-usable functionality from Redpanda Cloud services. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
+Deprecations indicate future removal of customer-usable functionality from Redpanda Cloud services. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
 
 [cols="1,3"]
 |===

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -95,3 +95,16 @@ There could be updated documentation, release notes, and communication from your
 |===
 
 See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
+
+=== Deprecated features
+
+
+[cols="1,2,3"]
+|===
+| Deprecated in | Feature | Details
+
+| March, 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
+| February, 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
+|===
+
+See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -24,12 +24,12 @@ Multiple minor upgrades could happen within your defined maintenance window. Min
 | Minimal
 
 | Examples
-| * Cluster rolling restart  +
+| New features +
+* Cluster rolling restart  +
 * Upgrade Redpanda to a fully backward-compatible version +
-* Add new features
 
 | Frequency
-| Minor upgrades could happen multiple times each day.
+| Frequent: minor upgrades could happen multiple times a day.
 
 | Communication
 | Prior communication happens only if necessary. 
@@ -57,7 +57,7 @@ A major upgrade could prevent use of the service without code or configuration c
 * Security update that materially changes cluster or client throughput
 
 | Frequency
-| Approximately three times per year to coincide with major releases of Redpanda, and at least once per year for Kubernetes upgrades.
+| Approximately three times a year to coincide with major releases of Redpanda, and at least once a year for Kubernetes upgrades.
 
 | Communication
 | Email notifications may be sent to registered users with details about the change and available options.
@@ -75,9 +75,7 @@ Deprecations include any removal of customer-usable functionality from Redpanda 
 [cols="1,3"]
 |===
 | Impact
-| Potentially large
-
-If you depend on this service, the deprecation could prevent use of service.
+| Potentially large, if you depend on the feature being deprecated.
 
 | Examples
 | * Remove a feature from the UI +

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -9,13 +9,13 @@ Redpanda runs maintenance operations on clusters in a rolling fashion, accompani
 
 Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
 
-If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations commence during your maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
+If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during your maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 
 TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters scheduled for maintenance on Tuesdays are updated first, and clusters scheduled on Mondays are updated last. Keep this in mind when sequencing updates for multiple clusters.
 
 == Minor upgrades
 
-Multiple minor upgrades could happen within your defined maintenance window. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+During your defined maintenance window, Redpanda runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
 
 
 [cols="1,3"]
@@ -37,7 +37,7 @@ Multiple minor upgrades could happen within your defined maintenance window. Min
 There could be email notifications, updated documentation, release notes, or communication from your Redpanda account team.
 
 | Timing
-| 100% at Redpanda's discretion within your defined maintenance window.
+| 100% at Redpanda's discretion during your defined maintenance window.
 |===
 
 == Major upgrades

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -46,7 +46,7 @@ There could be email notifications, updated documentation, release notes, or com
 
 == Major upgrades
 
-Major upgrades may require code changes to customer applications, such as Kafka clients, and API integrations. 
+Major upgrades may require code changes to customer applications, such as Kafka clients or API integrations. 
 
 [cols="1,4", options="header"]
 |===

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -15,7 +15,8 @@ TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters schedu
 
 == Minor upgrades
 
-During your maintenance window, Redpanda Cloud may run minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+Multiple minor upgrades could happen within the defined maintenance window. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+
 
 [cols="1,3"]
 |===
@@ -23,7 +24,7 @@ During your maintenance window, Redpanda Cloud may run minor upgrades. Minor upg
 | Minimal
 
 | Examples
-| * Redpanda cluster roll +
+| * Cluster rolling restart  +
 * Upgrade Redpanda to a fully backward-compatible version +
 * Add new features
 
@@ -41,14 +42,14 @@ There could be email notifications, updated documentation, release notes, or com
 
 == Major upgrades
 
-Major upgrades require code changes to customer applications, such as Kafka clients, and API integrations.
+Major upgrades may require code changes to customer applications, such as Kafka clients, and API integrations. 
 
 [cols="1,3"]
 |===
 | Impact
 | Large
 
-A major upgrade could prevent use of the service without code or configuration changes, or it could problematically alter the performance profile.
+A major upgrade could prevent use of the service without code or configuration changes, or it could problematically alter the performance profile. 
 
 | Examples
 | * Upgrade Kafka to a version that is not fully backward-compatible with the previous version +
@@ -59,9 +60,7 @@ A major upgrade could prevent use of the service without code or configuration c
 | Approximately three times per year to coincide with major releases of Redpanda, and at least once per year for Kubernetes upgrades.
 
 | Communication
-| Guaranteed
-
-Multiple email notifications are sent to all registered users—starting at least 180 days before the upgrade date—with details about the change and available options.
+| Email notifications may be sent to registered users with details about the change and available options.
 
 There could be updated documentation, release notes, and communication from Sales and Support.
 
@@ -89,9 +88,7 @@ If you depend on this service, the deprecation could prevent use of service.
 | Rare
 
 | Communication
-| Guaranteed
-
-Multiple email notifications are sent to all registered users—starting at least 180 days before the deprecation date—with details about the change and available alternatives.
+| Email notifications may be sent to registered users with details about the change and available alternatives.
 
 There could be updated documentation, release notes, and communication from Sales and Support.
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -94,7 +94,6 @@ There could be updated documentation, release notes, and communication from your
 | 100% at Redpanda's discretion.
 |===
 
-See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 
 === Deprecated features
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -18,21 +18,24 @@ TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters schedu
 During your defined maintenance window, Redpanda Cloud runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
 
 
-[cols="1,3"]
+[cols="1,4", options="header"]
 |===
+| Category
+| Details
+
 | Impact
 | Minimal.
 
 | Examples
 | * Patches to known issues. +
 * Cluster rolling restart.  +
-* Upgrade Redpanda to a fully backward-compatible version. +
+* Upgrade Redpanda to a fully backward-compatible version. 
 
 | Frequency
 | Frequent: minor upgrades could happen multiple times a day.
 
 | Communication
-| Prior communication happens only if necessary. 
+| Prior communication happens only if necessary. +
 
 There could be email notifications, updated documentation, release notes, or communication from your Redpanda account team.
 
@@ -44,8 +47,11 @@ There could be email notifications, updated documentation, release notes, or com
 
 Major upgrades may require code changes to customer applications, such as Kafka clients, and API integrations. 
 
-[cols="1,3"]
+[cols="1,4", options="header"]
 |===
+| Category
+| Details
+
 | Impact
 | Potentially large.
 
@@ -60,7 +66,7 @@ Major upgrades could require code changes to customer applications or could prob
 | Rare.
 
 | Communication
-| Email notifications may be sent to registered users with details about the change and available options.
+| Email notifications may be sent to registered users with details about the change and available options. +
 
 There could be updated documentation, release notes, and communication from your Redpanda account team.
 
@@ -72,8 +78,11 @@ There could be updated documentation, release notes, and communication from your
 
 Deprecations indicate future removal of customer-usable functionality from Redpanda Cloud services. There is no guarantee of equivalent functionality in new versions. Deprecations could be included in major upgrades. 
 
-[cols="1,3"]
+[cols="1,4", options="header"]
 |===
+| Category
+| Details
+
 | Impact
 | Potentially large, if you depend on the feature being deprecated.
 
@@ -86,7 +95,7 @@ Deprecations indicate future removal of customer-usable functionality from Redpa
 | Rare.
 
 | Communication
-| Email notifications may be sent to registered users with details about the change and available alternatives.
+| Email notifications may be sent to registered users with details about the change and available alternatives. +
 
 There could be updated documentation, release notes, and communication from your Redpanda account team.
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -15,7 +15,7 @@ TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters schedu
 
 == Minor upgrades
 
-During your defined maintenance window, Redpanda runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+During your defined maintenance window, Redpanda Cloud runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
 
 
 [cols="1,3"]
@@ -83,7 +83,7 @@ Deprecations indicate future removal of customer-usable functionality from Redpa
   * Remove a connector as an option.
 
 | Frequency
-| Rare
+| Rare.
 
 | Communication
 | Email notifications may be sent to registered users with details about the change and available alternatives.
@@ -93,6 +93,8 @@ There could be updated documentation, release notes, and communication from your
 | Timing
 | 100% at Redpanda's discretion.
 |===
+
+See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 
 
 === Deprecated features
@@ -105,5 +107,3 @@ There could be updated documentation, release notes, and communication from your
 | March, 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
 | February, 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
 |===
-
-See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -7,7 +7,7 @@ Redpanda runs maintenance operations on clusters in a rolling fashion, accompani
 
 == Maintenance windows
 
-Redpanda Cloud may run maintenance operations on any day at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
+Redpanda Cloud may run maintenance operations on any day, at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
 
 If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during your maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -15,7 +15,7 @@ TIP: Redpanda Cloud maintenance cycles always start on Tuesdays. Clusters schedu
 
 == Minor upgrades
 
-During your maintenance window, Redpanda Cloud runs minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
+During your maintenance window, Redpanda Cloud may run minor upgrades. Minor upgrades include standard Redpanda state changes that clients handle gracefully, such as leader elections. 
 
 [cols="1,3"]
 |===


### PR DESCRIPTION
## Description
This pull request expands Redpanda Cloud maintenance documentation with detailed sections on minor upgrades, major upgrades, and deprecations, including their impact, frequency, communication protocols, and scheduling policies.

Resolves https://redpandadata.atlassian.net/browse/DOC-1191
Review deadline: April 30

## Page previews
[Upgrades and Maintenance](https://deploy-preview-267--rp-cloud.netlify.app/redpanda-cloud/manage/maintenance/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

@coderabbitai pause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Expanded maintenance documentation with detailed sections on minor upgrades, major upgrades, and deprecations, including their impact, frequency, communication protocols, and scheduling policies.
	- Added a new table listing deprecated features scheduled for early 2025, with upgrade instructions and impact details.
	- Clarified maintenance window descriptions to specify that operations start within the window but may complete afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->