### PR TITLE
DOC-8 clarity how to enable tiered storage in Cloud

### DIFF
--- a/modules/get-started/pages/create-topic.adoc
+++ b/modules/get-started/pages/create-topic.adoc
@@ -14,7 +14,7 @@ include::develop:partial$topic-properties-warning.adoc[]
 <br>
 ++++
 
-[cols="2,2a"]
+[cols="1,2"]
 |===
 | Property | Description
 

--- a/modules/get-started/pages/create-topic.adoc
+++ b/modules/get-started/pages/create-topic.adoc
@@ -4,9 +4,15 @@
 
 
 
-After creating a cluster, you can create a topic for that cluster. Topic properties are populated from information stored in the broker. For Dedicated and BYOC clusters, you can optionally overwrite the default settings.
+Topics provide a way to organize events. After creating a cluster, you can create a topic in it. 
+
+Topic properties are populated from information stored in the broker. Redpanda features, such as Tiered Storage, are enabled and configured by default in Redpanda Cloud. For Dedicated and BYOC clusters, you can optionally overwrite some settings.
 
 include::develop:partial$topic-properties-warning.adoc[]
+
+++++
+<br>
+++++
 
 [cols="2,2a"]
 |===


### PR DESCRIPTION
## Description
This pull request updates the `create-topic.adoc` file to improve clarity and include additional details about Redpanda features. The most notable change is the addition of information about Tiered Storage being enabled by default in Redpanda Cloud.

Documentation improvements:

* [`modules/get-started/pages/create-topic.adoc`](diffhunk://#diff-06778b53581a732b5e0962d5126eaa6218bad56802d340dc828ae179fb2cc9a5L7-R16): Enhanced the description of topics to emphasize their role in organizing events and added a note about Tiered Storage being enabled and configurable by default in Redpanda Cloud.

Resolves https://redpandadata.atlassian.net/browse/DOC-8
Review deadline:

## Page previews
https://deploy-preview-307--rp-cloud.netlify.app/redpanda-cloud/get-started/create-topic/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)