### PR TITLE
DOC-1310 Add google_drive_download processor to Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-1310_Add_google_drive_download_processor
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -216,6 +216,7 @@
 **** xref:develop:connect/components/processors/gcp_bigquery_select.adoc[]
 **** xref:develop:connect/components/processors/gcp_vertex_ai_chat.adoc[]
 **** xref:develop:connect/components/processors/gcp_vertex_ai_embeddings.adoc[]
+**** xref:develop:connect/components/processors/google_drive_download.adoc[]
 **** xref:develop:connect/components/processors/group_by.adoc[]
 **** xref:develop:connect/components/processors/group_by_value.adoc[]
 **** xref:develop:connect/components/processors/http.adoc[]

--- a/modules/develop/pages/connect/components/processors/google_drive_download.adoc
+++ b/modules/develop/pages/connect/components/processors/google_drive_download.adoc
@@ -1,0 +1,4 @@
+= google_drive_download
+:page-aliases: components:processors/google_drive_download.adoc
+
+include::redpanda-connect:components:processors/google_drive_download.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves [DOC-1310](https://redpandadata.atlassian.net/browse/DOC-1310)
Review deadline: 14 May

This pull request introduces updates to the documentation for Redpanda Connect, specifically adding support for the new Google Drive Download processor. The changes include updating the branch for the `rp-connect-docs` repository, adding navigation for the new processor, and including its documentation.

### Updates for Google Drive Download Processor:

* **Branch Update for Documentation Source**:
  - Updated the branch in `local-antora-playbook.yml` for the `rp-connect-docs` repository to `DOC-1310_Add_google_drive_download_processor` to pull the relevant changes for the new processor.

* **Navigation Update**:
  - Added a navigation entry in `modules/ROOT/nav.adoc` for the new Google Drive Download processor documentation.

* **Documentation Inclusion**:
  - Included the Google Drive Download processor's documentation in `modules/develop/pages/connect/components/processors/google_drive_download.adoc` using a single-sourced reference.

## Page previews

[`google_drive_download` processor](https://deploy-preview-291--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/processors/google_drive_download/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1310]: https://redpandadata.atlassian.net/browse/DOC-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ