### PR TITLE
Serverless standard tiers should be removed

### DIFF
--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -353,7 +353,7 @@ resource "redpanda_cluster" "test" {
 
 === Create a Serverless cluster
 
-A Serverless cluster is cost-effective and scales automatically based on usage. This example creates a cluster in the `pro-us-east-1` region with minimal configuration.
+A Serverless cluster is cost-effective and scales automatically based on usage. This example creates a cluster in the `us-east-1` region with minimal configuration.
 
 [source,hcl]
 ----
@@ -394,7 +394,7 @@ variable "cluster_name" {
 
 variable "region" {
   description = "Region for the Serverless cluster"
-  default     = "pro-us-east-1"  # Default region for the cluster
+  default     = "us-east-1"  # Default region for the cluster
 }
 ----
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -269,7 +269,7 @@ TIP: When using a shell substitution variable for the token, use double quotes t
 {
     "serverless_regions": [
         {
-            "name": "pro-eu-central-1",
+            "name": "eu-central-1",
             "display_name": "eu-central-1",
             "default_timezone": {
                 "id": "Europe/Berlin",
@@ -279,7 +279,7 @@ TIP: When using a shell substitution variable for the token, use double quotes t
             "available": true
         },
         {
-            "name": "pro-us-east-1",
+            "name": "us-east-1",
             "display_name": "us-east-1",
             "default_timezone": {
                 "id": "America/New_York",
@@ -305,7 +305,7 @@ curl -H 'Content-Type: application/json' \
 -d '{
   "name": <serverless-cluster-name>,
   "resource_group_id": <resource-group-id>,
-  "serverless_region": "pro-us-east-1"
+  "serverless_region": "us-east-1"
 }' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 


### PR DESCRIPTION
## Description

Remove deprecated Serverless tiers from examples (for example, `pro-us-east-1`).
The work to mark Serverless standard as deprecated in the Cloud API has been applied in cloudv2 (https://github.com/redpanda-data/cloudv2/commit/a161e5ce364e29a91ed391dbca885637d2d2fd14#diff-86f882a25b800ddc897cd44c3e2dce7fa87bc61f0afca5eeafbdb7f532005110 and https://github.com/redpanda-data/cloudv2/commit/4fe2cf6f9de160859eace3129fe1f4c175066c6d).

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)