### PR TITLE
DOC-1311 Add google_drive_list_labels processor to cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: DOC-1311_Add_google_drive_list_labels_processor
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -20,7 +20,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: DOC-1311_Add_google_drive_list_labels_processor
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -216,6 +216,7 @@
 **** xref:develop:connect/components/processors/gcp_bigquery_select.adoc[]
 **** xref:develop:connect/components/processors/gcp_vertex_ai_chat.adoc[]
 **** xref:develop:connect/components/processors/gcp_vertex_ai_embeddings.adoc[]
+**** xref:develop:connect/components/processors/google_drive_list_labels.adoc[]
 **** xref:develop:connect/components/processors/group_by.adoc[]
 **** xref:develop:connect/components/processors/group_by_value.adoc[]
 **** xref:develop:connect/components/processors/http.adoc[]

--- a/modules/develop/pages/connect/components/processors/google_drive_list_labels.adoc
+++ b/modules/develop/pages/connect/components/processors/google_drive_list_labels.adoc
@@ -1,0 +1,3 @@
+= google_drive_list_labels
+:page-aliases: components:processors/google_drive_list_labels.adoc
+include::redpanda-connect:components:processors/google_drive_list_labels.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Resolves: [DOC-1311](https://redpandadata.atlassian.net/browse/DOC-1311)
Review deadline: 14 May

This pull request introduces a new processor, `google_drive_list_labels`, to the documentation and updates the relevant configuration and navigation files to include it. The most important changes are grouped below by theme.

### Documentation Updates:
* Added a new page for the `google_drive_list_labels` processor in `modules/develop/pages/connect/components/processors/google_drive_list_labels.adoc`. This includes a page alias and content sourced from a single source file.

### Configuration Changes:
* Updated the `branches` value in `local-antora-playbook.yml` for the `rp-connect-docs` repository to point to the `DOC-1311_Add_google_drive_list_labels_processor` branch.

### Navigation Updates:
* Added a navigation entry for the new `google_drive_list_labels` processor in `modules/ROOT/nav.adoc`.

## Page previews

[`google_drive_list_labels` processor](https://deploy-preview-292--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/processors/google_drive_list_labels/)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

[DOC-1311]: https://redpandadata.atlassian.net/browse/DOC-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ