### PR TITLE
DOC-1325 update metadata in cloud-docs single sourcing

### DIFF
--- a/modules/develop/pages/consume-data/consumer-offsets.adoc
+++ b/modules/develop/pages/consume-data/consumer-offsets.adoc
@@ -1,4 +1,5 @@
 = Consumer Offsets
+:description: pass:q[Redpanda uses an internal topic, `__consumer_offsets`, to store committed offsets from each Kafka consumer that is attached to Redpanda.]
 :page-aliases: introduction:consumer-offsets.adoc, development:consumer-offsets.adoc
 :page-categories: Clients, Development
 include::ROOT:develop:consume-data/consumer-offsets.adoc[tag=single-source]

--- a/modules/develop/pages/consume-data/consumer-offsets.adoc
+++ b/modules/develop/pages/consume-data/consumer-offsets.adoc
@@ -1,5 +1,5 @@
 = Consumer Offsets
 :description: pass:q[Redpanda uses an internal topic, `__consumer_offsets`, to store committed offsets from each Kafka consumer that is attached to Redpanda.]
 :page-aliases: introduction:consumer-offsets.adoc, development:consumer-offsets.adoc
-:page-categories: Clients, Development
+
 include::ROOT:develop:consume-data/consumer-offsets.adoc[tag=single-source]

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -1,4 +1,4 @@
 = Follower Fetching
-:page-categories: Clients, Development
 :description: Learn about follower fetching and how to configure a Redpanda consumer to fetch records from the closest replica.
+
 include::ROOT:develop:consume-data/follower-fetching.adoc[tag=single-source]

--- a/modules/develop/pages/consume-data/follower-fetching.adoc
+++ b/modules/develop/pages/consume-data/follower-fetching.adoc
@@ -1,3 +1,4 @@
 = Follower Fetching
 :page-categories: Clients, Development
+:description: Learn about follower fetching and how to configure a Redpanda consumer to fetch records from the closest replica.
 include::ROOT:develop:consume-data/follower-fetching.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -1,6 +1,5 @@
 = Develop Data Transforms
 :description: Learn how to initialize a data transforms project and write transform functions in your chosen language.
-:page-categories: Development, Stream Processing, Data Transforms
 
 NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
 

--- a/modules/develop/pages/data-transforms/configure.adoc
+++ b/modules/develop/pages/data-transforms/configure.adoc
@@ -1,5 +1,4 @@
 = Configure Data Transforms
 :description: pass:q[Learn how to configure data transforms in Redpanda, including editing the `transform.yaml` file, environment variables, and memory settings. This topic covers both the configuration of transform functions and the WebAssembly (Wasm) engine's environment.]
-:page-categories: Development, Stream Processing, Data Transforms
 
 include::ROOT:develop:data-transforms/configure.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/deploy.adoc
+++ b/modules/develop/pages/data-transforms/deploy.adoc
@@ -1,5 +1,4 @@
 = Deploy Data Transforms
 :description: Learn how to build, deploy, share, and troubleshoot data transforms in Redpanda.
-:page-categories: Development, Stream Processing, Data Transforms
 
 include::ROOT:develop:data-transforms/deploy.adoc[tag=single-source]

--- a/modules/develop/pages/data-transforms/how-transforms-work.adoc
+++ b/modules/develop/pages/data-transforms/how-transforms-work.adoc
@@ -1,5 +1,4 @@
 = How Data Transforms Work
-:page-categories: Development, Stream Processing, Data Transforms
 :description: Learn how Redpanda data transforms work.
 :page-aliases: develop:data-transforms/run-transforms.adoc
 

--- a/modules/develop/pages/data-transforms/monitor.adoc
+++ b/modules/develop/pages/data-transforms/monitor.adoc
@@ -1,5 +1,4 @@
 = Monitor Data Transforms
 :description: This topic provides guidelines on how to monitor the health of your data transforms and view logs.
-:page-categories: Development, Stream Processing, Data Transforms
 
 include::ROOT:develop:data-transforms/monitor.adoc[tag=single-source]

--- a/modules/develop/pages/http-proxy.adoc
+++ b/modules/develop/pages/http-proxy.adoc
@@ -1,4 +1,5 @@
 = Use Redpanda with the HTTP Proxy API
 :page-aliases: development:http-proxy.adoc, develop:http-proxy-cloud.adoc
 :page-categories: Clients, Development
+:description: HTTP Proxy exposes a REST API to list topics, produce events, and subscribe to events from topics using consumer groups.
 include::ROOT:develop:http-proxy.adoc[tag=single-source]

--- a/modules/develop/pages/http-proxy.adoc
+++ b/modules/develop/pages/http-proxy.adoc
@@ -1,5 +1,5 @@
 = Use Redpanda with the HTTP Proxy API
 :page-aliases: development:http-proxy.adoc, develop:http-proxy-cloud.adoc
-:page-categories: Clients, Development
 :description: HTTP Proxy exposes a REST API to list topics, produce events, and subscribe to events from topics using consumer groups.
+
 include::ROOT:develop:http-proxy.adoc[tag=single-source]

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -1,5 +1,5 @@
 = Kafka Compatibility
 :page-aliases: development:kafka-clients.adoc
-:page-categories: Clients, Development, Kafka Compatibility
 :description: Kafka clients, version 0.11 or later, are compatible with Redpanda. Validations and exceptions are listed.
+
 include::ROOT:develop:kafka-clients.adoc[tag=single-source]

--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -1,4 +1,5 @@
 = Kafka Compatibility
 :page-aliases: development:kafka-clients.adoc
 :page-categories: Clients, Development, Kafka Compatibility
+:description: Kafka clients, version 0.11 or later, are compatible with Redpanda. Validations and exceptions are listed.
 include::ROOT:develop:kafka-clients.adoc[tag=single-source]

--- a/modules/develop/pages/managed-connectors/create-mysql-source-connector.adoc
+++ b/modules/develop/pages/managed-connectors/create-mysql-source-connector.adoc
@@ -1,7 +1,6 @@
 = Create a MySQL (Debezium) Source Connector
 :description: Use the Redpanda Cloud UI to create a MySQL (Debezium) Source Connector.
 :page-aliases: deploy:deployment-option/cloud/managed-connectors/create-mysql-source-connector.adoc
-:page-categories: Deployment, Integration
 
 You can use a MySQL (Debezium) Source connector to import a stream of changes from MySQL,
 AmazonRDS, and Amazon Aurora.

--- a/modules/develop/pages/managed-connectors/create-postgresql-connector.adoc
+++ b/modules/develop/pages/managed-connectors/create-postgresql-connector.adoc
@@ -1,7 +1,6 @@
 = Create a PostgreSQL (Debezium) Source Connector
 :description: Use the Redpanda Cloud UI to create a PostgreSQL (Debezium) Source Connector.
 :page-aliases: deploy:deployment-option/cloud/managed-connectors/create-postgresql-connector.adoc
-:page-categories: Deployment, Integration
 
 You can use a PostgreSQL (Debezium) Source connector to import updates to Redpanda from PostgreSQL.
 

--- a/modules/develop/pages/managed-connectors/create-sqlserver-connector.adoc
+++ b/modules/develop/pages/managed-connectors/create-sqlserver-connector.adoc
@@ -1,7 +1,6 @@
 = Create a SQL Server (Debezium) Source Connector
 :description: Use the Redpanda Cloud UI to create a SQL Server (Debezium) Source Connector.
 :page-aliases: deploy:deployment-option/cloud/managed-connectors/create-sqlserver-connector.adoc
-:page-categories: Deployment, Integration
 
 You can use an SQL Server (Debezium) Source connector to import updates to Redpanda from SQL Server.
 

--- a/modules/develop/pages/managed-connectors/index.adoc
+++ b/modules/develop/pages/managed-connectors/index.adoc
@@ -2,7 +2,6 @@
 :description: Use Kafka Connect to stream data into and out of Redpanda.
 :page-layout: index
 :page-aliases: cloud:managed-connectors/index.adoc, cloud:managed-connectors/index/index.adoc, deploy:deployment-option/cloud/managed-connectors/index.adoc
-:page-categories: Deployment, Integration
 
 Use Kafka Connect to integrate your Redpanda data with different
 data systems. As managed solutions, connectors offer a simpler way to integrate

--- a/modules/develop/pages/produce-data/configure-producers.adoc
+++ b/modules/develop/pages/produce-data/configure-producers.adoc
@@ -1,4 +1,5 @@
 = Configure Producers
 :page-aliases: development:configure-producers.adoc
 :page-categories: Clients, Development
+:description: Learn about configuration options for producers, including write caching and acknowledgment settings.
 include::ROOT:develop:produce-data/configure-producers.adoc[tag=single-source]

--- a/modules/develop/pages/produce-data/configure-producers.adoc
+++ b/modules/develop/pages/produce-data/configure-producers.adoc
@@ -1,5 +1,5 @@
 = Configure Producers
 :page-aliases: development:configure-producers.adoc
-:page-categories: Clients, Development
 :description: Learn about configuration options for producers, including write caching and acknowledgment settings.
+
 include::ROOT:develop:produce-data/configure-producers.adoc[tag=single-source]

--- a/modules/develop/pages/produce-data/idempotent-producers.adoc
+++ b/modules/develop/pages/produce-data/idempotent-producers.adoc
@@ -1,4 +1,5 @@
 = Idempotent Producers
 :page-aliases: development:idempotent-producers.adoc
 :page-categories: Clients, Development
+:description: Idempotent producers assign a unique ID to every write request, guaranteeing that each message is recorded only once in the order in which it was sent.
 include::ROOT:develop:produce-data/idempotent-producers.adoc[tag=single-source]

--- a/modules/develop/pages/produce-data/idempotent-producers.adoc
+++ b/modules/develop/pages/produce-data/idempotent-producers.adoc
@@ -1,5 +1,5 @@
 = Idempotent Producers
 :page-aliases: development:idempotent-producers.adoc
-:page-categories: Clients, Development
 :description: Idempotent producers assign a unique ID to every write request, guaranteeing that each message is recorded only once in the order in which it was sent.
+
 include::ROOT:develop:produce-data/idempotent-producers.adoc[tag=single-source]

--- a/modules/develop/pages/produce-data/leader-pinning.adoc
+++ b/modules/develop/pages/produce-data/leader-pinning.adoc
@@ -1,2 +1,3 @@
 = Leader Pinning
+:description: Learn about leader pinning and how to configure a preferred partition leader location based on cloud availability zones or regions.
 include::ROOT:develop:produce-data/leader-pinning.adoc[tag=single-source]

--- a/modules/develop/pages/produce-data/leader-pinning.adoc
+++ b/modules/develop/pages/produce-data/leader-pinning.adoc
@@ -1,3 +1,4 @@
 = Leader Pinning
 :description: Learn about leader pinning and how to configure a preferred partition leader location based on cloud availability zones or regions.
+
 include::ROOT:develop:produce-data/leader-pinning.adoc[tag=single-source]

--- a/modules/develop/pages/transactions.adoc
+++ b/modules/develop/pages/transactions.adoc
@@ -1,4 +1,5 @@
 = Transactions
 :page-aliases: development:transactions.adoc
 :page-categories: Clients, Development
+:description: Learn how to use transactions; for example, you can fetch messages starting from the last consumed offset and transactionally process them one by one, updating the last consumed offset and producing events at the same time.
 include::ROOT:develop:transactions.adoc[tag=single-source]

--- a/modules/develop/pages/transactions.adoc
+++ b/modules/develop/pages/transactions.adoc
@@ -1,5 +1,5 @@
 = Transactions
 :page-aliases: development:transactions.adoc
-:page-categories: Clients, Development
 :description: Learn how to use transactions; for example, you can fetch messages starting from the last consumed offset and transactionally process them one by one, updating the last consumed offset and producing events at the same time.
+
 include::ROOT:develop:transactions.adoc[tag=single-source]

--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -1,5 +1,5 @@
 = How Redpanda Works
 :page-aliases: introduction:architecture.adoc
-:page-categories: Architecture
 :description: Learn specifics about Redpanda architecture.
+
 include::ROOT:get-started:architecture.adoc[tag=single-source]

--- a/modules/get-started/pages/architecture.adoc
+++ b/modules/get-started/pages/architecture.adoc
@@ -1,4 +1,5 @@
 = How Redpanda Works
 :page-aliases: introduction:architecture.adoc
 :page-categories: Architecture
+:description: Learn specifics about Redpanda architecture.
 include::ROOT:get-started:architecture.adoc[tag=single-source]

--- a/modules/get-started/pages/cluster-types/byoc/aws/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/index.adoc
@@ -1,4 +1,3 @@
 = BYOC: AWS
 :description: Learn how to create a BYOC or BYOVPC cluster on AWS.
 :page-layout: index
-:page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/azure/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/index.adoc
@@ -1,4 +1,3 @@
 = BYOC: Azure
 :description: Learn how to create a BYOC or BYOVPC cluster on Azure.
 :page-layout: index
-:page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/index.adoc
@@ -1,4 +1,3 @@
 = BYOC: GCP
 :description: Learn how to create a BYOC or BYOVPC cluster on GCP.
 :page-layout: index
-:page-categories: Deployment 

--- a/modules/get-started/pages/cluster-types/byoc/index.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/index.adoc
@@ -2,4 +2,3 @@
 :description: Learn how to create a Bring Your Own Cloud (BYOC) or Bring Your Own Virtual Private Cloud (BYOVPC) cluster.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/provision-a-byoc-cluster/index.adoc
-:page-categories: Deployment

--- a/modules/get-started/pages/config-topics.adoc
+++ b/modules/get-started/pages/config-topics.adoc
@@ -1,5 +1,4 @@
 = Manage Topics
-:page-categories: Clients, Development
 :description: Learn how to create topics, update topic configurations, and delete topics or records.
 
 include::ROOT:develop:config-topics.adoc[tag=single-source]

--- a/modules/get-started/pages/intro-to-events.adoc
+++ b/modules/get-started/pages/intro-to-events.adoc
@@ -1,4 +1,5 @@
 = Introduction to Redpanda
 :pp: {plus}{plus}
 :page-aliases: features:intro-to-events.adoc, introduction:intro-to-events.adoc
+:description: Learn about Redpanda event streaming.
 include::ROOT:get-started:intro-to-events.adoc[tag=single-source]

--- a/modules/get-started/pages/intro-to-events.adoc
+++ b/modules/get-started/pages/intro-to-events.adoc
@@ -2,4 +2,5 @@
 :pp: {plus}{plus}
 :page-aliases: features:intro-to-events.adoc, introduction:intro-to-events.adoc
 :description: Learn about Redpanda event streaming.
+
 include::ROOT:get-started:intro-to-events.adoc[tag=single-source]

--- a/modules/get-started/pages/partner-integration.adoc
+++ b/modules/get-started/pages/partner-integration.adoc
@@ -1,3 +1,4 @@
 = Partner Integrations
 :page-aliases: reference:partner-integration.adoc
+:description: Learn about Redpanda integrations built and supported by our partners.
 include::ROOT:get-started:partner-integration.adoc[tag=single-source]

--- a/modules/get-started/pages/partner-integration.adoc
+++ b/modules/get-started/pages/partner-integration.adoc
@@ -1,4 +1,5 @@
 = Partner Integrations
 :page-aliases: reference:partner-integration.adoc
 :description: Learn about Redpanda integrations built and supported by our partners.
+
 include::ROOT:get-started:partner-integration.adoc[tag=single-source]

--- a/modules/get-started/partials/quick-start-cloud.adoc
+++ b/modules/get-started/partials/quick-start-cloud.adoc
@@ -1,8 +1,6 @@
 = Redpanda Cloud Quickstart
 :description: Learn how to quickly start working with a cluster in Redpanda Cloud.
 
-:page-categories: Deployment, Development, rpk
-
 TIP: The fastest and easiest way to start data streaming is with a Serverless cluster free trial. Redpanda instantly prepares an account for you that includes a `welcome` cluster with a `hello-world` demo topic you can explore. You interact with Serverless clusters the same way you'd interact with Dedicated or BYOC clusters. To learn more, see xref:get-started:cluster-types/serverless.adoc[].
 
 The following steps describe how to spin up a Dedicated cluster with Redpanda Cloud, create a basic streaming application using the `rpk` command-line tool, and explore your cluster in glossterm:Redpanda Console[].

--- a/modules/manage/pages/audit-logging.adoc
+++ b/modules/manage/pages/audit-logging.adoc
@@ -1,6 +1,5 @@
 = Audit Logging
 :description: Learn how to use Redpanda's audit logging capabilities.
-:page-categories: Management, Security
 :env-linux: true
 
 NOTE: Audit logging is supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later. To configure audit logging, see xref:manage:cluster-maintenance/config-cluster.adoc[].

--- a/modules/manage/pages/audit-logging/audit-log-samples.adoc
+++ b/modules/manage/pages/audit-logging/audit-log-samples.adoc
@@ -1,5 +1,4 @@
 = Sample Audit Log Messages
 :description: Sample Redpanda audit log messages.
-:page-categories: Management, Security 
 
 include::ROOT:manage:audit-logging/audit-log-samples.adoc[tag=single-source] 

--- a/modules/manage/pages/cluster-maintenance/index.adoc
+++ b/modules/manage/pages/cluster-maintenance/index.adoc
@@ -1,4 +1,3 @@
 = Cluster Maintenance
 :description: Learn about cluster maintenance and configuration properties.
 :page-layout: index
-:page-categories: Management

--- a/modules/manage/pages/iceberg/about-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/about-iceberg-topics.adoc
@@ -1,7 +1,5 @@
 = About Iceberg Topics
 :description: Learn how Redpanda can integrate topics with Apache Iceberg.
-:page-categories: Iceberg, Integration, Management, High Availability, Data Replication
 :page-beta: true
-:env-cloud: true
 
 include::ROOT:manage:partial$iceberg/about-iceberg-topics.adoc[]

--- a/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
+++ b/modules/manage/pages/iceberg/choose-iceberg-mode.adoc
@@ -1,6 +1,5 @@
 = Choose an Iceberg Mode
 :description: Learn about supported Iceberg modes and how you can integrate schemas with Iceberg topics.
-:page-categories: Iceberg, Integration, Management, High Availability, Data Replication
 :page-beta: true
 
 include::ROOT:manage:iceberg/choose-iceberg-mode.adoc[tag=single-source]

--- a/modules/manage/pages/iceberg/query-iceberg-topics.adoc
+++ b/modules/manage/pages/iceberg/query-iceberg-topics.adoc
@@ -1,8 +1,6 @@
 = Query Iceberg Topics
 :description: Query Redpanda topic data stored in Iceberg tables, based on the topic Iceberg mode and schema.
-:page-categories: Iceberg, Integration, Management, High Availability, Data Replication
 :page-beta: true
-:env-cloud: true
 
 When you access Iceberg topics from a data lakehouse or other Iceberg-compatible tools, how you consume the data depends on the xref:manage:iceberg/about-iceberg-topics.adoc#enable-iceberg-integration[Iceberg mode] you've chosen for a topic, and whether you've registered a schema for the topic in the xref:manage:schema-reg/schema-reg-overview.adoc[Redpanda Schema Registry]. You do not need to rely on complex ETL jobs or pipelines to access real-time data from Redpanda.
 

--- a/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
+++ b/modules/manage/pages/iceberg/use-iceberg-catalogs.adoc
@@ -1,8 +1,6 @@
 = Use Iceberg Catalogs
 :description: Learn how to access Redpanda topic data stored in Iceberg tables, using table metadata or a catalog integration.
-:page-categories: Iceberg, Management, High Availability, Data Replication, Integration
 :page-beta: true
-:env-cloud: true
 
 include::ROOT:manage:partial$iceberg/use-iceberg-catalogs.adoc[]
 

--- a/modules/manage/pages/index.adoc
+++ b/modules/manage/pages/index.adoc
@@ -1,5 +1,3 @@
 = Manage
 :description: Manage Redpanda.
 :page-layout: index
-:page-aliases: data-management:index.adoc, data-management:index/index.adoc, manage:index/index.adoc
-:page-categories: Management

--- a/modules/manage/pages/rpk/broker-admin.adoc
+++ b/modules/manage/pages/rpk/broker-admin.adoc
@@ -1,4 +1,5 @@
 = Specify Broker Addresses for rpk
 :page-categories: rpk
 :page-aliases: get-started:rpk/broker-admin.adoc
+:description: pass:q[Learn how and when to specify Redpanda broker addresses for `rpk` commands, so `rpk` knows where to run Kafka-related commands.]
 include::ROOT:get-started:broker-admin.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/broker-admin.adoc
+++ b/modules/manage/pages/rpk/broker-admin.adoc
@@ -1,5 +1,5 @@
 = Specify Broker Addresses for rpk
-:page-categories: rpk
 :page-aliases: get-started:rpk/broker-admin.adoc
 :description: pass:q[Learn how and when to specify Redpanda broker addresses for `rpk` commands, so `rpk` knows where to run Kafka-related commands.]
+
 include::ROOT:get-started:broker-admin.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/config-rpk-profile.adoc
+++ b/modules/manage/pages/rpk/config-rpk-profile.adoc
@@ -1,4 +1,5 @@
 = rpk Profiles
 :page-aliases: get-started:rpk/config-rpk-profile.adoc
 :page-categories: rpk
+:description: pass:q[Use `rpk profile` to simplify your development experience with multiple Redpanda clusters by saving and reusing configurations for different clusters.]
 include::ROOT:get-started:config-rpk-profile.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/config-rpk-profile.adoc
+++ b/modules/manage/pages/rpk/config-rpk-profile.adoc
@@ -1,5 +1,5 @@
 = rpk Profiles
 :page-aliases: get-started:rpk/config-rpk-profile.adoc
-:page-categories: rpk
 :description: pass:q[Use `rpk profile` to simplify your development experience with multiple Redpanda clusters by saving and reusing configurations for different clusters.]
+
 include::ROOT:get-started:config-rpk-profile.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/intro-to-rpk.adoc
+++ b/modules/manage/pages/rpk/intro-to-rpk.adoc
@@ -1,4 +1,5 @@
 = Introduction to rpk
 :page-aliases: get-started:intro-to-rpk.adoc
 :page-categories: rpk
+:description: pass:q[Learn about `rpk` and how to use it to interact with your Redpanda cluster.]
 include::ROOT:get-started:intro-to-rpk.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/intro-to-rpk.adoc
+++ b/modules/manage/pages/rpk/intro-to-rpk.adoc
@@ -1,5 +1,5 @@
 = Introduction to rpk
 :page-aliases: get-started:intro-to-rpk.adoc
-:page-categories: rpk
 :description: pass:q[Learn about `rpk` and how to use it to interact with your Redpanda cluster.]
+
 include::ROOT:get-started:intro-to-rpk.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/rpk-install.adoc
+++ b/modules/manage/pages/rpk/rpk-install.adoc
@@ -1,4 +1,5 @@
 = Install or Update rpk
 :page-aliases: get-started:rpk-install.adoc, quickstart:rpk-install.adoc
 :page-categories: rpk
+:description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
 include::ROOT:get-started:rpk-install.adoc[tag=single-source]

--- a/modules/manage/pages/rpk/rpk-install.adoc
+++ b/modules/manage/pages/rpk/rpk-install.adoc
@@ -1,5 +1,5 @@
 = Install or Update rpk
 :page-aliases: get-started:rpk-install.adoc, quickstart:rpk-install.adoc
-:page-categories: rpk
 :description: pass:q[Install or update `rpk` to interact with Redpanda from the command line.]
+
 include::ROOT:get-started:rpk-install.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/index.adoc
+++ b/modules/manage/pages/schema-reg/index.adoc
@@ -2,4 +2,3 @@
 :description: Redpanda's Schema Registry provides the interface to store and manage event schemas.
 :page-layout: index
 :page-aliases: manage:schema-registry.adoc
-:page-categories: Management, Schema Registry

--- a/modules/manage/pages/schema-reg/programmable-push-filters.adoc
+++ b/modules/manage/pages/schema-reg/programmable-push-filters.adoc
@@ -1,5 +1,4 @@
 = Programmable Push Filters
-:page-aliases: console:features/programmable-push-filters.adoc, reference:console/programmable-push-filters.adoc
 :description: Learn how to filter Kafka records in Redpanda Cloud based on your provided JavaScript code.
 
 include::ROOT:reference:console/programmable-push-filters.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/record-deserialization.adoc
+++ b/modules/manage/pages/schema-reg/record-deserialization.adoc
@@ -1,5 +1,4 @@
 = Deserialization
-:page-aliases: console:features/record-deserialization.adoc, manage:console/protobuf.adoc, reference:console/record-deserialization.adoc
 :description: Learn how Redpanda Cloud deserializes messages.
 
 include::ROOT:reference:console/record-deserialization.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -1,4 +1,4 @@
 = Use the Schema Registry API
-:page-categories: Management, Schema Registry
 :description: Perform common Schema Registry management operations with the API.
+
 include::ROOT:manage:schema-reg/schema-reg-api.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-api.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-api.adoc
@@ -1,3 +1,4 @@
 = Use the Schema Registry API
 :page-categories: Management, Schema Registry
+:description: Perform common Schema Registry management operations with the API.
 include::ROOT:manage:schema-reg/schema-reg-api.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -1,4 +1,4 @@
 = Redpanda Schema Registry
-:page-categories: Management, Schema Registry
 :description: Redpanda's Schema Registry provides the interface to store and manage event schemas.
+
 include::ROOT:manage:schema-reg/schema-reg-overview.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-overview.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-overview.adoc
@@ -1,4 +1,4 @@
 = Redpanda Schema Registry
-:page-aliases: console:features/schema-registry.adoc, manage:console/schema-registry.adoc
 :page-categories: Management, Schema Registry
+:description: Redpanda's Schema Registry provides the interface to store and manage event schemas.
 include::ROOT:manage:schema-reg/schema-reg-overview.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-ui.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-ui.adoc
@@ -1,5 +1,4 @@
 = Use Schema Registry
-:page-categories: Management, Schema Registry
 :description: Perform common Schema Registry management operations in Redpanda Cloud.
 
 include::ROOT:manage:schema-reg/schema-reg-ui.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-ui.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-ui.adoc
@@ -1,6 +1,5 @@
 = Use Schema Registry
 :page-categories: Management, Schema Registry
-:page-aliases: deploy:deployment-option/cloud/schema-reg-cloud.adoc
 :description: Perform common Schema Registry management operations in Redpanda Cloud.
 
 include::ROOT:manage:schema-reg/schema-reg-ui.adoc[tag=single-source]

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -1,6 +1,5 @@
 = Redpanda Terraform Provider
 :description: Use the Redpanda Terraform provider to create and manage Redpanda Cloud resources.
-:page-cloud: true
 :page-beta: true
 
 The https://registry.terraform.io/providers/redpanda-data/redpanda/latest[Redpanda Terraform provider^] allows you to manage your Redpanda Cloud infrastructure as code using https://www.terraform.io/[Terraform^]. Terraform is an infrastructure-as-code tool that enables you to define, automate, and version-control your infrastructure configurations.

--- a/modules/networking/pages/byoc/aws/index.adoc
+++ b/modules/networking/pages/byoc/aws/index.adoc
@@ -1,4 +1,3 @@
 = AWS
 :description: Learn how to configure private networking for BYOC clusters on GCP. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/byoc/azure/index.adoc
+++ b/modules/networking/pages/byoc/azure/index.adoc
@@ -1,4 +1,3 @@
 = Azure
 :description: Learn how to configure private networking for BYOC clusters on Azure. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/byoc/gcp/index.adoc
+++ b/modules/networking/pages/byoc/gcp/index.adoc
@@ -1,4 +1,3 @@
 = GCP
 :description: Learn how to configure private networking for BYOC clusters on GCP. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/byoc/index.adoc
+++ b/modules/networking/pages/byoc/index.adoc
@@ -1,4 +1,3 @@
 = Networking: BYOC
 :description: Learn how to create a VPC peering connection, how to configure AWS PrivateLink, and how to configure GCP Private Service Connect. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/dedicated/aws/index.adoc
+++ b/modules/networking/pages/dedicated/aws/index.adoc
@@ -1,4 +1,3 @@
 = AWS
 :description: Learn how to configure private networking for Dedicated clusters on AWS. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/dedicated/azure/index.adoc
+++ b/modules/networking/pages/dedicated/azure/index.adoc
@@ -1,4 +1,3 @@
 = Azure
 :description: Learn how to configure private networking for Dedicated clusters on Azure. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/dedicated/gcp/index.adoc
+++ b/modules/networking/pages/dedicated/gcp/index.adoc
@@ -1,4 +1,3 @@
 = GCP
 :description: Learn how to configure private networking for Dedicated clusters on GCP. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/dedicated/index.adoc
+++ b/modules/networking/pages/dedicated/index.adoc
@@ -1,4 +1,3 @@
 = Networking: Dedicated
 :description: Learn how to create a VPC peering connection, how to configure AWS PrivateLink, and how to configure GCP Private Service Connect. 
 :page-layout: index
-:page-categories: Networking

--- a/modules/networking/pages/index.adoc
+++ b/modules/networking/pages/index.adoc
@@ -2,4 +2,3 @@
 :description: Learn about Redpanda Cloud networking options and fundamentals.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/networking/index.adoc
-:page-categories: Management, Networking

--- a/modules/reference/pages/data-transforms/golang-sdk.adoc
+++ b/modules/reference/pages/data-transforms/golang-sdk.adoc
@@ -1,5 +1,4 @@
 = Golang SDK for Data Transforms
 :description: Work with data transform APIs in Redpanda using Go.
-:page-categories: Development, Stream Processing, Data Transforms
 
 include::ROOT:reference:data-transforms/golang-sdk.adoc[tag=single-source]

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1,2 +1,3 @@
 = Metrics Reference
+:description: Metrics to create your system dashboard.
 include::ROOT:reference:public-metrics-reference.adoc[tag=single-source]

--- a/modules/reference/pages/public-metrics-reference.adoc
+++ b/modules/reference/pages/public-metrics-reference.adoc
@@ -1,3 +1,4 @@
 = Metrics Reference
 :description: Metrics to create your system dashboard.
+
 include::ROOT:reference:public-metrics-reference.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-delete.adoc
@@ -1,2 +1,3 @@
 = rpk cloud auth delete
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-auth-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-list.adoc
@@ -1,2 +1,3 @@
 = rpk cloud auth list
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-auth-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-use.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-use.adoc
@@ -1,2 +1,3 @@
 = rpk cloud auth use
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-auth-use.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth.adoc
@@ -1,2 +1,3 @@
 = rpk cloud auth
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-auth.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc-install.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc-install.adoc
@@ -1,2 +1,3 @@
 = rpk cloud byoc install
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-byoc-install.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc-uninstall.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc-uninstall.adoc
@@ -1,2 +1,3 @@
 = rpk cloud byoc uninstall
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-byoc-uninstall.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-byoc.adoc
@@ -1,2 +1,3 @@
 = rpk cloud byoc
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-byoc.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-cluster-select.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-cluster-select.adoc
@@ -1,2 +1,3 @@
 = rpk cloud cluster select
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-cluster-select.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-cluster.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-cluster.adoc
@@ -1,2 +1,3 @@
 = rpk cloud cluster
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-cluster.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-login.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-login.adoc
@@ -1,2 +1,3 @@
 = rpk cloud login
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-login.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-logout.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-logout.adoc
@@ -1,2 +1,3 @@
 = rpk cloud logout
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud-logout.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud.adoc
@@ -1,3 +1,4 @@
 = rpk cloud
 :page-aliases: reference:rpk/rpk-cloud.adoc
+
 include::ROOT:reference:partial$rpk-cloud/rpk-cloud.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-info.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-info.adoc
@@ -1,3 +1,4 @@
 = rpk cluster info
 :page-aliases: reference:rpk/rpk-cluster/rpk-cluster-metadata.adoc
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-info.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-logdirs-describe.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-logdirs-describe.adoc
@@ -1,2 +1,3 @@
 = rpk cluster logdirs describe
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-logdirs-describe.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-logdirs.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-logdirs.adoc
@@ -1,2 +1,3 @@
 = rpk cluster logdirs
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-logdirs.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-cancel-mount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-cancel-mount.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage cancel mount
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-cancel-mount.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mount.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage list mount
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-list-mount.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage list-mountable
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-list-mountable.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-mount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-mount.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage mount
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-mount.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-status-mount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-status-mount.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage status mount
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-status-mount.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-unmount.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-storage-unmount.adoc
@@ -1,2 +1,3 @@
 = rpk cluster storage unmount
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-storage-unmount.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-describe-producers.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-describe-producers.adoc
@@ -1,2 +1,3 @@
 = rpk cluster txn describe-producers
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-txn-describe-producers.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-describe.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-describe.adoc
@@ -1,2 +1,3 @@
 = rpk cluster txn describe
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-txn-describe.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-list.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn-list.adoc
@@ -1,2 +1,3 @@
 = rpk cluster txn list
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-txn-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster-txn.adoc
@@ -1,2 +1,3 @@
 = rpk cluster txn
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster-txn.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
+++ b/modules/reference/pages/rpk/rpk-cluster/rpk-cluster.adoc
@@ -1,2 +1,3 @@
 = rpk cluster
+
 include::ROOT:reference:rpk/rpk-cluster/rpk-cluster.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-commands.adoc
+++ b/modules/reference/pages/rpk/rpk-commands.adoc
@@ -1,3 +1,4 @@
 = rpk
 :page-aliases: reference:rpk-commands.adoc
+
 include::ROOT:reference:rpk/rpk-commands.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate-app.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate-app.adoc
@@ -1,3 +1,4 @@
 = rpk generate app
 :page-aliases: reference:rpk/rpk-generate.adoc
+
 include::ROOT:reference:rpk/rpk-generate/rpk-generate-app.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate-shell-completion.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate-shell-completion.adoc
@@ -1,2 +1,3 @@
 = rpk generate shell-completion
+
 include::ROOT:reference:rpk/rpk-generate/rpk-generate-shell-completion.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
+++ b/modules/reference/pages/rpk/rpk-generate/rpk-generate.adoc
@@ -1,2 +1,3 @@
 = rpk generate
+
 include::ROOT:reference:rpk/rpk-generate/rpk-generate.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-delete.adoc
@@ -1,2 +1,3 @@
 = rpk group delete
+
 include::ROOT:reference:rpk/rpk-group/rpk-group-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group-describe.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-describe.adoc
@@ -1,2 +1,3 @@
 = rpk group describe
+
 include::ROOT:reference:rpk/rpk-group/rpk-group-describe.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group-list.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-list.adoc
@@ -1,2 +1,3 @@
 = rpk group list
+
 include::ROOT:reference:rpk/rpk-group/rpk-group-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group-offset-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-offset-delete.adoc
@@ -1,2 +1,3 @@
 = rpk group offset-delete
+
 include::ROOT:reference:rpk/rpk-group/rpk-group-offset-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group-seek.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group-seek.adoc
@@ -1,2 +1,3 @@
 = rpk group seek
+
 include::ROOT:reference:rpk/rpk-group/rpk-group-seek.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-group/rpk-group.adoc
+++ b/modules/reference/pages/rpk/rpk-group/rpk-group.adoc
@@ -1,2 +1,3 @@
 = rpk group
+
 include::ROOT:reference:rpk/rpk-group/rpk-group.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-help.adoc
+++ b/modules/reference/pages/rpk/rpk-help.adoc
@@ -1,2 +1,3 @@
 = rpk help
+
 include::ROOT:reference:rpk/rpk-help.adoc[]

--- a/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-install.adoc
+++ b/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-install.adoc
@@ -1,2 +1,3 @@
 = rpk plugin install
+
 include::ROOT:reference:rpk/rpk-plugin/rpk-plugin-install.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-list.adoc
+++ b/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-list.adoc
@@ -1,2 +1,3 @@
 = rpk plugin list
+
 include::ROOT:reference:rpk/rpk-plugin/rpk-plugin-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-uninstall.adoc
+++ b/modules/reference/pages/rpk/rpk-plugin/rpk-plugin-uninstall.adoc
@@ -1,2 +1,3 @@
 = rpk plugin uninstall
+
 include::ROOT:reference:rpk/rpk-plugin/rpk-plugin-uninstall.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-plugin/rpk-plugin.adoc
+++ b/modules/reference/pages/rpk/rpk-plugin/rpk-plugin.adoc
@@ -1,3 +1,4 @@
 = rpk plugin
 :page-aliases: reference:rpk/rpk-plugin.adoc
+
 include::ROOT:reference:rpk/rpk-plugin/rpk-plugin.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-clear.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-clear.adoc
@@ -1,2 +1,3 @@
 = rpk profile clear
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-clear.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-create.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-create.adoc
@@ -1,2 +1,3 @@
 = rpk profile create
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-current.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-current.adoc
@@ -1,2 +1,3 @@
 = rpk profile current
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-current.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-delete.adoc
@@ -1,2 +1,3 @@
 = rpk profile delete
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-edit-globals.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-edit-globals.adoc
@@ -1,2 +1,3 @@
 = rpk profile edit-globals
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-edit-globals.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-edit.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-edit.adoc
@@ -1,2 +1,3 @@
 = rpk profile edit
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-edit.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-list.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-list.adoc
@@ -1,2 +1,3 @@
 = rpk profile list
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-print-globals.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-print-globals.adoc
@@ -1,2 +1,3 @@
 = rpk profile print-globals
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-print-globals.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-print.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-print.adoc
@@ -1,2 +1,3 @@
 = rpk profile print
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-print.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-prompt.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-prompt.adoc
@@ -1,2 +1,3 @@
 = rpk profile prompt
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-prompt.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-rename-to.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-rename-to.adoc
@@ -1,2 +1,3 @@
 = rpk profile rename-to
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-rename-to.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-set-globals.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-set-globals.adoc
@@ -1,2 +1,3 @@
 = rpk profile set-globals
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-set-globals.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-set.adoc
@@ -1,2 +1,3 @@
 = rpk profile set
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-set.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile-use.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile-use.adoc
@@ -1,2 +1,3 @@
 = rpk profile use
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile-use.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-profile/rpk-profile.adoc
+++ b/modules/reference/pages/rpk/rpk-profile/rpk-profile.adoc
@@ -1,3 +1,4 @@
 = rpk profile
 :page-aliases: reference:rpk/rpk-profile.adoc
+
 include::ROOT:reference:rpk/rpk-profile/rpk-profile.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level-get.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level-get.adoc
@@ -1,2 +1,3 @@
 = rpk registry compatibility-level get
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-compatibility-level-get.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level-set.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level-set.adoc
@@ -1,2 +1,3 @@
 = rpk registry compatibility-level set
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-compatibility-level-set.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-compatibility-level.adoc
@@ -1,2 +1,3 @@
 = rpk registry compatibility-level
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-compatibility-level.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-get.adoc
@@ -1,2 +1,3 @@
 = rpk registry mode get
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-mode-get.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-reset.adoc
@@ -1,2 +1,3 @@
 = rpk registry mode reset
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-mode-reset.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode-set.adoc
@@ -1,2 +1,3 @@
 = rpk registry mode set
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-mode-set.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-mode.adoc
@@ -1,2 +1,3 @@
 = rpk registry mode
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-mode.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-check-compatibility.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-check-compatibility.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema check-compatibility
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-check-compatibility.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-create.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-create.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema create
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-delete.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema delete
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-get.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-get.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema get
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-get.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-list.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-list.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema list
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-references.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema-references.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema references
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema-references.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-schema.adoc
@@ -1,2 +1,3 @@
 = rpk registry schema
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-schema.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject-delete.adoc
@@ -1,2 +1,3 @@
 = rpk registry subject delete
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-subject-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject-list.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject-list.adoc
@@ -1,2 +1,3 @@
 = rpk registry subject list
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-subject-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry-subject.adoc
@@ -1,2 +1,3 @@
 = rpk registry subject
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry-subject.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-registry/rpk-registry.adoc
+++ b/modules/reference/pages/rpk/rpk-registry/rpk-registry.adoc
@@ -1,2 +1,3 @@
 = rpk registry
+
 include::ROOT:reference:rpk/rpk-registry/rpk-registry.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-acl-create.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-acl-create.adoc
@@ -1,3 +1,4 @@
 = rpk security acl create
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-create.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-acl-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-acl-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-acl-delete.adoc
@@ -1,3 +1,4 @@
 = rpk security acl delete
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-delete.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-acl-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-acl-list.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-acl-list.adoc
@@ -1,3 +1,4 @@
 = rpk security acl list
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-list.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-acl-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-acl.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-acl.adoc
@@ -1,3 +1,4 @@
 = rpk security acl
 :page-aliases: reference:rpk/rpk-acl.adoc, reference:rpk/rpk-acl/rpk-acl.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-acl.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-assign.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-assign.adoc
@@ -1,2 +1,3 @@
 = rpk security role assign
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-assign.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-create.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-create.adoc
@@ -1,2 +1,3 @@
 = rpk security role create
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-delete.adoc
@@ -1,2 +1,3 @@
 = rpk security role delete
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-describe.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-describe.adoc
@@ -1,2 +1,3 @@
 = rpk security role describe
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-describe.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-list.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-list.adoc
@@ -1,2 +1,3 @@
 = rpk security role list
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role-unassign.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role-unassign.adoc
@@ -1,2 +1,3 @@
 = rpk security role unassign
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role-unassign.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-role.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-role.adoc
@@ -1,2 +1,3 @@
 = rpk security role
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-role.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-create.adoc
@@ -1,3 +1,4 @@
 = rpk security user create
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-create.adoc, reference:rpk/rpk-security/rpk-security-acl-user-create.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-user-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-delete.adoc
@@ -1,3 +1,4 @@
 = rpk security user delete
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-delete.adoc, reference:rpk/rpk-security/rpk-security-acl-user-delete.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-user-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-list.adoc
@@ -1,3 +1,4 @@
 = rpk security user list
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-list.adoc, reference:rpk/rpk-security/rpk-security-acl-user-list.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-user-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user-update.adoc
@@ -1,3 +1,4 @@
 = rpk security user update
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user-update.adoc, reference:rpk/rpk-security/rpk-security-acl-user-update.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-user-update.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security-user.adoc
@@ -1,3 +1,4 @@
 = rpk security user
 :page-aliases: reference:rpk/rpk-acl/rpk-acl-user.adoc, reference:rpk/rpk-security/rpk-security-acl-user.adoc
+
 include::ROOT:reference:rpk/rpk-security/rpk-security-user.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
+++ b/modules/reference/pages/rpk/rpk-security/rpk-security.adoc
@@ -1,2 +1,3 @@
 = rpk security
+
 include::ROOT:reference:rpk/rpk-security/rpk-security.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-add-partitions.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-add-partitions.adoc
@@ -1,2 +1,3 @@
 = rpk topic add-partitions
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-add-partitions.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-alter-config.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-alter-config.adoc
@@ -1,2 +1,3 @@
 = rpk topic alter-config
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-alter-config.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-consume.adoc
@@ -1,2 +1,3 @@
 = rpk topic consume
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-consume.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-create.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-create.adoc
@@ -1,2 +1,3 @@
 = rpk topic create
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-create.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-delete.adoc
@@ -1,2 +1,3 @@
 = rpk topic delete
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-describe.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-describe.adoc
@@ -1,2 +1,3 @@
 = rpk topic describe
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-describe.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-list.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-list.adoc
@@ -1,2 +1,3 @@
 = rpk topic list
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-produce.adoc
@@ -1,2 +1,3 @@
 = rpk topic produce
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-produce.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic-trim-prefix.adoc
@@ -1,2 +1,3 @@
 = rpk topic trim-prefix
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic-trim-prefix.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
+++ b/modules/reference/pages/rpk/rpk-topic/rpk-topic.adoc
@@ -1,3 +1,4 @@
 = rpk topic
 :page-aliases: reference:rpk/rpk-topic.adoc
+
 include::ROOT:reference:rpk/rpk-topic/rpk-topic.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-build.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-build.adoc
@@ -1,3 +1,4 @@
 = rpk transform build
 :page-aliases: labs:data-transform/rpk-transform-build.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-build.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-delete.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-delete.adoc
@@ -1,3 +1,4 @@
 = rpk transform delete
 :page-aliases: labs:data-transform/rpk-transform-delete.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-delete.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-deploy.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-deploy.adoc
@@ -1,3 +1,4 @@
 = rpk transform deploy
 :page-aliases: labs:data-transform/rpk-transform-deploy.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-deploy.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-init.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-init.adoc
@@ -1,3 +1,4 @@
 = rpk transform init
 :page-aliases: labs:data-transform/rpk-transform-init.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-init.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-list.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-list.adoc
@@ -1,3 +1,4 @@
 = rpk transform list
 :page-aliases: labs:data-transform/rpk-transform-list.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-list.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform-logs.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform-logs.adoc
@@ -1,2 +1,3 @@
 = rpk transform logs
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform-logs.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-transform/rpk-transform.adoc
+++ b/modules/reference/pages/rpk/rpk-transform/rpk-transform.adoc
@@ -1,3 +1,4 @@
 = rpk transform
 :page-aliases: labs:data-transform/rpk-transform.adoc
+
 include::ROOT:reference:rpk/rpk-transform/rpk-transform.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-version.adoc
+++ b/modules/reference/pages/rpk/rpk-version.adoc
@@ -1,2 +1,3 @@
 = rpk version
+
 include::ROOT:reference:rpk/rpk-version.adoc[]

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -1,2 +1,3 @@
 = rpk -X
+
 include::ROOT:reference:rpk/rpk-x-options.adoc[]

--- a/modules/security/pages/authorization/index.adoc
+++ b/modules/security/pages/authorization/index.adoc
@@ -2,4 +2,3 @@
 :description: Learn about Redpanda Cloud authorization.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/security/authorization/index.adoc
-:page-categories: Management, Security

--- a/modules/security/pages/authorization/rbac/acl.adoc
+++ b/modules/security/pages/authorization/rbac/acl.adoc
@@ -1,2 +1,3 @@
 = Use ACLs in the Data Plane
+
 include::ROOT:manage:security/authorization/acl.adoc[tag=single-source]

--- a/modules/security/pages/authorization/rbac/index.adoc
+++ b/modules/security/pages/authorization/rbac/index.adoc
@@ -1,4 +1,3 @@
 = Role-Based Access Control (RBAC)
 :description: Learn about using RBAC in the control plane and in the data plane.
 :page-layout: index
-:page-categories: Management, Security

--- a/modules/security/pages/authorization/rbac/rbac.adoc
+++ b/modules/security/pages/authorization/rbac/rbac.adoc
@@ -1,6 +1,5 @@
 = Use RBAC in the Control Plane
 :description: Use RBAC in the control plane to manage access to organization-level resources like clusters, resource groups, and networks.
-:page-categories: Management, Security
 
 Use Redpanda Cloud role-based access control (RBAC) in the glossterm:control plane[] to manage and restrict access to resources in your organization. For example, you could grant everyone access to clusters in a development resource group while limiting access to clusters in a production resource group. Or, you could limit access to geographically-dispersed clusters in accordance with data residency laws.  
 

--- a/modules/security/pages/authorization/rbac/rbac_dp.adoc
+++ b/modules/security/pages/authorization/rbac/rbac_dp.adoc
@@ -1,6 +1,5 @@
 = Use RBAC in the Data Plane
 :description: Use RBAC in the data plane to configure cluster-level permissions for provisioned users.
-:page-categories: Management, Security
 
 Use role-based access control (RBAC) in the glossterm:data plane[] to configure cluster-level permissions for provisioned users at scale. RBAC works in conjunction with all supported authentication methods.
 

--- a/modules/security/pages/index.adoc
+++ b/modules/security/pages/index.adoc
@@ -2,4 +2,3 @@
 :description: Learn about the fundamental building blocks of the Redpanda Cloud security.
 :page-layout: index
 :page-aliases: deploy:deployment-option/cloud/security/index.adoc
-:page-categories: Management, Security


### PR DESCRIPTION
## Description
This pull request standarizes metadata attributes in single-sourced files. It removes `:env-cloud: true` and `:page-categories:` For better SEO for Redpanda Cloud, it also adds `:description:` instead of single sourcing it from the file in the `docs` repo. (see `docs` update in https://github.com/redpanda-data/docs/pull/1114).

Resolves https://redpandadata.atlassian.net/browse/DOC-1325
Review deadline:

## Page previews
https://deploy-preview-284--rp-cloud.netlify.app/redpanda-cloud/develop/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)