### PR TITLE
Enable mTLS and SASL (GCP)

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,12 @@ This page lists new features added in Redpanda Cloud.
 
 == April 2025
 
+=== mTLS and SASL authentication for Kafka API on GCP
+
+You can now enable mTLS and SASL authentication simultaneously for the Kafka API on GCP clusters. If you enable both mTLS and SASL on GCP clusters, Redpanda creates two distinct listeners: an mTLS listener operating on one port and a SASL listener operating on a different port.
+
+See xref:security:cloud-authentication.adoc#service-authentication[Authentication] for details on available authentication methods in Redpanda Cloud.
+
 === Increased number of supported partitions
 
 The number of partitions (pre-replication) Redpanda Cloud supports for each xref:reference:tiers/index.adoc[usage tier] has been doubled. For example, the number of supported partitions in tier 1 went from 1,000 to 2,000, and tier 5 went from 22,800 to 45,600.   

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -68,7 +68,7 @@ Each Redpanda Cloud data plane runs its own dedicated agent,
 which authenticates and connects against the control plane over a single TLS 1.2
 encrypted TCP connection.
 
-Different Redpanda APIs support different authentication methods. For GCP, you can simultaneously enable mTLS and SASL. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener are created each on separate ports.
+Different Redpanda APIs support different authentication methods. For GCP, you can simultaneously enable mTLS and SASL for Kafka API, and mTLS and Basic authentication for the HTTP APIs (HTTP Proxy and Schema Registry). If you enable both mTLS and SASL on GCP clusters, Redpanda creates two distinct listeners: an mTLS listener operating on one port and a SASL listener operating on a different port.
 
 .Redpanda APIs authentication methods
 [%collapsible]
@@ -186,10 +186,19 @@ AUTH_TOKEN=`curl -s --request POST \
     --data client_secret=<client-secret> \
     --data audience=cloudv2-production.redpanda.cloud | jq -r .access_token`
 ----
++
 Make sure to replace the following variables:
++
+[cols="1,1"]
+|===
+|Placeholder variable |Description
 
-* `<client-id>`: Client ID.
-* `<client-secret>`: Client secret.
+|`<client-id>`
+|Client ID.
+
+|`<client-secret>`
+|Client secret.
+|===
 
 [[mtls]]
 === Enable mTLS authentication
@@ -237,26 +246,50 @@ curl -v -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
-====
 
 Make sure to replace the following variables:
 
-* `<cluster-id>`: ID of the Redpanda cluster.
-* `<cluster-name>`: Name of the Redpanda cluster.
-* `<resource-group-id>`: ID of the resource group.
-* `<network-id>`: ID of the network.
-* `<region>`: The region where the cluster is created. For example, `us-central1`.
-* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
-* `<tier>`: The usage tier of the cluster. For example, .
-* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
-* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
-* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
-+
+[cols="1,1"]
+|===
+|Placeholder variable |Description
+
+|`<cluster-id>`
+|ID of the Redpanda cluster.
+
+|`<cluster-name>`
+|Name of the Redpanda cluster.
+
+|`<resource-group-id>`
+|ID of the resource group.
+
+|`<network-id>`
+|ID of the network.
+
+|`<region>`
+|The region where the cluster is created. For example, `us-central1`.
+
+|`<zones>`
+|The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
+
+|`<tier>`
+|The usage tier of the cluster. For example, .
+
+|`<cluster-type>`
+|The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
+
+|`<ca-certificate-pem>`
+|A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+
+|`<principal-mapping-rule>`
+a|Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
+
 For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
-+
+
 `Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
-+
+
 See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+|===
+====
 
 The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
 
@@ -294,19 +327,29 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
-====
 
 Make sure to replace the following variables:
 
-* `<cluster-id>`: ID of Redpanda cluster.
-* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
-* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
-+
+[cols="1,1"]
+|===
+|Placeholder variable |Description
+
+|`<cluster-id>`
+|ID of Redpanda cluster.
+
+|`<ca-certificate-pem>`
+|A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+
+|`<principal-mapping-rule>`
+a|Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
+
 For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
-+
+
 `Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
-+
+
 See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+|===
+====
 
 The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
 
@@ -384,26 +427,50 @@ curl -v -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
-====
 
 Make sure to replace the following variables:
 
-* `<cluster-id>`: ID of Redpanda cluster.
-* `<cluster-name>`: Name of the Redpanda cluster.
-* `<resource-group-id>`: ID of the resource group.
-* `<network-id>`: ID of the network.
-* `<region>`: The region where the cluster is created. For example, `us-central1`.
-* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
-* `<tier>`: The usage tier of the cluster. For example, .
-* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
-* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
-* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
-+
+[cols="1,1"]
+|===
+|Placeholder variable |Description
+
+|`<cluster-id>`
+|ID of Redpanda cluster.
+
+|`<cluster-name>`
+|Name of the Redpanda cluster.
+
+|`<resource-group-id>`
+|ID of the resource group.
+
+|`<network-id>`
+|ID of the network.
+
+|`<region>`
+|The region where the cluster is created. For example, `us-central1`.
+
+|`<zones>`
+|The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
+
+|`<tier>`
+|The usage tier of the cluster. For example, .
+
+|`<cluster-type>`
+|The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
+
+|`<ca-certificate-pem>`
+|A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+
+|`<principal-mapping-rule>`
+a|Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
+
 For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
-+
+
 `Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
-+
+
 See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+|===
+====
 
 The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
 
@@ -413,6 +480,8 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 ----
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
+
+NOTE: If you enable mTLS only, you cannot disable it later.
 
 ==== Update an existing cluster to use mTLS and SASL
 
@@ -462,19 +531,29 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
-====
 
 Make sure to replace the following variables:
 
-* `<cluster-id>`: ID of Redpanda cluster.
-* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
-* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
-+
+[cols="1,1"]
+|===
+|Placeholder variable |Description
+
+|`<cluster-id>`
+|ID of Redpanda cluster.
+
+|`<ca-certificate-pem>`
+|A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+
+|`<principal-mapping-rule>`
+a|Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
+
 For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
-+
+
 `Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
-+
+
 See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+|===
+====
 
 The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
 
@@ -484,6 +563,31 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 ----
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
+
+==== Update an existing cluster to disable SASL
+
+If you enabled mTLS and SASL on a cluster, you can disable SASL by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request:
+
+.Show example request
+[%collapsible]
+====
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+  "kafka_api": {
+     "sasl": {
+        "enabled": false
+     }
+  }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+====
 
 === Retrieve API endpoints
 
@@ -572,6 +676,17 @@ curl -u test:12345 -k --cert cert.pem --key key.pem -H "Content-Type: applicatio
 # Schema Registry
 curl -u test:12345 -k --cert cert.pem --key key.pem https://schema-registry-15d24f32.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30081/subjects/Kafka-value/versions/1
 ----
+
+=== Verify SASL
+
+To verify that SASL is enabled for Kafka API, run the following `rpk` command:
+
+[,bash]
+----
+rpk topic create test-topic --tls-enabled --user <username> --password <password>
+----
+
+The command should succeed, and you should be able to create a topic named `test-topic`.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -152,13 +152,21 @@ least privilege.
 
 Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry.
 
-When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled with SASL by default. If you want to enable mTLS, or both mTLS and SASL for GCP clusters only, you must use the Cloud API to create the cluster or update an existing cluster.
+When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled by default with SASL for Kafka API,  and Basic authentication for HTTP Proxy and Schema Registry.
 
 === Requirements
 
-To configure service authentication in your cluster, you must have the following:
+NOTE: mTLS authentication is supported on AWS and GCP clusters only.
 
-// version?
+If you want to enable mTLS authentication:
+
+* You must use the Cloud API to create a new mTLS-enabled cluster. 
+* You must also use the Cloud API to update an existing cluster to switch to mTLS authentication for Kafka API.
+* You can use the Cloud UI to update an existing cluster to switch to mTLS authentication for HTTP Proxy and Schema Registry only.
+* To enable mTLS and SASL (or Basic authentication) simultaneously on GCP clusters, you must use the Cloud API to create a new cluster or update an existing cluster.
+
+To configure service authentication in your cluster using the Cloud API, you must have the following:
+
 * A service account in your Redpanda organization. You must have administrative privileges to create a service account.
 * Access to the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS or both SASL and mTLS. You use the service account to obtain an access token. You then make a request to the Control Plane API, passing the access token in the authorization header.
 
@@ -194,8 +202,10 @@ For clusters with mTLS authentication, Redpanda creates a dedicated mTLS-enabled
 . Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already. You'll need the resource group ID and network ID to create a cluster in the next step.
 
 . Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with mTLS enabled.
-+
-.Show example request
+
+NOTE: The following example enables mTLS for Kafka API. To enable mTLS for HTTP Proxy and Schema Registry, add the `http_proxy.mtls` and `schema_registry.mtls` fields to the request body. You can choose to enable mTLS for any combination of the three services.
+
+.Show example request to enable mTLS for Kafka API
 [%collapsible]
 ====
 [,bash,lines=13-19,%collapsible]
@@ -261,7 +271,7 @@ When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS 
 
 Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
 
-The following code block shows a request to enable mTLS:
+The following code block shows a request to enable mTLS for Kafka API. To enable mTLS for HTTP Proxy and Schema Registry, add the `http_proxy.mtls` and `schema_registry.mtls` fields to the request body:
 
 .Show example request
 [%collapsible]
@@ -311,18 +321,20 @@ When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS 
 
 NOTE: Enabling mTLS and SASL simultaneously is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
 
+You can choose to enable mTLS and SASL simultaneously for the Kafka API, and mTLS and Basic authentication for HTTP Proxy and Schema Registry. The `sasl` field in the API request examples toggle both SASL and Basic authentication. 
+
 ==== Create a new cluster with both mTLS and SASL enabled
 
 . Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with both mTLS and SASL enabled.
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with both mTLS and SASL or Basic authentication enabled.
 +
-You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
+You can enable mTLS and SASL or Basic authentication for any combination of the three services. For example, if you want to enable mTLS and SASL simultaneously for Kafka API and mTLS and Basic authentication simultaneously for Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for Kafka API, and mTLS and Basic authentication for HTTP Proxy and Schema Registry, leave out the `kafka_api.sasl` field.
 +
 .Show example request
 [%collapsible]
 ====
-[,bash,lines=13+23+33]
+[,bash,lines=13+23+32]
 ----
 CLUSTER_CREATE_BODY=`cat << EOF
 {
@@ -349,8 +361,7 @@ CLUSTER_CREATE_BODY=`cat << EOF
     "http_proxy": {
        "mtls": {
           "enabled": true,
-          "ca_certificates_pem": ["<ca-certificate-pem>"],
-          "principal_mapping_rules": ["<principal-mapping-rule>"]
+          "ca_certificates_pem": ["<ca-certificate-pem>"]
        },
        "sasl": {
           "enabled": true
@@ -359,8 +370,7 @@ CLUSTER_CREATE_BODY=`cat << EOF
     "schema_registry": {
        "mtls": {
           "enabled": true,
-          "ca_certificates_pem": ["<ca-certificate-pem>"],
-          "principal_mapping_rules": ["<principal-mapping-rule>"]
+          "ca_certificates_pem": ["<ca-certificate-pem>"]
        },
        "sasl": {
           "enabled": true
@@ -408,12 +418,12 @@ When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS 
 
 Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS and SASL on an existing cluster.
 
-You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
+You can choose to enable mTLS and SASL or Basic authentication for any combination of the three services. For example, if you want to enable mTLS and SASL simultaneously for Kafka API and mTLS and Basic authentication simultaneously for Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for Kafka API, and mTLS and Basic authentication for HTTP Proxy and Schema Registry, leave out the `kafka_api.sasl` field.
 
 .Show example request
 [%collapsible]
 ====
-[,bash,lines=3+13+23]
+[,bash,lines=3+13+22]
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
 {
@@ -430,8 +440,7 @@ CLUSTER_PATCH_BODY=`cat << EOF
   "schema_registry": {
      "mtls": {
         "enabled": true,
-        "ca_certificates_pem": ["<ca-certificate-pem>"],
-        "principal_mapping_rules": ["<principal-mapping-rule>"]
+        "ca_certificates_pem": ["<ca-certificate-pem>"]
      },
      "sasl": {
         "enabled": true
@@ -440,8 +449,7 @@ CLUSTER_PATCH_BODY=`cat << EOF
   "http_proxy": {
      "mtls": {
         "enabled": true,
-        "ca_certificates_pem": ["<ca-certificate-pem>"],
-        "principal_mapping_rules": ["<principal-mapping-rule>"]
+        "ca_certificates_pem": ["<ca-certificate-pem>"]
      },
      "sasl": {
         "enabled": true
@@ -554,15 +562,15 @@ curl -u $USERNAME:$PASSWORD -k -H "Content-Type: application/vnd.schemaregistry.
 
 You should get an error indicating that the certificate is required.
 
-To successfully connect to the HTTP Proxy and Schema Registry, you must provide a client certificate and private key. The following cURL commands show example requests to mTLS-enabled endpoints using `test` as the username and `12345` as the password.
+To successfully connect to the HTTP Proxy and Schema Registry, you must provide a client certificate and private key. The following `curl` commands show example requests to mTLS-enabled endpoints using `test` as the username and `12345` as the password.
 
 [,bash]
 ----
 # HTTP Proxy
-curl -u test:12345 -k --cert $CERT_FILE --key $PRIVATE_KEY_FILE -H "Content-Type: application/vnd.kafka.json.v2+json" --sslv2 --http2 https://pandaproxy-45f811b1.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30082/topics
+curl -u test:12345 -k --cert cert.pem --key key.pem -H "Content-Type: application/vnd.kafka.json.v2+json" --sslv2 --http2 https://pandaproxy-45f811b1.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30082/topics
 
 # Schema Registry
-curl -u test:12345 -k --cert $CERT_FILE --key $CERT_FILE https://schema-registry-15d24f32.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30081/subjects/Kafka-value/versions/1
+curl -u test:12345 -k --cert cert.pem --key key.pem https://schema-registry-15d24f32.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30081/subjects/Kafka-value/versions/1
 ----
 
 include::shared:partial$suggested-reading.adoc[]

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -206,7 +206,7 @@ Make sure to replace the following variables:
 
 For clusters with mTLS authentication, Redpanda creates a dedicated mTLS-enabled listener for each API service (Kafka API, HTTP Proxy, or Schema Registry) where you've enabled this authentication method. After you enable mTLS, <<retrieve-api-endpoints,get the API endpoints>> and <<verify-mtls,verify that mTLS authentication is in effect>>. 
 
-NOTE: If you enable mTLS only, you cannot disable it later.
+NOTE: If you enable mTLS authentication, you cannot disable it later.
 
 ==== Create a new cluster with mTLS enabled
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -68,12 +68,67 @@ Each Redpanda Cloud data plane runs its own dedicated agent,
 which authenticates and connects against the control plane over a single TLS 1.2
 encrypted TCP connection.
 
-Redpanda Cloud enables SASL/SCRAM authentication
+Different Redpanda APIs support different authentication methods. You can configure a listener with an authentication method for each API. For GCP, you can simultaneously enable mTLS and SASL for multi-protocol authentication. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener on separate ports are created.
+
+.Redpanda APIs authentication methods
+[%collapsible]
+|===
+|Cloud provider |API |Supported authentication methods
+
+.3+|AWS
+|Kafka API
+a|
+* mTLS only
+* SASL only
+
+
+|HTTP Proxy
+|
+
+|Schema Registry
+|
+
+.3+|GCP
+|Kafka API
+a|
+* mTLS only
+* SASL only
+* Multi-protocol (SASL + mTLS)
+
+|HTTP Proxy
+a|
+* mTLS only
+* SASL only
+* Multi-protocol (SASL + mTLS)
+
+|Schema Registry
+a|
+* mTLS only
+* SASL only
+* Multi-protocol (SASL + mTLS)
+
+.3+|Azure
+|Kafka API
+a|
+* mTLS only
+* SASL only
+
+
+|HTTP Proxy
+|
+
+|Schema Registry
+|
+|===
+
+* Kafka API: Redpanda Cloud enables SASL/SCRAM authentication
 over TLS 1.2 as well as <<mtls,mTLS>> to authenticate Kafka clients connecting to Redpanda clusters over
 the TCP endpoint or listener.
 
-When connecting through Redpanda's HTTP Proxy, authentication is done through an
+* HTTP Proxy: Authentication is done through an
 HTTP Basic Authentication header encrypted over TLS 1.2.
+
+* Schema Registry:
 
 The following features use IAM policies to generate
 dynamic and short-lived credentials to interact with cloud provider APIs:
@@ -87,105 +142,17 @@ xref:security:authorization/cloud-iam-policies.adoc[IAM policies] have constrain
 access or manage its own data plane-scoped resources, following the principle of
 least privilege.
 
-[[mtls]]
-== Enable mTLS authentication for Kafka API
-:description: Use the Cloud API to enable mTLS for Kafka API connections on your Redpanda cluster.
+== Configure service authentication
 
-
-Redpanda Cloud supports mTLS authentication for the Kafka API. 
+Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry. For GCP clusters, you can enable both authentication methods simultaneously.
 
 === Requirements
 
+To configure service authentication in your cluster, you must have the following:
+
+// version?
 * A service account in your Redpanda organization. You must have administrative privileges to create a service account.
-* Use the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS. You use the service account to obtain an access token. You then make a request to the API to update an existing cluster to use mTLS, passing the access token in the authorization header.  
-
-=== Use the Cloud API to enable mTLS
-
-. Create a service account in your organization, if you have not already done so. Go to the Service account tab of the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Organization IAM^] page in the Redpanda Cloud UI and click *Create service account* to create a service account. Enter a name and description.
-. Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
-. Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
-
-The following code block shows a request for an access token, followed by a request to enable mTLS:
-
-[,bash]
-----
-AUTH_TOKEN=`curl -s --request POST \
-    --url 'https://auth.prd.cloud.redpanda.com/oauth/token' \
-    --header 'content-type: application/x-www-form-urlencoded' \
-    --data grant_type=client_credentials \
-    --data client_id=<client-id> \
-    --data client_secret=<client-secret> \
-    --data audience=cloudv2-production.redpanda.cloud | jq -r .access_token`
-
-CLUSTER_PATCH_BODY=`cat << EOF
-{
-  "kafka_api": {
-     "mtls": {
-        "enabled": true,
-        "ca_certificates_pem": ["<ca-certificate-pem>"],
-        "principal_mapping_rules": ["<principal-mapping-rule>"]
-     }
-  }
-}
-EOF`
-curl -v -X PATCH \
--H "Content-Type: application/json" \
--H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
-----
-
-Make sure to replace the following variables:
-
-* `<client-id>`: Client ID.
-* `<client-secret>`: Client secret.
-* `<cluster-id>`: ID of Redpanda cluster.
-* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
-* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
-+
-For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
-+
-`Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
-+
-See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
-
-==== Verify that mTLS is enabled
-
-To verify that mTLS is enabled for the Kafka API, run the following `rpk` command, without providing a security certificate or key:
-
-[,bash]
-----
-rpk cluster info --tls-enabled
-----
-
-You should get the following error:
-
-```
-unable to request metadata: remote error: tls: certificate required
-```
-
-=== Consume and produce with mTLS enabled
-
-When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[`rpk`], you must provide a client certificate and private key. You may use the `--tls-cert` and `--tls-key` options, or xref:ROOT:reference:rpk/rpk-x-options.adoc[environment variables] with `rpk`.
-
-[,bash]
-----
-rpk topic create test-topic --tls-enabled --tls-cert=/path/to/tls.crt --tls-key=/path/to/tls.key
-----
-
-[[mtls-sasl]]
-== Enable mTLS and SASL authentication
-
-NOTE: This feature is supported in GCP clusters only. To unlock this feature for GCP, contact your Customer Success Manager.
-
-Redpanda Cloud supports mTLS with SASL authentication for Kafka API, HTTP Proxy, and Schema Registry. 
-
-=== Requirements
-
-// version
-// cluster type
-* A service account in your Redpanda organization. You must have administrative privileges to create a service account.
-* Use the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS and SASL. You use the service account to obtain an access token. You then make a request to the API to create a new cluster or update an existing cluster to use mTLS and SASL, passing the access token in the authorization header.
+* Access to the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS or SASL. You use the service account to obtain an access token. You then make a request to the API to update an existing cluster to use mTLS or SASL, passing the access token in the authorization header.
 
 === Authenticate to the Cloud API
 
@@ -208,23 +175,227 @@ Make sure to replace the following variables:
 * `<client-id>`: Client ID.
 * `<client-secret>`: Client secret.
 
-=== Use the Cloud API to create a cluster with mTLS and SASL
+[[mtls]]
+=== Enable mTLS authentication
+:description: Use the Cloud API to enable mTLS for Kafka API, HTTP Proxy, and Schema Registry connections on your Redpanda cluster.
 
-. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated]. You'll need the resource group ID and network ID to create a cluster in the next step.
+==== Enable mTLS on a new cluster
 
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with both mTLS and SASL enabled.
+. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already. You'll need the resource group ID and network ID to create a cluster in the next step.
+
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with mTLS enabled.
 +
-You can choose to enable mTLS and SASL on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` block.
-+
-[,bash]
+[,bash,lines=13-19]
 ----
-
 CLUSTER_CREATE_BODY=`cat << EOF
 {
   "cluster": {
     "cloud_provider": "CLOUD_PROVIDER_GCP",
     "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "name": "$cluster_name",
+    "name": "<cluster-name>",
+    "resource_group_id": "<resource-group-id>",
+    "network_id": "<network-id>",
+    "region": "<region>",
+    "zones": [ <zones> ],
+    "throughput_tier": "<tier>",
+    "type": "<cluster-type>",
+    "kafka_api": {
+       "mtls": {
+          "enabled": true,
+          "ca_certificates_pem": ["<ca-certificate-pem>"],
+          "principal_mapping_rules": ["<principal-mapping-rule>"]
+       }
+    }
+  }
+}
+EOF`
+curl -v -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the following variables:
+
+* `<cluster-id>`: ID of the Redpanda cluster.
+* `<cluster-name>`: Name of the Redpanda cluster.
+* `<resource-group-id>`: ID of the resource group.
+* `<network-id>`: ID of the network.
+* `<region>`: The region where the cluster is created. For example, `us-central1`.
+* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
+* `<tier>`: The usage tier of the cluster. For example, .
+* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
+* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
++
+For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
++
+`Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
++
+See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+
+The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
+
+==== Enable mTLS on an existing cluster
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
+
+The following code block shows a request to enable mTLS:
+
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+  "kafka_api": {
+     "mtls": {
+        "enabled": true,
+        "ca_certificates_pem": ["<ca-certificate-pem>"],
+        "principal_mapping_rules": ["<principal-mapping-rule>"]
+     }
+  }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the following variables:
+
+* `<cluster-id>`: ID of Redpanda cluster.
+* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
++
+For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
++
+`Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
++
+See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+
+The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
+
+[sasl]]
+=== Enable SASL authentication
+
+==== Enable SASL on a new cluster
+
+. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
+
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with SASL enabled.
++
+[,bash,lines=13-17]
+----
+CLUSTER_CREATE_BODY=`cat << EOF
+{
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PRIVATE",
+    "name": "<cluster-name>",
+    "resource_group_id": "<resource-group-id>",
+    "network_id": "<network-id>",
+    "region": "<region>",
+    "zones": [ <zones> ],
+    "throughput_tier": "<tier>",
+    "type": "<cluster-type>",
+    "kafka_api": {
+       "sasl": {
+          "enabled": true
+       }
+    }
+  }
+}
+EOF`
+curl -v -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the following variables:
+
+* `<cluster-id>`: ID of the Redpanda cluster.
+* `<cluster-name>`: Name of the Redpanda cluster.
+* `<resource-group-id>`: ID of the resource group.
+* `<network-id>`: ID of the network.
+* `<region>`: The region where the cluster is created. For example, `us-central1`.
+* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
+* `<tier>`: The usage tier of the cluster. For example, .
+* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
+
+The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+==== Enable SASL on an existing cluster
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable SASL for the Kafka API on a cluster.
+
+The following code block shows a request to enable SASL:
+
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+  "kafka_api": {
+     "sasl": {
+        "enabled": true
+     }
+  }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the `<cluster-id>` placeholder with the ID of your Redpanda cluster.
+
+The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+=== Enable multi-protocol authentication (mTLS and SASL)
+
+NOTE: Multi-protocol authentication is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
+
+==== Enable mTLS and SASL on a new cluster
+
+. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
+
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with both mTLS and SASL enabled.
++
+You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
++
+[,bash,lines=13+23+33]
+----
+CLUSTER_CREATE_BODY=`cat << EOF
+{
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PRIVATE",
+    "name": "<cluster-name>",
     "resource_group_id": "<resource-group-id>",
     "network_id": "<network-id>",
     "region": "<region>",
@@ -272,9 +443,10 @@ curl -v -X POST \
 
 Make sure to replace the following variables:
 
-* `<client-id>`: Client ID.
-* `<client-secret>`: Client secret.
 * `<cluster-id>`: ID of Redpanda cluster.
+* `<cluster-name>`: Name of the Redpanda cluster.
+* `<resource-group-id>`: ID of the resource group.
+* `<network-id>`: ID of the network.
 * `<region>`: The region where the cluster is created. For example, `us-central1`.
 * `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
 * `<tier>`: The usage tier of the cluster. For example, .
@@ -295,15 +467,15 @@ The Create Cluster endpoint returns a long-running operation. You can check the 
 curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
 ----
 
-When the operation state is `COMPLETED`, you can <<verify-mtls-sasl,verify that mTLS and SASL are enabled>> for the API endpoints.
+When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-=== Use the Cloud API to update a cluster to use mTLS and SASL
+==== Update a cluster to use mTLS and SASL
 
 Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS and SASL on an existing cluster.
 
-You can choose to enable mTLS and SASL on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` block.
+You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
 
-[,bash]
+[,bash,lines=3+13+23]
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
 {
@@ -347,8 +519,6 @@ curl -v -X PATCH \
 
 Make sure to replace the following variables:
 
-* `<client-id>`: Client ID.
-* `<client-secret>`: Client secret.
 * `<cluster-id>`: ID of Redpanda cluster.
 * `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
 * `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
@@ -366,10 +536,10 @@ The Update Cluster endpoint returns a long-running operation. You can check the 
 curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
 ----
 
-When the operation state is `COMPLETED`, you can <<verify-mtls-sasl,verify that mTLS and SASL are enabled>> for the API endpoints.
+When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-[[verify-mtls-sasl]]
-=== Verify that mTLS and SASL are enabled
+[[verify-mtls]]
+=== Verify that mTLS is enabled
 
 To verify that mTLS is enabled for the Kafka API, run the following `rpk` command, without providing a security certificate or key:
 
@@ -386,21 +556,42 @@ unable to request metadata: remote error: tls: certificate required
 
 === Retrieve API endpoints
 
-Retrieve the mTLS and SASL-enabled endpoints by calling the GET /v1/clusters/{id} endpoint, passing the cluster ID as a parameter.
+Retrieve the mTLS and SASL-enabled endpoints by calling the `GET /v1/clusters/\{id}` endpoint, passing the cluster ID as a parameter.
 
 [,bash]
 ----
-
+curl -X GET "https://api.redpanda.com/v1/clusters/<cluster-id>" \
+ -H "accept: application/json"\
+ -H "content-type: application/json" \
+ -H "authorization: Bearer ${AUTH_TOKEN}"
 ----
 
+The API endpoints are returned in the response body in the following fields:
 
-For Kafka API, use the `mtls` and `sasl` values in the `kafka_api.all_seed_brokers` field in the response.
+[cols="1,1,2"]
+|=== 
+| API | Field | Example
 
-For HTTP Proxy, use the values in `http_proxy.all_urls`.
+| Kafka API 
+| `kafka_api.all_seed_brokers` 
+a| 
+* `sasl`: `seed-2f92c489.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:9092`
+* `mtls`: `seed-2f92c489.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:9093`
 
-For Schema Registry, use the values in `schema_registry.all_urls`.
+| HTTP Proxy 
+| `http_proxy.all_urls` 
+a| 
+* `sasl`: `\https://pandaproxy-ce24d80a.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:30082`
+* `mtls`: `\https://pandaproxy-ce24d80a.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:30083`
 
-=== Consume and produce with mTLS and SASL enabled
+| Schema Registry 
+| `schema_registry.all_urls`
+a| 
+* `sasl`: `\https://schema-registry-20b02d09.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:30081`
+* `mtls`: `\https://schema-registry-20b02d09.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:30080`
+|===
+
+=== Consume and produce with mTLS enabled
 
 When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[`rpk`], you must provide a client certificate and private key. You may use the `--tls-cert` and `--tls-key` options, or xref:ROOT:reference:rpk/rpk-x-options.adoc[environment variables] with `rpk`.
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -68,7 +68,7 @@ Each Redpanda Cloud data plane runs its own dedicated agent,
 which authenticates and connects against the control plane over a single TLS 1.2
 encrypted TCP connection.
 
-Different Redpanda APIs support different authentication methods. You can configure a listener with an authentication method for each API. For GCP, you can simultaneously enable mTLS and SASL for multi-protocol authentication. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener are created each on separate ports.
+Different Redpanda APIs support different authentication methods. For GCP, you can simultaneously enable mTLS and SASL. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener are created each on separate ports.
 
 .Redpanda APIs authentication methods
 [%collapsible]
@@ -78,53 +78,57 @@ Different Redpanda APIs support different authentication methods. You can config
 .3+|AWS
 |Kafka API
 a|
-* SASL/SCRAM only
-* mTLS only
+* SASL/SCRAM
+* mTLS
 
 |HTTP Proxy
 a|
-* Basic authentication only
-* mTLS only
+* Basic authentication
+* mTLS
 
 |Schema Registry
 a|
-* Basic authentication only
-* mTLS only
+* Basic authentication
+* mTLS
 
-.3+|GCP
+.3+a|GCP
+
+See <<enable-mtls-and-sasl,Enable mTLS and SASL>>. 
+
 |Kafka API
 a|
-* SASL/SCRAM only
-* mTLS only
-* Multi-protocol (SASL/SCRAM + mTLS)
+* SASL
+** SASL/SCRAM
+** SASL/PLAIN
+* mTLS
 
 |HTTP Proxy
 a|
-* Basic authentication only
-* mTLS only
-* Multi-protocol (SASL + mTLS)
+* Basic authentication
+* mTLS
 
 |Schema Registry
 a|
-* Basic authentication only
-* mTLS only
-* Multi-protocol (SASL + mTLS)
+* Basic authentication
+* mTLS
 
 .3+|Azure
 |Kafka API
 a|
-* SASL/SCRAM only
-* mTLS only
+* SASL
+** SASL/SCRAM
+** SASL/PLAIN
+* mTLS
 
 |HTTP Proxy
 a|
-* Basic authentication only
-* mTLS only
+* Basic authentication
+* mTLS
 
 |Schema Registry
 a|
-* Basic authentication only
-* mTLS only
+* Basic authentication
+* mTLS
 |===
 
 * Kafka API: Redpanda Cloud enables SASL/SCRAM authentication
@@ -147,9 +151,9 @@ least privilege.
 
 == Configure service authentication
 
-Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry. For GCP clusters, you can enable both authentication methods simultaneously.
+Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry.
 
-When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled with SASL by default. If you want to enable mTLS, or multi-protocol authentication (both mTLS and SASL) for GCP clusters only, you must use the Cloud API to create the cluster or update an existing cluster.
+When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled with SASL by default. If you want to enable mTLS, or both mTLS and SASL for GCP clusters only, you must use the Cloud API to create the cluster or update an existing cluster.
 
 === Requirements
 
@@ -183,6 +187,8 @@ Make sure to replace the following variables:
 [[mtls]]
 === Enable mTLS authentication
 :description: Use the Cloud API to enable mTLS for Kafka API, HTTP Proxy, and Schema Registry connections on your Redpanda cluster.
+
+For clusters with mTLS authentication, Redpanda creates a dedicated mTLS-enabled listener for each API service (Kafka API, HTTP Proxy, or Schema Registry) where you've enabled this authentication method. After you enable mTLS, <<retrieve-api-endpoints,get the API endpoints>> and <<verify-mtls,verify that mTLS authentication is in effect>>. 
 
 ==== Create a new cluster with mTLS enabled
 
@@ -302,9 +308,40 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-=== Enable multi-protocol authentication (mTLS and SASL)
+=== Enable SASL authentication
 
-NOTE: Multi-protocol authentication is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
+New clusters are enabled with SASL authentication by default. If you enabled mTLS and want to switch to SASL, you must use the Cloud API to update the cluster. 
+
+To switch to SASL authentication on AWS and Azure clusters, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request.
+
+The following code block shows a request to enable SASL authentication only for the Kafka API:
+
+.Show example request
+[%collapsible]
+====
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+  "kafka_api": {
+     "sasl": {
+        "enabled": true
+     }
+  }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+====
+
+For GCP clusters, you have the option to enable both mTLS and SASL. This means that the cluster has one mTLS-enabled listener and one SASL-enabled listener.
+
+=== Enable mTLS and SASL
+
+NOTE: Enabling mTLS and SASL simultaneously is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
 
 ==== Create a new cluster with both mTLS and SASL enabled
 
@@ -533,6 +570,7 @@ When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk
 rpk topic create test-topic --tls-enabled --tls-cert=/path/to/tls.crt --tls-key=/path/to/tls.key
 ----
 
+[[verify-mtls-http]]
 === Verify mTLS for HTTP Proxy and Schema Registry
 
 To verify that mTLS is enabled for the HTTP Proxy and Schema Registry, run the following `curl` commands, without providing a security certificate or key:

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -152,7 +152,7 @@ least privilege.
 
 Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry.
 
-When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled by default with SASL for Kafka API,  and Basic authentication for HTTP Proxy and Schema Registry.
+When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled by default with SASL for Kafka API, and Basic authentication for HTTP Proxy and Schema Registry.
 
 === Requirements
 
@@ -205,6 +205,8 @@ Make sure to replace the following variables:
 :description: Use the Cloud API to enable mTLS for Kafka API, HTTP Proxy, and Schema Registry connections on your Redpanda cluster.
 
 For clusters with mTLS authentication, Redpanda creates a dedicated mTLS-enabled listener for each API service (Kafka API, HTTP Proxy, or Schema Registry) where you've enabled this authentication method. After you enable mTLS, <<retrieve-api-endpoints,get the API endpoints>> and <<verify-mtls,verify that mTLS authentication is in effect>>. 
+
+NOTE: If you enable mTLS only, you cannot disable it later.
 
 ==== Create a new cluster with mTLS enabled
 
@@ -480,8 +482,6 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 ----
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
-
-NOTE: If you enable mTLS only, you cannot disable it later.
 
 ==== Update an existing cluster to use mTLS and SASL
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -78,7 +78,9 @@ Different Redpanda APIs support different authentication methods. For GCP, you c
 .3+|AWS
 |Kafka API
 a|
-* SASL/SCRAM
+* SASL
+** SASL/SCRAM
+** SASL/PLAIN
 * mTLS
 
 |HTTP Proxy
@@ -118,17 +120,14 @@ a|
 * SASL
 ** SASL/SCRAM
 ** SASL/PLAIN
-* mTLS
 
 |HTTP Proxy
 a|
 * Basic authentication
-* mTLS
 
 |Schema Registry
 a|
 * Basic authentication
-* mTLS
 |===
 
 * Kafka API: Redpanda Cloud enables SASL/SCRAM authentication

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -68,7 +68,7 @@ Each Redpanda Cloud data plane runs its own dedicated agent,
 which authenticates and connects against the control plane over a single TLS 1.2
 encrypted TCP connection.
 
-Different Redpanda APIs support different authentication methods. You can configure a listener with an authentication method for each API. For GCP, you can simultaneously enable mTLS and SASL for multi-protocol authentication. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener on separate ports are created.
+Different Redpanda APIs support different authentication methods. You can configure a listener with an authentication method for each API. For GCP, you can simultaneously enable mTLS and SASL for multi-protocol authentication. If you enable both mTLS and SASL for an API on GCP clusters, one mTLS listener and one SASL listener are created each on separate ports.
 
 .Redpanda APIs authentication methods
 [%collapsible]
@@ -78,57 +78,60 @@ Different Redpanda APIs support different authentication methods. You can config
 .3+|AWS
 |Kafka API
 a|
+* SASL/SCRAM only
 * mTLS only
-* SASL only
-
 
 |HTTP Proxy
-|
+a|
+* Basic authentication only
+* mTLS only
 
 |Schema Registry
-|
+a|
+* Basic authentication only
+* mTLS only
 
 .3+|GCP
 |Kafka API
 a|
+* SASL/SCRAM only
 * mTLS only
-* SASL only
-* Multi-protocol (SASL + mTLS)
+* Multi-protocol (SASL/SCRAM + mTLS)
 
 |HTTP Proxy
 a|
+* Basic authentication only
 * mTLS only
-* SASL only
 * Multi-protocol (SASL + mTLS)
 
 |Schema Registry
 a|
+* Basic authentication only
 * mTLS only
-* SASL only
 * Multi-protocol (SASL + mTLS)
 
 .3+|Azure
 |Kafka API
 a|
+* SASL/SCRAM only
 * mTLS only
-* SASL only
-
 
 |HTTP Proxy
-|
+a|
+* Basic authentication only
+* mTLS only
 
 |Schema Registry
-|
+a|
+* Basic authentication only
+* mTLS only
 |===
 
 * Kafka API: Redpanda Cloud enables SASL/SCRAM authentication
 over TLS 1.2 as well as <<mtls,mTLS>> to authenticate Kafka clients connecting to Redpanda clusters over
 the TCP endpoint or listener.
-
-* HTTP Proxy: Authentication is done through an
+* HTTP Proxy and Schema Registry: Authentication is done through an
 HTTP Basic Authentication header encrypted over TLS 1.2.
-
-* Schema Registry:
 
 The following features use IAM policies to generate
 dynamic and short-lived credentials to interact with cloud provider APIs:
@@ -146,17 +149,19 @@ least privilege.
 
 Redpanda Cloud supports mTLS or SASL authentication for Kafka API, HTTP Proxy, and Schema Registry. For GCP clusters, you can enable both authentication methods simultaneously.
 
+When you create a new cluster using the https://cloud.redpanda.com/[Cloud UI^], the cluster is enabled with SASL by default. If you want to enable mTLS, or multi-protocol authentication (both mTLS and SASL) for GCP clusters only, you must use the Cloud API to create the cluster or update an existing cluster.
+
 === Requirements
 
 To configure service authentication in your cluster, you must have the following:
 
 // version?
 * A service account in your Redpanda organization. You must have administrative privileges to create a service account.
-* Access to the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS or SASL. You use the service account to obtain an access token. You then make a request to the API to update an existing cluster to use mTLS or SASL, passing the access token in the authorization header.
+* Access to the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS or both SASL and mTLS. You use the service account to obtain an access token. You then make a request to the Control Plane API, passing the access token in the authorization header.
 
 === Authenticate to the Cloud API
 
-. Create a service account in your organization, if you have not already done so. Go to the Service account tab of the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Organization IAM^] page in the Redpanda Cloud UI and click *Create service account* to create a service account. Enter a name and description.
+. Create a service account in your organization, if you haven't already. Go to the Service account tab of the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Organization IAM^] page in the Redpanda Cloud UI and click *Create service account* to create a service account. Enter a name and description.
 . Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
 . Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
 +
@@ -179,13 +184,16 @@ Make sure to replace the following variables:
 === Enable mTLS authentication
 :description: Use the Cloud API to enable mTLS for Kafka API, HTTP Proxy, and Schema Registry connections on your Redpanda cluster.
 
-==== Enable mTLS on a new cluster
+==== Create a new cluster with mTLS enabled
 
 . Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already. You'll need the resource group ID and network ID to create a cluster in the next step.
 
 . Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with mTLS enabled.
 +
-[,bash,lines=13-19]
+.Show example request
+[%collapsible]
+====
+[,bash,lines=13-19,%collapsible]
 ----
 CLUSTER_CREATE_BODY=`cat << EOF
 {
@@ -214,6 +222,7 @@ curl -v -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
+====
 
 Make sure to replace the following variables:
 
@@ -243,12 +252,15 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-==== Enable mTLS on an existing cluster
+==== Update an existing cluster to use mTLS
 
 Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
 
 The following code block shows a request to enable mTLS:
 
+.Show example request
+[%collapsible]
+====
 [,bash]
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
@@ -267,6 +279,7 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
+====
 
 Make sure to replace the following variables:
 
@@ -289,98 +302,11 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-[sasl]]
-=== Enable SASL authentication
-
-==== Enable SASL on a new cluster
-
-. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
-
-. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with SASL enabled.
-+
-[,bash,lines=13-17]
-----
-CLUSTER_CREATE_BODY=`cat << EOF
-{
-  "cluster": {
-    "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "name": "<cluster-name>",
-    "resource_group_id": "<resource-group-id>",
-    "network_id": "<network-id>",
-    "region": "<region>",
-    "zones": [ <zones> ],
-    "throughput_tier": "<tier>",
-    "type": "<cluster-type>",
-    "kafka_api": {
-       "sasl": {
-          "enabled": true
-       }
-    }
-  }
-}
-EOF`
-curl -v -X POST \
--H "Content-Type: application/json" \
--H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
-----
-
-Make sure to replace the following variables:
-
-* `<cluster-id>`: ID of the Redpanda cluster.
-* `<cluster-name>`: Name of the Redpanda cluster.
-* `<resource-group-id>`: ID of the resource group.
-* `<network-id>`: ID of the network.
-* `<region>`: The region where the cluster is created. For example, `us-central1`.
-* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
-* `<tier>`: The usage tier of the cluster. For example, .
-* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
-
-The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
-
-[,bash]
-----
-curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
-----
-
-==== Enable SASL on an existing cluster
-
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable SASL for the Kafka API on a cluster.
-
-The following code block shows a request to enable SASL:
-
-[,bash]
-----
-CLUSTER_PATCH_BODY=`cat << EOF
-{
-  "kafka_api": {
-     "sasl": {
-        "enabled": true
-     }
-  }
-}
-EOF`
-curl -v -X PATCH \
--H "Content-Type: application/json" \
--H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
-----
-
-Make sure to replace the `<cluster-id>` placeholder with the ID of your Redpanda cluster.
-
-The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
-
-[,bash]
-----
-curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
-----
-
 === Enable multi-protocol authentication (mTLS and SASL)
 
 NOTE: Multi-protocol authentication is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
 
-==== Enable mTLS and SASL on a new cluster
+==== Create a new cluster with both mTLS and SASL enabled
 
 . Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
 
@@ -388,6 +314,9 @@ NOTE: Multi-protocol authentication is available for GCP clusters only. To unloc
 +
 You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
 +
+.Show example request
+[%collapsible]
+====
 [,bash,lines=13+23+33]
 ----
 CLUSTER_CREATE_BODY=`cat << EOF
@@ -440,6 +369,7 @@ curl -v -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
+====
 
 Make sure to replace the following variables:
 
@@ -469,12 +399,15 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-==== Update a cluster to use mTLS and SASL
+==== Update an existing cluster to use mTLS and SASL
 
 Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS and SASL on an existing cluster.
 
 You can choose to enable mTLS and SASL simultaneously on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable multi-protocol authentication for Kafka API and Schema Registry, and enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` field.
 
+.Show example request
+[%collapsible]
+====
 [,bash,lines=3+13+23]
 ----
 CLUSTER_PATCH_BODY=`cat << EOF
@@ -516,6 +449,7 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
 ----
+====
 
 Make sure to replace the following variables:
 
@@ -537,22 +471,6 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 ----
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
-
-[[verify-mtls]]
-=== Verify that mTLS is enabled
-
-To verify that mTLS is enabled for the Kafka API, run the following `rpk` command, without providing a security certificate or key:
-
-[,bash]
-----
-rpk cluster info --tls-enabled
-----
-
-You should get the following error:
-
-```
-unable to request metadata: remote error: tls: certificate required
-```
 
 === Retrieve API endpoints
 
@@ -591,13 +509,54 @@ a|
 * `mtls`: `\https://schema-registry-20b02d09.d040oh0mf339m7q5uu0g.byoc.ign.cloud.redpanda.com:30080`
 |===
 
-=== Consume and produce with mTLS enabled
+[[verify-mtls]]
+=== Verify mTLS for Kafka API connections
 
+To verify that mTLS is enabled for Kafka API, run the following `rpk` without providing a security certificate or private key:
+
+[,bash]
+----
+rpk cluster info --tls-enabled
+----
+
+You should get the following error:
+
+```
+unable to request metadata: remote error: tls: certificate required
+```
+
+[[consume-produce-mtls]]
 When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[`rpk`], you must provide a client certificate and private key. You may use the `--tls-cert` and `--tls-key` options, or xref:ROOT:reference:rpk/rpk-x-options.adoc[environment variables] with `rpk`.
 
 [,bash]
 ----
 rpk topic create test-topic --tls-enabled --tls-cert=/path/to/tls.crt --tls-key=/path/to/tls.key
+----
+
+=== Verify mTLS for HTTP Proxy and Schema Registry
+
+To verify that mTLS is enabled for the HTTP Proxy and Schema Registry, run the following `curl` commands, without providing a security certificate or key:
+
+[,bash]
+----
+# Run the following to verify HTTP Proxy
+curl -u $USERNAME:$PASSWORD -k -H "Content-Type: application/vnd.kafka.json.v2+json" --sslv2 --http2 -d '{"records":[{"test":"hello"},{"test":"world"}]}' $HTTP_PROXY_MTLS_URL/topics/<topic-name>
+
+# Run the following to verify Schema Registry
+curl -u $USERNAME:$PASSWORD -k -H "Content-Type: application/vnd.schemaregistry.v1+json" $SCHEMA_REGISTRY_MTLS_URL/subjects/<subject-name>/versions/1
+----
+
+You should get an error indicating that the certificate is required.
+
+To successfully connect to the HTTP Proxy and Schema Registry, you must provide a client certificate and private key. The following cURL commands show example requests to mTLS-enabled endpoints using `test` as the username and `12345` as the password.
+
+[,bash]
+----
+# HTTP Proxy
+curl -u test:12345 -k --cert $CERT_FILE --key $PRIVATE_KEY_FILE -H "Content-Type: application/vnd.kafka.json.v2+json" --sslv2 --http2 https://pandaproxy-45f811b1.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30082/topics
+
+# Schema Registry
+curl -u test:12345 -k --cert $CERT_FILE --key $CERT_FILE https://schema-registry-15d24f32.cge5asc6006u7fvep0q0.fmc.dev.cloud.redpanda.com:30081/subjects/Kafka-value/versions/1
 ----
 
 include::shared:partial$suggested-reading.adoc[]

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -308,37 +308,6 @@ curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operatio
 
 When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS is enabled>> for the API endpoints.
 
-=== Enable SASL authentication
-
-New clusters are enabled with SASL authentication by default. If you enabled mTLS and want to switch to SASL, you must use the Cloud API to update the cluster. 
-
-To switch to SASL authentication on AWS and Azure clusters, make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request.
-
-The following code block shows a request to enable SASL authentication only for the Kafka API:
-
-.Show example request
-[%collapsible]
-====
-[,bash]
-----
-CLUSTER_PATCH_BODY=`cat << EOF
-{
-  "kafka_api": {
-     "sasl": {
-        "enabled": true
-     }
-  }
-}
-EOF`
-curl -v -X PATCH \
--H "Content-Type: application/json" \
--H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
-----
-====
-
-For GCP clusters, you have the option to enable both mTLS and SASL. This means that the cluster has one mTLS-enabled listener and one SASL-enabled listener.
-
 === Enable mTLS and SASL
 
 NOTE: Enabling mTLS and SASL simultaneously is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -629,7 +629,7 @@ a|
 [[verify-mtls]]
 === Verify mTLS for Kafka API connections
 
-To verify that mTLS is enabled for Kafka API, run the following `rpk` without providing a security certificate or private key:
+To verify that mTLS is enabled for Kafka API, run the following `rpk` command without providing a security certificate or private key:
 
 [,bash]
 ----

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -88,7 +88,7 @@ access or manage its own data plane-scoped resources, following the principle of
 least privilege.
 
 [[mtls]]
-== Enable mTLS Authentication for Kafka API
+== Enable mTLS authentication for Kafka API
 :description: Use the Cloud API to enable mTLS for Kafka API connections on your Redpanda cluster.
 
 
@@ -101,7 +101,7 @@ Redpanda Cloud supports mTLS authentication for the Kafka API.
 
 === Use the Cloud API to enable mTLS
 
-. Create a service account in your organization, if you have not already done so. Go to the https://cloud.redpanda.com/clients[Clients^] page in the Redpanda Cloud UI and click *Add client* to create a service account. Enter a name and description.
+. Create a service account in your organization, if you have not already done so. Go to the Service account tab of the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Organization IAM^] page in the Redpanda Cloud UI and click *Create service account* to create a service account. Enter a name and description.
 . Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
 . Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
 . Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS for the Kafka API on a cluster.
@@ -165,6 +165,242 @@ unable to request metadata: remote error: tls: certificate required
 ```
 
 === Consume and produce with mTLS enabled
+
+When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[`rpk`], you must provide a client certificate and private key. You may use the `--tls-cert` and `--tls-key` options, or xref:ROOT:reference:rpk/rpk-x-options.adoc[environment variables] with `rpk`.
+
+[,bash]
+----
+rpk topic create test-topic --tls-enabled --tls-cert=/path/to/tls.crt --tls-key=/path/to/tls.key
+----
+
+[[mtls-sasl]]
+== Enable mTLS and SASL authentication
+
+NOTE: This feature is supported in GCP clusters only. To unlock this feature for GCP, contact your Customer Success Manager.
+
+Redpanda Cloud supports mTLS with SASL authentication for Kafka API, HTTP Proxy, and Schema Registry. 
+
+=== Requirements
+
+// version
+// cluster type
+* A service account in your Redpanda organization. You must have administrative privileges to create a service account.
+* Use the xref:manage:api/cloud-api-overview.adoc[Cloud API] to enable mTLS and SASL. You use the service account to obtain an access token. You then make a request to the API to create a new cluster or update an existing cluster to use mTLS and SASL, passing the access token in the authorization header.
+
+=== Authenticate to the Cloud API
+
+. Create a service account in your organization, if you have not already done so. Go to the Service account tab of the https://cloud.redpanda.com/organization-iam?tab=service-accounts[Organization IAM^] page in the Redpanda Cloud UI and click *Create service account* to create a service account. Enter a name and description.
+. Retrieve the client ID and secret by clicking *Copy ID* and *Copy Secret*. 
+. Obtain an access token by making a `POST` request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
++
+[,bash]
+----
+AUTH_TOKEN=`curl -s --request POST \
+    --url 'https://auth.prd.cloud.redpanda.com/oauth/token' \
+    --header 'content-type: application/x-www-form-urlencoded' \
+    --data grant_type=client_credentials \
+    --data client_id=<client-id> \
+    --data client_secret=<client-secret> \
+    --data audience=cloudv2-production.redpanda.cloud | jq -r .access_token`
+----
+Make sure to replace the following variables:
+
+* `<client-id>`: Client ID.
+* `<client-secret>`: Client secret.
+
+=== Use the Cloud API to create a cluster with mTLS and SASL
+
+. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated]. You'll need the resource group ID and network ID to create a cluster in the next step.
+
+. Make a xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters/-cluster.id-[`POST /v1/clusters/{cluster.id}`] request to create a new cluster with both mTLS and SASL enabled.
++
+You can choose to enable mTLS and SASL on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` block.
++
+[,bash]
+----
+
+CLUSTER_CREATE_BODY=`cat << EOF
+{
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PRIVATE",
+    "name": "$cluster_name",
+    "resource_group_id": "<resource-group-id>",
+    "network_id": "<network-id>",
+    "region": "<region>",
+    "zones": [ <zones> ],
+    "throughput_tier": "<tier>",
+    "type": "<cluster-type>",
+    "kafka_api": {
+       "mtls": {
+          "enabled": true,
+          "ca_certificates_pem": ["<ca-certificate-pem>"],
+          "principal_mapping_rules": ["<principal-mapping-rule>"]
+       },
+       "sasl": {
+          "enabled": true
+       }
+    },
+    "http_proxy": {
+       "mtls": {
+          "enabled": true,
+          "ca_certificates_pem": ["<ca-certificate-pem>"],
+          "principal_mapping_rules": ["<principal-mapping-rule>"]
+       },
+       "sasl": {
+          "enabled": true
+       }
+    },
+    "schema_registry": {
+       "mtls": {
+          "enabled": true,
+          "ca_certificates_pem": ["<ca-certificate-pem>"],
+          "principal_mapping_rules": ["<principal-mapping-rule>"]
+       },
+       "sasl": {
+          "enabled": true
+       }
+    }
+  }
+}
+EOF`
+curl -v -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the following variables:
+
+* `<client-id>`: Client ID.
+* `<client-secret>`: Client secret.
+* `<cluster-id>`: ID of Redpanda cluster.
+* `<region>`: The region where the cluster is created. For example, `us-central1`.
+* `<zones>`: The zones where the cluster is created. For example, `["us-central1-a", "us-central1-b", "us-central1-c"]`.
+* `<tier>`: The usage tier of the cluster. For example, .
+* `<cluster-type>`: The Redpanda cluster type, `TYPE_BYOC` or `TYPE_DEDICATED`.
+* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
++
+For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
++
+`Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
++
+See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+
+The Create Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+When the operation state is `COMPLETED`, you can <<verify-mtls-sasl,verify that mTLS and SASL are enabled>> for the API endpoints.
+
+=== Use the Cloud API to update a cluster to use mTLS and SASL
+
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request to enable mTLS and SASL on an existing cluster.
+
+You can choose to enable mTLS and SASL on any of the following Redpanda services: Kafka API, HTTP Proxy, and Schema Registry. For example, if you want to enable both mTLS and SASL for Kafka API and Schema Registry only, leave out the entire `http_proxy` block from the request body. If you want to enable mTLS only for HTTP Proxy, leave out the `http_proxy.sasl` block.
+
+[,bash]
+----
+CLUSTER_PATCH_BODY=`cat << EOF
+{
+  "kafka_api": {
+     "mtls": {
+        "enabled": true,
+        "ca_certificates_pem": ["<ca-certificate-pem>"],
+        "principal_mapping_rules": ["<principal-mapping-rule>"]
+     },
+     "sasl": {
+        "enabled": true
+     }
+  },
+  "schema_registry": {
+     "mtls": {
+        "enabled": true,
+        "ca_certificates_pem": ["<ca-certificate-pem>"],
+        "principal_mapping_rules": ["<principal-mapping-rule>"]
+     },
+     "sasl": {
+        "enabled": true
+     }
+  },
+  "http_proxy": {
+     "mtls": {
+        "enabled": true,
+        "ca_certificates_pem": ["<ca-certificate-pem>"],
+        "principal_mapping_rules": ["<principal-mapping-rule>"]
+     },
+     "sasl": {
+        "enabled": true
+     }
+  }
+}
+EOF`
+curl -v -X PATCH \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+----
+
+Make sure to replace the following variables:
+
+* `<client-id>`: Client ID.
+* `<client-secret>`: Client secret.
+* `<cluster-id>`: ID of Redpanda cluster.
+* `<ca-certificate-pem>`: A trusted Kafka client CA certificate in PEM format. The `ca_certificates_pem` field accepts a list of certificates.
+* `<principal-mapping-rule>`: Configurable rule for mapping the Distinguished Name of Kafka client certificates to Kafka principals.  
++
+For example, the mapping rule `RULE:.\*CN=([^,]+).*/\\$1/` maps the following certificate subject to a principal named `test`:
++
+`Subject: C=US, ST=IL, L=Chicago, O=redpanda, OU=cloud, CN=test, emailAddress=test123@redpanda.com`
++
+See xref:ROOT:manage:security/authentication.adoc#mtls[Configure Authentication] for more details on principal mapping rules. The `principal_mapping_rules` field accepts a list of rules.
+
+The Update Cluster endpoint returns a long-running operation. You can check the status of the operation by making a `GET` request to the following endpoint:
+
+[,bash]
+----
+curl -H "Authorization: Bearer $AUTH_TOKEN" https://api.redpanda.com/v1/operations/<operation-id>
+----
+
+When the operation state is `COMPLETED`, you can <<verify-mtls-sasl,verify that mTLS and SASL are enabled>> for the API endpoints.
+
+[[verify-mtls-sasl]]
+=== Verify that mTLS and SASL are enabled
+
+To verify that mTLS is enabled for the Kafka API, run the following `rpk` command, without providing a security certificate or key:
+
+[,bash]
+----
+rpk cluster info --tls-enabled
+----
+
+You should get the following error:
+
+```
+unable to request metadata: remote error: tls: certificate required
+```
+
+=== Retrieve API endpoints
+
+Retrieve the mTLS and SASL-enabled endpoints by calling the GET /v1/clusters/{id} endpoint, passing the cluster ID as a parameter.
+
+[,bash]
+----
+
+----
+
+
+For Kafka API, use the `mtls` and `sasl` values in the `kafka_api.all_seed_brokers` field in the response.
+
+For HTTP Proxy, use the values in `http_proxy.all_urls`.
+
+For Schema Registry, use the values in `schema_registry.all_urls`.
+
+=== Consume and produce with mTLS and SASL enabled
 
 When you consume, produce to, or manage topics using xref:ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[`rpk`], you must provide a client certificate and private key. You may use the `--tls-cert` and `--tls-key` options, or xref:ROOT:reference:rpk/rpk-x-options.adoc[environment variables] with `rpk`.
 


### PR DESCRIPTION
## Description

New doc on simultaneously enabling mTLS and SASL for Kafka API, HTTP Proxy, and Schema Registry on GCP clusters.

Also adds a new matrix to more easily convey what auth protocols are available for which Redpanda services based on cloud provider.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 9 May

## Page previews

[Enable mTLS + SASL authentication](https://deploy-preview-279--rp-cloud.netlify.app/redpanda-cloud/security/cloud-authentication/#mtls-sasl)
[What's New in Redpanda Cloud
](https://deploy-preview-279--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#april-2025)
<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)