### PR TITLE
Add Iceberg Snowflake doc to Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, api, shared, site-search]
+    branches: ['DOC-1389-Iceberg-on-Cloud-Single-source-Snowflake-doc', v/*, api, shared, site-search]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: ['DOC-1389-Iceberg-on-Cloud-Single-source-Snowflake-doc', v/*, api, shared, site-search]
+    branches: [main, v/*, api, shared, site-search]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -397,6 +397,7 @@
 *** xref:manage:iceberg/choose-iceberg-mode.adoc[Choose Iceberg Mode]
 *** xref:manage:iceberg/use-iceberg-catalogs.adoc[]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[]
+*** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Query Iceberg Topics with Snowflake]
 ** xref:manage:schema-reg/index.adoc[Schema Registry]
 *** xref:manage:schema-reg/schema-reg-overview.adoc[]
 *** xref:manage:schema-reg/schema-reg-ui.adoc[]

--- a/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
+++ b/modules/manage/pages/iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc
@@ -1,0 +1,6 @@
+= Query Iceberg Topics using Snowflake and Open Catalog
+:description: Add Redpanda topics as Iceberg tables that you can query in Snowflake using an Open Catalog integration.
+:page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+:page-beta: true
+
+include::ROOT:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[tag=single-source]


### PR DESCRIPTION
## Description

This pull request introduces updates to the documentation to include a new feature for querying Iceberg topics with Snowflake. The most important changes involve adding a new branch to the Antora playbook, updating the navigation structure, and creating a new documentation page for this feature.

See related PR: https://github.com/redpanda-data/docs/pull/1131

### Documentation updates:

* **Antora playbook update**: Added the branch `'DOC-1389-Iceberg-on-Cloud-Single-source-Snowflake-doc'` to the `content:` section in `local-antora-playbook.yml` to include the new documentation source.
* **Navigation structure update**: Added a new navigation entry in `modules/ROOT/nav.adoc` for the page `redpanda-topics-iceberg-snowflake-catalog.adoc`, titled "Query Iceberg Topics with Snowflake."
* **New documentation page**: Created a new page `redpanda-topics-iceberg-snowflake-catalog.adoc` under `modules/manage/pages/iceberg/`. This page includes metadata, a description, and a reference to additional content for querying Iceberg topics in Snowflake using an Open Catalog integration.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

https://deploy-preview-302--rp-cloud.netlify.app/redpanda-cloud/manage/iceberg/redpanda-topics-iceberg-snowflake-catalog/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)