### PR TITLE
DOC-1283 add rpk to config-cluster.adoc

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -241,7 +241,6 @@ Redpanda Cloud deployments do not support the following functionality available 
 - Kubernetes Helm chart and Redpanda Operator functionality.
 - The following `rpk` commands:
  
-** `rpk cluster config`
 ** `rpk cluster health`
 ** `rpk cluster license`
 ** `rpk cluster maintenance`

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -21,7 +21,7 @@ Iceberg topics are supported for BYOC clusters in AWS and GCP.
 
 === Cluster configuration
 
-You can now xref:manage:cluster-maintenance/config-cluster.adoc[configure certain cluster properties] with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
+You can now xref:manage:cluster-maintenance/config-cluster.adoc[configure certain cluster properties] with `rpk` or the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 Iceberg topics properties are available for clusters running Redpanda version 25.1 or later. 
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -21,7 +21,7 @@ Iceberg topics are supported for BYOC clusters in AWS and GCP.
 
 === Cluster configuration
 
-You can now xref:manage:cluster-maintenance/config-cluster.adoc[configure certain cluster properties] with `rpk` or the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
+You can now xref:manage:cluster-maintenance/config-cluster.adoc[configure certain cluster properties] with `rpk cluster config` or with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 Iceberg topics properties are available for clusters running Redpanda version 25.1 or later. 
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -1,20 +1,27 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties to enable and manage features.
 
-Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. When you create or edit a cluster, you can set certain cluster configuration properties with `rpk cluster config` or with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
+Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. With cluster properties, you can enable and manage certain features, like xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
 
-For a complete list of the cluster configuration properties you can edit in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
+For a complete list of the cluster configuration properties you can set in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 == Limitations
 
-Cluster configuration with the Cloud API is supported on BYOC and Dedicated clusters running on AWS and GCP. 
+Cluster configuration is supported on BYOC and Dedicated clusters running on AWS and GCP. 
 
 - It is not available on Serverless clusters. 
 - It is not available on BYOC and Dedicated clusters running on Azure.
 
-== Set cluster properties with `rpk`
+== Set cluster configuration properties 
 
-Use `rpk cluster config` to set cluster properties. For example, to enable data transforms, set the `data_transforms_enabled` cluster property to `true`:
+[tabs]
+======
+`rpk`::
++
+--
+Use `rpk cluster config` to set cluster properties. 
+
+For example, to enable data transforms, set xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`:
 
 [source,bash]
 ----
@@ -29,15 +36,47 @@ rpk redpanda stop
 rpk redpanda start
 ----
 
-== Set cluster properties with the Cloud API
+--
+Cloud API::
++
+--
+Use the Cloud API to set cluster properties:
 
 * Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] request. Edit `cluster_configuration` in the request body with a key-value pair for `custom_properties`.
 
 * Update a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request, passing the cluster ID as a parameter. Include the properties to update in the request body.
 
-NOTE: Some properties require a cluster restart for updates to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
+For example, to set xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`:
+
+[source,bash]
+----
+# Store your cluster ID in a variable
+export RP_CLUSTER_ID=<cluster-id>
+
+# Retrieve a Redpanda Cloud access token
+export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
+    -H "content-type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=<client-id>" \
+    -d "client_secret=<client-secret>"`
+
+# Update cluster configuration to enable data transforms
+curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
+  "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
+ -H 'accept: application/json'\
+ -H 'content-type: application/json' \
+ -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
+----
+
+The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
+
+NOTE: You must restart your cluster if you change this configuration for a running cluster.
+
+--
+======
 
 == Suggested reading
 
+* xref:manage:rpk/intro-to-rpk.adoc[]
 * xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API Overview]
 * xref:manage:api/cloud-api-quickstart.adoc[Redpanda Cloud API Quickstart]

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -30,7 +30,7 @@ For example, to enable data transforms, set xref:reference:properties/cluster-pr
 rpk cluster config set data_transforms_enabled true
 ----
 
-NOTE: Some properties require a rolling restart, and it can take several minutes for the update to take effect. The `rpk cluster config set` command returns the operation ID.  
+NOTE: Some properties require a rolling restart, and it can take several minutes for the update to complete. The `rpk cluster config set` command returns the operation ID.  
 
 
 --

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -1,9 +1,9 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties to enable and manage features.
 
-Cluster configuration properties are set to their default values and automatically replicated across all brokers. You can use them to enable and manage features such as xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging].
+Cluster configuration properties are set to their default values and automatically replicated across all brokers. You can use cluster properties to enable and manage features such as xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging].
 
-For a complete list of the cluster configuration properties you can set in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
+For a complete list of the cluster properties you can set in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 == Limitations
 
@@ -14,6 +14,7 @@ Cluster configuration is supported on BYOC and Dedicated clusters running on AWS
 
 == Set cluster configuration properties 
 
+Set cluster configuration properties using the `rpk` command-line tool or the Cloud API.
 
 [tabs]
 ======
@@ -29,13 +30,7 @@ For example, to enable data transforms, set xref:reference:properties/cluster-pr
 rpk cluster config set data_transforms_enabled true
 ----
 
-Some properties require a cluster restart for updates to take effect. To restart all brokers, run:
-
-[source,bash]
-----
-rpk redpanda stop
-rpk redpanda start
-----
+NOTE: The `rpk cluster config set` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
 
 --
 Cloud API::
@@ -71,7 +66,6 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 
 The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
 
-NOTE: You must restart your cluster if you change this configuration for a running cluster.
 
 --
 ======

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -65,7 +65,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
  -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
 ----
 
-The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
+The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
 
 NOTE: Some properties require a rolling restart for the update to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -49,7 +49,7 @@ For example, to set xref:reference:properties/cluster-properties.adoc#data_trans
 # Store your cluster ID in a variable
 export RP_CLUSTER_ID=<cluster-id>
 
-# Retrieve a Redpanda Cloud access token
+# Retrieve a Redpanda Cloud access token.
 export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
     -H "content-type: application/x-www-form-urlencoded" \
     -d "grant_type=client_credentials" \

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -14,7 +14,7 @@ Cluster configuration is supported on BYOC and Dedicated clusters running on AWS
 
 == Set cluster configuration properties 
 
-Set cluster configuration properties using the `rpk` command-line tool or the Cloud API.
+You can set cluster configuration properties using the `rpk` command-line tool or the Cloud API.
 
 [tabs]
 ======

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -1,7 +1,9 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties to enable and manage features.
 
-Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. You can edit certain cluster configuration properties with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
+Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. When you create or edit a cluster, you can set certain cluster configuration properties with `rpk cluster config` or with the Cloud API. For example, you can enable and manage xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
+
+For a complete list of the cluster configuration properties you can edit in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 == Limitations
 
@@ -10,15 +12,28 @@ Cluster configuration with the Cloud API is supported on BYOC and Dedicated clus
 - It is not available on Serverless clusters. 
 - It is not available on BYOC and Dedicated clusters running on Azure.
 
-== Set cluster configuration properties
+== Set cluster properties with `rpk`
 
-You can set cluster configuration properties when you create a cluster, or you can edit an existing cluster.
+Use `rpk cluster config` to set cluster properties. For example, to enable data transforms, set the `data_transforms_enabled` cluster property to `true`:
+
+[source,bash]
+----
+rpk cluster config set data_transforms_enabled true
+----
+
+Some properties require a cluster restart for updates to take effect. To restart all brokers, run:
+
+[source,bash]
+----
+rpk redpanda stop
+rpk redpanda start
+----
+
+== Set cluster properties with the Cloud API
 
 * Create a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] request. Edit `cluster_configuration` in the request body with a key-value pair for `custom_properties`.
 
 * Update a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request, passing the cluster ID as a parameter. Include the properties to update in the request body.
-
-For a complete list of the cluster configuration properties you can edit in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
 NOTE: Some properties require a cluster restart for updates to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -1,7 +1,7 @@
 = Configure Cluster Properties
 :description: Learn how to configure cluster properties to enable and manage features.
 
-Redpanda cluster configuration properties are automatically set to the default values and are replicated across all brokers. With cluster properties, you can enable and manage certain features, like xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging]. 
+Cluster configuration properties are set to their default values and automatically replicated across all brokers. You can use them to enable and manage features such as xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics], xref:develop:data-transforms/index.adoc[data transforms], and xref:manage:audit-logging.adoc[audit logging].
 
 For a complete list of the cluster configuration properties you can set in Redpanda Cloud, see xref:reference:properties/cluster-properties.adoc[Cluster Configuration Properties].
 
@@ -13,6 +13,7 @@ Cluster configuration is supported on BYOC and Dedicated clusters running on AWS
 - It is not available on BYOC and Dedicated clusters running on Azure.
 
 == Set cluster configuration properties 
+
 
 [tabs]
 ======

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -56,7 +56,7 @@ export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/t
     -d "client_id=<client-id>" \
     -d "client_secret=<client-secret>"`
 
-# Update cluster configuration to enable data transforms
+# Update your cluster configuration to enable data transforms.
 curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
   "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
  -H 'accept: application/json'\

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -30,7 +30,8 @@ For example, to enable data transforms, set xref:reference:properties/cluster-pr
 rpk cluster config set data_transforms_enabled true
 ----
 
-NOTE: The `rpk cluster config set` command returns the operation ID. Cluster configuration operations can take up to ten minutes to complete. 
+NOTE: Some properties require a rolling restart, and it can take several minutes for the update to take effect. The `rpk cluster config set` command returns the operation ID.  
+
 
 --
 Cloud API::
@@ -66,6 +67,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 
 The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. The operation may take up to ten minutes to complete. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
 
+NOTE: Some properties require a rolling restart for the update to take effect. This triggers a xref:manage:api/cloud-byoc-controlplane-api.adoc#lro[long-running operation] that can take several minutes to complete.
 
 --
 ======

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -46,7 +46,7 @@ For example, to set xref:reference:properties/cluster-properties.adoc#data_trans
 
 [source,bash]
 ----
-# Store your cluster ID in a variable
+# Store your cluster ID in a variable.
 export RP_CLUSTER_ID=<cluster-id>
 
 # Retrieve a Redpanda Cloud access token.


### PR DESCRIPTION
## Description
This pull request adds `rpk cluster config` for configuring cluster properties. It also updates the What's New blurb to add `rpk` and removes `rpk cluster config` from the list of unsupported commands in Cloud.

### Clarifications on unsupported features:
* Updated the list of unsupported `rpk` commands in Redpanda Cloud deployments, removing `rpk cluster config` from the list of unsupported commands. (`modules/get-started/pages/cloud-overview.adoc`, [modules/get-started/pages/cloud-overview.adocL244](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL244))

### Enhancements to cluster configuration documentation:
* Refined the explanation of cluster configuration properties, linking to a complete list of configurable properties. (`modules/manage/pages/cluster-maintenance/config-cluster.adoc`, [modules/manage/pages/cluster-maintenance/config-cluster.adocL4-R75](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL4-R75))
* Added tabs for `rpk` and Cloud API, with detailed instructions for setting cluster properties using `rpk`, including an example for enabling data transforms with `rpk cluster config set`. (`modules/manage/pages/cluster-maintenance/config-cluster.adoc`, [modules/manage/pages/cluster-maintenance/config-cluster.adocL4-R75](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL4-R75))

Resolves https://redpandadata.atlassian.net/browse/DOC-1283
Review deadline:

## Page previews
[Configure Cluster Properties](https://deploy-preview-278--rp-cloud.netlify.app/redpanda-cloud/manage/cluster-maintenance/config-cluster/)
[Redpanda Cloud vs Self-Managed feature compatibility](https://deploy-preview-278--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-cloud-vs-self-managed-feature-compatibility)
[What's New](https://deploy-preview-278--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#cluster-configuration)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Clarified and restructured instructions for configuring Redpanda cluster properties, including a new tabbed interface for CLI and API methods.
	- Expanded step-by-step guidance for setting properties using both the `rpk` CLI and the Cloud API, with detailed examples and operational notes.
	- Updated documentation to indicate that certain cluster properties can now be configured using the `rpk` CLI in addition to the Cloud API.
	- Adjusted the list of unsupported `rpk` commands in Redpanda Cloud, removing `rpk cluster config` from the unsupported list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->