### PR TITLE
Update vpc-byo-aws.adoc - add create_internet_gateway flag

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -87,7 +87,6 @@ cat > byoc.auto.tfvars.json <<EOF
     "use2-az2",
     "use2-az3"
   ],
-  "create_rpk_user": true,
   "create_internet_gateway": true, 
   "enable_private_link": false,
   "create_rpk_user": true,

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -105,7 +105,7 @@ EOF
 
 ```
 
-NOTE: At least one public subnet is required to create a cluster. The example configuration includes multiple public subnets to allow for future scaling. The example above creates an Internet Gateway and an associated Route Table rule that exposes traffic into the VPC which allows the Redpanda Control Plane to access the cluster. To disable creation of the Internet Gateway, either remove the config and value for `create_internet_gateway` or set `"create_internet_gateway": false`.
+NOTE: At least one public subnet is required to create a cluster. The example configuration includes multiple public subnets to allow for future scaling. The example above creates an Internet Gateway and an associated Route Table rule that exposes traffic into the VPC, which allows the Redpanda Control Plane to access the cluster. To disable creation of the Internet Gateway, either remove the configuration and value for `create_internet_gateway` or set `"create_internet_gateway": false`.
 
 
 == Deploy Terraform

--- a/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/vpc-byo-aws.adoc
@@ -88,6 +88,7 @@ cat > byoc.auto.tfvars.json <<EOF
     "use2-az3"
   ],
   "create_rpk_user": true,
+  "create_internet_gateway": true, 
   "enable_private_link": false,
   "create_rpk_user": true,
   "force_destroy_cloud_storage": true,
@@ -104,7 +105,7 @@ EOF
 
 ```
 
-NOTE: At least one public subnet is required to create a cluster. The example configuration includes multiple public subnets to allow for future scaling. In addition, the VPC should have an Internet Gateway and an associated Route Table that exposes traffic into the VPC, and allows the Redpanda Control Plane to access the cluster.
+NOTE: At least one public subnet is required to create a cluster. The example configuration includes multiple public subnets to allow for future scaling. The example above creates an Internet Gateway and an associated Route Table rule that exposes traffic into the VPC which allows the Redpanda Control Plane to access the cluster. To disable creation of the Internet Gateway, either remove the config and value for `create_internet_gateway` or set `"create_internet_gateway": false`.
 
 
 == Deploy Terraform


### PR DESCRIPTION
## Description

If no internet gateway is provided (the default setting), then the creation of the BYOVPC cluster will fail. Related to change made in the `cloud-examples` repo: https://github.com/redpanda-data/cloud-examples/pull/50

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)