### PR TITLE
DOC-1357 add desupported date for Serverless Standard

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,12 @@ This page lists new features added to Redpanda Cloud.
 
 == May 2025
 
+=== Serverless Standard: deprecated
+
+Serverless Standard has been deprecated, and all existing clusters are migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
+
+- Retirement date: August 30, 2025
+
 === Cloud API beta versions: deprecated
 
 The Cloud Control Plane API versions v1beta1 and v1beta2, and Data Plane API versions v1alpha1 and v1alpha2 are deprecated. These Cloud API versions will be removed in a future release and are not recommended for use. 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Serverless Standard: deprecated
 
-Serverless Standard has been deprecated, and all existing clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
+Serverless Standard is deprecated. All existing clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
 
 - Retirement date: August 30, 2025
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Serverless Standard: deprecated
 
-Serverless Standard has been deprecated, and all existing clusters are migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
+Serverless Standard has been deprecated, and all existing clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
 
 - Retirement date: August 30, 2025
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -124,7 +124,7 @@ The deprecation timeline is:
 - Retirement date: May 28, 2026
 
 See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
-| March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. 
+| March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. Serverless Standard is deprecated.  
 
 All existing Serverless Standard clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -126,7 +126,7 @@ The deprecation timeline is:
 See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. 
 
-All existing Serverless Standard clusters are migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
+All existing Serverless Standard clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
 
 Retirement date: August 30, 2025
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -124,6 +124,11 @@ The deprecation timeline is:
 - Retirement date: May 28, 2026
 
 See xref:manage:api/cloud-api-deprecation-policy.adoc[] for more information.
-| March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. xref:get-started:cluster-types/serverless.adoc[Serverless clusters] include the higher usage limits, 99.9% SLA, additional regions, and the free trial. 
+| March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. 
+
+All existing Serverless Standard clusters are migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.
+
+Retirement date: August 30, 2025
+
 | February 2025 | Private Service Connect v1 | The Redpanda xref:networking:gcp-private-service-connect.adoc[GCP Private Service Connect v2] service provides the ability to allow requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 |===


### PR DESCRIPTION
## Description
This pull request updates documentation to reflect the deprecation and migration of the Serverless Standard platform and associated clusters. It also clarifies the deprecation timeline for related products.

### Serverless Standard deprecation and migration:

* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R12-R17): Added details about the deprecation of Serverless Standard, including migration of clusters to the new Serverless platform with higher usage limits, 99.9% SLA, and additional regions. Migration will occur on August 31, 2025, with a retirement date of August 30, 2025.
* [`modules/manage/pages/maintenance.adoc`](diffhunk://#diff-531001571c634f60e334f3906cd4257a926abe42fe2c54fd92e3f90f2e1209cfL127-R132): Updated the deprecation timeline to include migration details for Serverless Standard clusters to the new Serverless platform, along with the retirement date of August 30, 2025.

Resolves https://redpandadata.atlassian.net/browse/DOC-1357
Review deadline:

## Page previews
[What's New](https://deploy-preview-312--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[Deprecations](https://deploy-preview-312--rp-cloud.netlify.app/redpanda-cloud/manage/maintenance/#deprecated-features)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)