### PR TITLE
DOC-1374 one PL per connected client VPC

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -11,8 +11,10 @@ Consider using the PrivateLink endpoint service if you have multiple VPCs and co
 
 [NOTE]
 ====
-* PrivateLink allows overlapping CIDR ranges in VPC networks.
+* Each client VPC can have one endpoint connected to the PrivateLink service.
+* PrivateLink allows overlapping xref:networking:cidr-ranges.adoc[CIDR ranges] in VPC networks.
 * PrivateLink does not limit the number of VPC connections. However, VPC peering is limited to 125 connections. See https://aws.amazon.com/privatelink/faqs/[How scalable is AWS PrivateLink?^]
+* You control which AWS principals are allowed to connect to the endpoint service.
 ====
 
 After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-cluster-with-privatelink-endpoint-service-enabled,enable PrivateLink when creating a new cluster>>, or you can <<enable-privatelink-endpoint-service-for-existing-clusters,enable PrivateLink for existing clusters>>.

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -5,17 +5,16 @@ include::shared:partial$feature-flag.adoc[]
 
 The Redpanda Azure Private Link service provides secure access to Redpanda Cloud from your own virtual network. Traffic over Azure Private Link does not go through the public internet, but instead through Microsoft's backbone network. While clients can initiate connections against the Redpanda Cloud cluster endpoints, Redpanda Cloud services cannot access your virtual networks directly.
 
-Consider using Private Link if you have multiple virtual networks and require more secure network management.
+Consider using Private Link if you have multiple virtual networks and require more secure network management. To learn more, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
 
 [NOTE]
 ====
+* Each client VNet can have one endpoint connected to the Private Link service.
 * Private Link allows overlapping xref:networking:cidr-ranges.adoc[CIDR ranges] in virtual networks.
 * Private Link does not limit the number of connections.
 ====
 
 After <<get-a-cloud-api-access-token,getting an access token>>, you can <<create-new-cluster-with-private-link-service-enabled,enable Private Link when creating a new cluster>>, or you can <<enable-private-link-service-for-existing-clusters,enable Private Link for existing clusters>>.
-
-To learn more about Azure Private Link, see the https://learn.microsoft.com/en-us/azure/private-link/private-link-service-overview[Azure documentation].
 
 == Requirements
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -6,18 +6,21 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud UI. To configure and manage Private Service on an existing public cluster, you must use the xref:networking:gcp-private-service-connect.adoc[Redpanda Cloud API].
-* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. NOTE: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. DEPRECATION: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
-
 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because these connections are treated as their own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
-Consider using the endpoint services if you have multiple VPCs and could benefit from a more simplified approach to network management:
+Consider using the endpoint services if you have multiple VPCs and could benefit from a more simplified approach to network management.
 
+[NOTE]
+====
+* Each client VPC can have one endpoint connected to the Private Service Connect service.
 * Private Service Connect allows overlapping xref:networking:cidr-ranges.adoc[CIDR ranges] in VPC networks.
-* Private Service Connect does not limit the number of connections using the service.
-* You control which GCP projects are allowed to connect to the service.
+* Private Service Connect does not limit the number of connections.
+* You control from which GCP projects connections are allowed.
+====
 
 == Requirements
 

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -6,11 +6,15 @@ NOTE: This guide is for configuring AWS PrivateLink using the Redpanda Cloud UI.
 
 The Redpanda AWS PrivateLink endpoint service provides secure access to Redpanda Cloud from your own VPC. Traffic over PrivateLink does not go through the public internet because these connections are treated as their own private AWS service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
 
-Consider using the endpoint service if you have multiple VPCs and could benefit from a more simplified approach to network management:
+Consider using the endpoint service if you have multiple VPCs and could benefit from a more simplified approach to network management.
 
+[NOTE]
+====
+* Each client VPC can have one endpoint connected to the PrivateLink service.
 * PrivateLink allows overlapping xref:networking:cidr-ranges.adoc[CIDR ranges] in VPC networks.
-* PrivateLink does not limit the number of connections that use the endpoint service.
+* PrivateLink does not limit the number of VPC connections. However, VPC peering is limited to 125 connections. See https://aws.amazon.com/privatelink/faqs/[How scalable is AWS PrivateLink?^]
 * You control which AWS principals are allowed to connect to the endpoint service.
+====
 
 == Requirements
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -6,7 +6,7 @@
 ====
 
 * This guide is for configuring GCP Private Service Connect using the Redpanda Cloud API. To configure and manage Private Service Connect on an existing public cluster, you must use the Cloud API. See xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI] to set up the endpoint service using the Redpanda Cloud UI.
-* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. NOTE: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
+* The latest version of the Redpanda GCP Private Service Connect service (available March, 2025) supports AZ affinity. This allows requests from Private Service Connect endpoints to stay within the same availability zone, avoiding additional networking costs. To upgrade, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. DEPRECATION: The original GCP Private Service Connect service is deprecated and will be removed in a future release.
 ==== 
 
 The Redpanda GCP Private Service Connect service provides secure access to Redpanda Cloud from your own VPC. Traffic over Private Service Connect does not go through the public internet because a Private Service Connect connection is treated as its own private GCP service. While your VPC has access to the Redpanda VPC, Redpanda cannot access your VPC.
@@ -17,6 +17,7 @@ Consider using Private Service Connect if you have multiple VPCs and could benef
 
 [NOTE]
 ====
+* Each client VPC can have one endpoint connected to the Private Service Connect service.
 * Private Service Connect allows overlapping xref:networking:cidr-ranges.adoc[CIDR ranges] in VPC networks.
 * Private Service Connect does not limit the number of connections.
 * You control from which GCP projects connections are allowed.


### PR DESCRIPTION
## Description
This pull request updates documentation across several files to clarify features and limitations of private networking services (AWS PrivateLink, Azure Private Link, and GCP Private Service Connect). The changes include adding details about endpoint connections, updating deprecation notices, and improving references to related documentation.

### Updates to Private Networking Documentation:

#### AWS PrivateLink:
* Clarified that each client VPC can have one endpoint connected to the PrivateLink service. [[1]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acL14-R17) [[2]](diffhunk://#diff-c251c8951879bdb57e77fa5fda3a50ec9e7b4f77790279dd23e9bbe8f96d5284L9-R17)
* Added information about VPC peering limitations (125 connections) and included a reference to AWS PrivateLink FAQs. [[1]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acL14-R17) [[2]](diffhunk://#diff-c251c8951879bdb57e77fa5fda3a50ec9e7b4f77790279dd23e9bbe8f96d5284L9-R17)

#### Azure Private Link:
* Added a reference to Azure documentation for more details on Private Link services.
* Specified that each client VNet can have one endpoint connected to the Private Link service.

#### GCP Private Service Connect:
* Updated deprecation notice for the original GCP Private Service Connect service, marking it as deprecated and slated for removal in a future release. [[1]](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56L9-R23) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L9-R9)
* Clarified that each client VPC can have one endpoint connected to the Private Service Connect service. [[1]](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56L9-R23) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280R20)
* Improved phrasing for controlling connections from specific GCP projects. [[1]](diffhunk://#diff-2bfa9933fae9ea3a4c66b82b452f77f3f5828891997345a99631d5827d490e56L9-R23) [[2]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280R20)

Resolves https://redpandadata.atlassian.net/browse/DOC-1374
Review deadline:

## Page previews
AWS PrivateLink in UI
AWS PrivateLink in API
Azure Private Link
GPC PSC in UI
GCP PSC in API

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)