### PR TITLE
DOC-1270 Remove beta flag from redpanda input

### DIFF
--- a/modules/develop/pages/connect/components/inputs/redpanda.adoc
+++ b/modules/develop/pages/connect/components/inputs/redpanda.adoc
@@ -1,5 +1,4 @@
 = redpanda
 :page-aliases: components:inputs/redpanda.adoc
-:page-beta: true
 
 include::redpanda-connect:components:inputs/redpanda.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1270](https://redpandadata.atlassian.net/browse/DOC-1270)
Review deadline: 25th April

Removes beta status.

## Page previews

[`redpanda` input](https://deploy-preview-272--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/inputs/redpanda/)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)

[DOC-1270]: https://redpandadata.atlassian.net/browse/DOC-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove the beta label from the relevant page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->