### PR TITLE
DOC-1213 Document feature BYOC in GCP us-west2

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -7,6 +7,12 @@
 
 This page lists new features added in Redpanda Cloud.
 
+== May 2025
+
+=== Support for additional region
+
+xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters] on GCP now support the us-west2 (Los Angeles) region.
+
 == April 2025
 
 === Increased number of supported partitions

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -55,6 +55,7 @@ Google Cloud Platform (GCP)::
 | us-east1
 | us-east4
 | us-west1
+| us-west2
 |===
 --
 Amazon Web Services (AWS)::


### PR DESCRIPTION
## Description
This pull request introduces updates to the documentation for Redpanda Cloud, specifically adding support for a new GCP region. The changes ensure that the feature is reflected in both the "What's New" section and the list of supported regions.

* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R10-R15): Added an entry for May 2025 announcing support for the `us-west2` (Los Angeles) region for BYOC clusters on GCP.
* [`modules/reference/partials/tiers.adoc`](diffhunk://#diff-4a284041e150b37b311c93863e20d3d09c6fa62c1c3a3832c72f9c3469a6d867R58): Updated the list of supported GCP regions to include `us-west2`.

Resolves https://redpandadata.atlassian.net/browse/DOC-1213
Review deadline:

## Page previews
[What's New](https://deploy-preview-287--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[BYOC regions](https://deploy-preview-287--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/byoc-tiers/#byoc-supported-regions)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)