### PR TITLE
DOC-1277 Serverless scale to zero

### DIFF
--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -19,7 +19,8 @@ Pricing for Serverless clusters depends on the data in, data out, data stored, p
 | Uptime | Tracks the number of hours the instance is running.    
 
 | Uptime | Tracks the number of hours the instance is running. +
-NOTE: Uptime is not charged if partitions = 0 and storage = 0. This condition is met when deleting all topics.
+
+*NOTE*: Uptime is not charged if partitions = 0 and storage = 0. This condition is met when all topics are deleted.
 
 | Ingress | Tracks the data written into Redpanda (in GB).
 

--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -18,7 +18,8 @@ Pricing for Serverless clusters depends on the data in, data out, data stored, p
 
 | Uptime | Tracks the number of hours the instance is running.    
 
-*NOTE*: Uptime is not charged if partitions = 0 and storage = 0.
+| Uptime | Tracks the number of hours the instance is running. +
+NOTE: Uptime is not charged if partitions = 0 and storage = 0. This condition is met when deleting all topics.
 
 | Ingress | Tracks the data written into Redpanda (in GB).
 

--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -18,6 +18,8 @@ Pricing for Serverless clusters depends on the data in, data out, data stored, p
 
 | Uptime | Tracks the number of hours the instance is running.    
 
+*NOTE*: Uptime is not charged if partitions = 0 and storage = 0.
+
 | Ingress | Tracks the data written into Redpanda (in GB).
 
 All Kafka protocol requests (_except_ message headers) are counted as ingress as soon as they are read by Redpanda's proxy process. 


### PR DESCRIPTION
## Description
This pull request introduces a clarification to the billing documentation for Serverless clusters. The change specifies that uptime is not charged when both partitions and storage are zero.

* [`modules/billing/pages/billing.adoc`](diffhunk://#diff-e1d4caca64cf7059e6701065a142427ca0abb3f361c8346f58ad114b396b5fd5R21-R22): Added a note clarifying that uptime charges are waived if `partitions = 0` and `storage = 0`.

Resolves https://redpandadata.atlassian.net/browse/DOC-1277
Review deadline: April 29

## Page previews
[Serverless metrics](https://deploy-preview-277--rp-cloud.netlify.app/redpanda-cloud/billing/billing/#serverless-metrics)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)