### PR TITLE
DOC-1278 add clarification note for partition limits

### DIFF
--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -22,7 +22,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 * On Azure, tiers 1-5 are supported. 
 * Redpanda supports compute-optimized tiers with AWS Graviton3 processors.
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on the assumption that the Redpanda Cloud replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on Redpanda version 25.1 limits and the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -123,7 +123,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 [NOTE]
 ====
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on the assumption that the Redpanda Cloud replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on Redpanda version 25.1 limits and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -22,7 +22,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 * On Azure, tiers 1-5 are supported. 
 * Redpanda supports compute-optimized tiers with AWS Graviton3 processors.
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on Redpanda version 25.1 limits and the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on Redpanda version 25.1 limits and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -18,11 +18,11 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 |===
 
 [NOTE]
-====
-* On Azure, tiers 1-5 are supported. 
+==== 
+* Partition counts are based on clusters running Redpanda version 25.1 and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* On Azure, tiers 1-5 are supported.
 * Redpanda supports compute-optimized tiers with AWS Graviton3 processors.
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on clusters running Redpanda version 25.1 and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -122,8 +122,8 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 
 [NOTE]
 ====
-* Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
 * Partition counts are based on clusters running Redpanda version 25.1 and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -22,7 +22,7 @@ When you create a BYOC cluster, you select your usage tier. Each tier provides t
 * On Azure, tiers 1-5 are supported. 
 * Redpanda supports compute-optimized tiers with AWS Graviton3 processors.
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on Redpanda version 25.1 limits and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on clusters running Redpanda version 25.1 and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====
@@ -123,7 +123,7 @@ When you create a Dedicated cluster, you select your usage tier. Each tier provi
 [NOTE]
 ====
 * Depending on the workload, it may not be possible to achieve all maximum values. For example, a high number of partitions may make it more difficult to reach the maximum value in throughput.
-* Partition counts are based on Redpanda version 25.1 limits and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
+* Partition counts are based on clusters running Redpanda version 25.1 and on the assumption that the replication factor is 3 (default). If you set a higher replication factor, the maximum value for partitions will be lower.
 * Connections are regulated per broker for best performance. For example, in a tier 1 cluster with 3 brokers, there could be up to 3,000 connections per broker. 
 
 ====


### PR DESCRIPTION
## Description
This pull request updates documentation in the `modules/reference/partials/tiers.adoc` file to clarify partition count limits for Redpanda clusters. The changes specify that the limits are based on Redpanda version 25.1.

### Documentation updates:

* Updated partition count descriptions to specify that limits are based on Redpanda version 25.1 in the usage tier details for BYOC clusters.
* Updated partition count descriptions to specify that limits are based on Redpanda version 25.1 in the usage tier details for Dedicated clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1278
Review deadline:

## Page previews
[BYOC usage tiers](https://deploy-preview-300--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/byoc-tiers/#byoc-usage-tiers)
[Dedicate usage tiers](https://deploy-preview-300--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/dedicated-tiers/#dedicated-usage-tiers)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)