### PR TITLE
Update vpc-byo-gcp.adoc - missing comma in BYOVPC role

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -498,7 +498,7 @@ cat << EOT > redpanda-gke.role
     "secretmanager.versions.access",
     "stackdriver.resourceMetadata.write",
     "storage.objects.get",
-    "storage.objects.list"
+    "storage.objects.list",
     "compute.instances.use",
     "iam.serviceAccounts.getAccessToken",
     "compute.regionNetworkEndpointGroups.create",


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)