### PR TITLE
DOC-1406 add CIDR doc for Azure

### DIFF
--- a/modules/networking/pages/cidr-ranges.adoc
+++ b/modules/networking/pages/cidr-ranges.adoc
@@ -2,32 +2,33 @@
 :description: Guidelines for choosing CIDR ranges when VPC peering.
 :page-aliases: deploy:deployment-option/cloud/cidr-ranges.adoc
 
-Choosing Classless Inter-Domain Routing (CIDR) ranges is an essential part of the VPC peering process, required to ensure that data can transfer successfully between Redpanda and your cloud provider. Redpanda supports the RFC 1918 standard for IP addresses. RFC 1918 addresses are used in private networks, which are not available, or reachable, from the internet.
+Choosing appropriate Classless Inter-Domain Routing (CIDR) ranges is essential for successful VPC peering between Redpanda and your cloud provider. Redpanda supports the RFC 1918 standard for IP addresses, which are used in private networks and not accessible from the internet.
 
-NOTE: These are general recommendations for choosing a CIDR range to peer. If you have a complex networking setup, work with a networking engineer to identify the Redpanda CIDRs that do not conflict with your existing VPCs.
+NOTE: These guidelines provide general recommendations for choosing non-conflicting CIDR ranges. If you have a complex networking setup, work with a networking engineer to identify Redpanda CIDRs that won't conflict with your existing VPCs.
 
 == Prerequisites
 
-* *VPC network*: Before setting up a peering connection in Redpanda Cloud, you must have another VPC to which Redpanda can connect. If you do not already have a network, create one in your cloud provider.
+* *VPC network or virtual network (VNet)*: Before setting up a peering connection in Redpanda Cloud, you must have another VPC or VNet to which Redpanda can connect. If you do not already have a network, create one in your cloud provider.
 * *Matching region*: VPC peering connections can only be established between networks created in the _same region_. Redpanda Cloud does not support inter-region VPC peering connections.
 
-TIP: Consider adding an `rp-` prefix to the VPC name to indicate that the VPC is for deploying a Redpanda cluster.
+TIP: Consider adding an `rp-` prefix to the VPC or VNet name to indicate that it is for deploying a Redpanda cluster.
 
 == What are CIDRs?
 
 The following CIDR ranges are a critical part of Redpanda's BYOC configuration:
 
-* Your existing (client) VPC CIDR
+* Your existing (client) VPC/VNet CIDR
 * Your Redpanda cluster CIDR
 
 It is important to ensure that these ranges do not overlap when setting up VPC peering.
 
 == Choose the CIDR ranges
 
-To choose a range for Redpanda, you must know your VPC CIDR:
+To choose a range for Redpanda, you must know your VPC or VNet CIDR:
 
 * In AWS, find it in the VPC area of the AWS Management Console, labeled *IPv4 CIDRs*.
-* In GCP, find it in the Details view of your VPC, and labeled *Internal IP Ranges*.
+* In Azure, find it in Essentials view of your virtual network, labeled *Address space*.
+* In GCP, find it in the Details view of your VPC, labeled *Internal IP Ranges*.
 
 You can check which IPs this range encompasses by using either the https://www.linux.com/topic/networking/how-calculate-network-addresses-ipcalc/[ipcalc^] command in your terminal or the https://www.ipaddressguide.com/cidr[CIDR calculation tool^]. For example, if your client's CIDR range is 10.0.0.0/20, run:
 
@@ -60,9 +61,9 @@ A limited set of examples that work with `10.0.0.0/20` are `10.8.0.0/20`, `10.0.
 
 Ranges like `10.0.0.6/20`, `10.0.8.0/20`, or `10.0.1.7/20` would not work. You can use http://trk.free.fr/ipcalc/tools.html[ipcalc^] to check for overlapping IPs.
 
-== Multi-VPC example
+== Multi-VPC/VNet example
 
-If you have many IP ranges allocated in a complex system, seek guidance from a network engineer who can help with IP allocation. Your Redpanda CIDR cannot overlap with any of your existing VPCs, nor can it overlap with the VPC you want to peer with.
+If you have many IP ranges allocated in a complex system, work with a network engineer who can help with IP allocation. Your Redpanda CIDR cannot overlap with any of your existing VPCs/Vnets, nor can it overlap with the VPC/VNet you want to peer with.
 
 Assume that the following example ranges are in use:
 


### PR DESCRIPTION
## Description
This pull request updates the `modules/networking/pages/cidr-ranges.adoc` file to enhance clarity and inclusivity by refining language and adding support for Azure virtual networks (VNets). The changes improve readability and ensure the documentation accommodates multiple cloud providers.

### Enhancements to documentation clarity:

* Simplified and refined explanations of CIDR ranges, emphasizing their role in VPC peering and aligning terminology for better readability.
* Updated recommendations to explicitly highlight the importance of avoiding IP conflicts in complex networking setups.

### Support for Azure VNets:

* Expanded references to include Azure VNets alongside VPCs, ensuring the documentation is relevant for Azure users. [[1]](diffhunk://#diff-9f4ed83f393e6be64f6c82c9da4c6931830020c17a0fef1a272425ec1902a383L5-R31) [[2]](diffhunk://#diff-9f4ed83f393e6be64f6c82c9da4c6931830020c17a0fef1a272425ec1902a383L63-R66)
* Added instructions for locating CIDR ranges in Azure's virtual network settings under the Essentials view.

### Terminology updates:

* Adjusted section headings and examples to consistently reference both VPCs and VNets, reflecting broader applicability across cloud platforms.

Resolves https://redpandadata.atlassian.net/browse/DOC-1406
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)