### PR TITLE
Update vpc-byo-aws.adoc - Connect by default

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -64,6 +64,7 @@ You can update the example configuration to customize your setup:
 "condition_tags": {
   "redpanda-managed": "true"
 },
+- Redpanda Connect is enabled by default. To explicitly disable Redpanda Connect, set the following variable in the tfvars file: `"enable_redpanda_connect": true` and remove the additional security groups and node instance profiles that are required for Redpanda Connect. 
 ```
 
 Example configuration:
@@ -87,7 +88,6 @@ cat > byoc.auto.tfvars.json <<EOF
     "use2-az3"
   ],
   "create_rpk_user": true,
-  "enable_redpanda_connect": true,
   "enable_private_link": false,
   "create_rpk_user": true,
   "force_destroy_cloud_storage": true,

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -58,13 +58,13 @@ You can update the example configuration to customize your setup:
 
 - Enable PrivateLink (`"enable_private_link": true`).
 - Preserve cluster data when deleting the cluster (`"force_destroy_cloud_storage": false`).
+- Redpanda Connect is enabled by default. To disable Redpanda Connect, set `"enable_redpanda_connect": false` in the `tfvars` file, and remove the additional security groups and node instance profiles that are required for Redpanda Connect. 
 - Use https://docs.aws.amazon.com/IAM/latest/UserGuide/access_iam-tags.html[condition tags^] to control resource modifications based on AWS tags. For example:
 +
 ```json
 "condition_tags": {
   "redpanda-managed": "true"
 },
-- Redpanda Connect is enabled by default. To explicitly disable Redpanda Connect, set the following variable in the tfvars file: `"enable_redpanda_connect": true` and remove the additional security groups and node instance profiles that are required for Redpanda Connect. 
 ```
 
 Example configuration:

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -58,7 +58,7 @@ You can update the example configuration to customize your setup:
 
 - Enable PrivateLink (`"enable_private_link": true`).
 - Preserve cluster data when deleting the cluster (`"force_destroy_cloud_storage": false`).
-- Redpanda Connect is enabled by default. To disable Redpanda Connect, set `"enable_redpanda_connect": false` in the `tfvars` file, and remove the additional security groups and node instance profiles that are required for Redpanda Connect. 
+- Redpanda Connect is enabled by default. To disable Redpanda Connect, set `"enable_redpanda_connect": false` in the `byoc.auto.tfvars.json` file, and remove the additional security groups and node instance profiles that are required for Redpanda Connect. 
 - Use https://docs.aws.amazon.com/IAM/latest/UserGuide/access_iam-tags.html[condition tags^] to control resource modifications based on AWS tags. For example:
 +
 ```json


### PR DESCRIPTION
## Description

Ensures that our docs uses default for Redpanda Connect on BYOVPC AWS is opt out via docs., with some information on how to disable it explicitly. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)