### PR TITLE
DOC-1339 fix single sourcing

### DIFF
--- a/modules/manage/pages/rpk/config-rpk-profile.adoc
+++ b/modules/manage/pages/rpk/config-rpk-profile.adoc
@@ -1,5 +1,5 @@
 = rpk Profiles
-:page-aliases: get-started:rpk/config-rpk-profile.adoc
+:page-aliases: get-started:rpk/config-rpk-profile.adoc, get-started:config-rpk-profile.adoc
 :description: pass:q[Use `rpk profile` to simplify your development experience with multiple Redpanda clusters by saving and reusing configurations for different clusters.]
 
 include::ROOT:get-started:config-rpk-profile.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-help.adoc
+++ b/modules/reference/pages/rpk/rpk-help.adoc
@@ -1,3 +1,3 @@
 = rpk help
 
-include::ROOT:reference:rpk/rpk-help.adoc[]
+include::ROOT:reference:rpk/rpk-help.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-version.adoc
+++ b/modules/reference/pages/rpk/rpk-version.adoc
@@ -1,3 +1,3 @@
 = rpk version
 
-include::ROOT:reference:rpk/rpk-version.adoc[]
+include::ROOT:reference:rpk/rpk-version.adoc[tag=single-source]

--- a/modules/reference/pages/rpk/rpk-x-options.adoc
+++ b/modules/reference/pages/rpk/rpk-x-options.adoc
@@ -1,3 +1,3 @@
 = rpk -X
 
-include::ROOT:reference:rpk/rpk-x-options.adoc[]
+include::ROOT:reference:rpk/rpk-x-options.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1339
This pull request updates several `rpk` documentation files to use a specific tagged section for content inclusion. The changes ensure consistency and enable single-sourcing of documentation across files.

Documentation updates for single-sourcing:

* [`modules/reference/pages/rpk/rpk-help.adoc`](diffhunk://#diff-c04ec961a4f928339a256659fd23791a5904a9364f3894f78c858c42c9764c0aL3-R3): Updated the `include` directive to use the `tag=single-source` parameter for content inclusion.
* [`modules/reference/pages/rpk/rpk-version.adoc`](diffhunk://#diff-b7d57fffc2cc499493ba0442601caa03646877d10a5fdd9d861bc229a4e9284aL3-R3): Modified the `include` directive to reference the `tag=single-source` parameter for better content management.
* [`modules/reference/pages/rpk/rpk-x-options.adoc`](diffhunk://#diff-f82cde572d819d8060e796b9c4fa84187fbeaeb690909fa9f5125adb758ad43eL3-R3): Adjusted the `include` directive to include the tagged section `single-source` for consistency.
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)