### PR TITLE
Add deprecation notice for Cloud API

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added to Redpanda Cloud.
 
 == May 2025
 
+=== Cloud API beta versions deprecated
+
+The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+
 === Read-only cluster configuration properties
 
 You can now xref:manage:cluster-maintenance/config-cluster.adoc#view-cluster-property-values[view the value of read-only cluster configuration properties] with `rpk cluster config` or with the Cloud API. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Properties] and xref:reference:properties/object-storage-properties.adoc[Object Storage Properties].

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,7 +9,7 @@ This page lists new features added to Redpanda Cloud.
 
 == May 2025
 
-=== Cloud API beta versions deprecated
+=== Cloud API beta versions: deprecated
 
 The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. 
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,15 @@ This page lists new features added to Redpanda Cloud.
 
 === Cloud API beta versions deprecated
 
-The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. 
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
 
 === Read-only cluster configuration properties
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -49,6 +49,8 @@ https://api.redpanda.com/v1/clusters
 
 The current Control Plane API version is *v1*.
 
+IMPORTANT: The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+
 === Data Plane APIs URL
 
 The Data Plane API base URL is unique to the individual target cluster. It is different for each cluster. When making requests to the Data Plane API endpoints, the request URL is the base URL, plus the API version, plus the resource path. For example:
@@ -59,6 +61,8 @@ https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1/users
 ----
 
 The current Data Plane API version is *v1*.
+
+IMPORTANT: The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
 
 == Pagination
 

--- a/modules/manage/pages/api/cloud-api-overview.adoc
+++ b/modules/manage/pages/api/cloud-api-overview.adoc
@@ -49,7 +49,18 @@ https://api.redpanda.com/v1/clusters
 
 The current Control Plane API version is *v1*.
 
-IMPORTANT: The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+[IMPORTANT]
+====
+The Control Plane API versions v1beta1 and v1beta2 are deprecated. v1beta1 and v1beta2 are still available, but they will be removed in a future release and are not recommended for use. 
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
+====
 
 === Data Plane APIs URL
 
@@ -62,7 +73,18 @@ https://api-aeb32d9b.cn20bu40d061nvem7sv0.fmc.prd.cloud.redpanda.com/v1/users
 
 The current Data Plane API version is *v1*.
 
-IMPORTANT: The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+[IMPORTANT]
+====
+The Data Plane API versions v1alpha1 and v1alpha2 are deprecated. v1alpha1 and v1alpha2 are still available, but they will be removed in a future release and are not recommended for use. 
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
+====
 
 == Pagination
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -115,7 +115,15 @@ See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 |===
 | Deprecated in | Feature | Details
 
-| May 2025 | Cloud API beta versions | The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
+| May 2025 | Cloud API beta versions a| The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. 
+
+The deprecation timeline is: 
+
+- Announcement date: May 27, 2025
+- End-of-support date: November 28, 2025
+- Retirement date: May 28, 2026
+
+See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
 | February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
 |===

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -125,5 +125,5 @@ The deprecation timeline is:
 
 See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
-| February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
+| February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 |===

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -115,6 +115,7 @@ See also: xref:manage:api/cloud-api-deprecation-policy.adoc[]
 |===
 | Deprecated in | Feature | Details
 
+| May 2025 | Cloud API beta versions | The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. See xref:manage:api/cloud-api-deprecation-policy.adoc[] for details.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
-| February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. 
+| February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].  
 |===


### PR DESCRIPTION
## Description

This pull request focuses on documenting the deprecation of several Cloud API beta versions and updating relevant sections across multiple documentation files. The most important changes involve adding notices about the deprecated API versions and linking to the deprecation policy for further details.

### Deprecation Notices for Cloud API Versions:

* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R12-R15): Added a new section under "May 2025" announcing the deprecation of Cloud Control Plane API versions `v1beta1` and `v1beta2`, and Data Plane API versions `v1alpha1` and `v1alpha2`. These versions are marked for future removal and are not recommended for use.

* [`modules/manage/pages/api/cloud-api-overview.adoc`](diffhunk://#diff-a925e672ba8c10f79e29531a747e44dff32effeeb1a7a48645dac60ff0e8f8e5R52-R53): Added deprecation notices for Control Plane API versions `v1beta1` and `v1beta2` and Data Plane API versions `v1alpha1` and `v1alpha2`, specifying that these versions are still available but will be removed in a future release. [[1]](diffhunk://#diff-a925e672ba8c10f79e29531a747e44dff32effeeb1a7a48645dac60ff0e8f8e5R52-R53) [[2]](diffhunk://#diff-a925e672ba8c10f79e29531a747e44dff32effeeb1a7a48645dac60ff0e8f8e5R65-R66)

* [`modules/manage/pages/maintenance.adoc`](diffhunk://#diff-531001571c634f60e334f3906cd4257a926abe42fe2c54fd92e3f90f2e1209cfR118): Updated the deprecation table to include the May 2025 deprecation of the aforementioned Cloud API versions, with a link to the deprecation policy for additional details.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

[Cloud API Overview](https://deploy-preview-306--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-api-overview/#base-urls)
[What's New ](https://deploy-preview-306--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#cloud-api-beta-versions-deprecated)
Upgrades and Maintenance > [Deprecated features](https://deploy-preview-306--rp-cloud.netlify.app/redpanda-cloud/manage/maintenance/#deprecated-features)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)