### PR TITLE
DOC-1415 add new AWS regions

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -429,7 +429,7 @@
 
 * xref:reference:index.adoc[Reference]
 ** xref:reference:tiers/index.adoc[Cloud Tiers and Regions]
-*** xref:reference:tiers/serverless-regions.adoc[Serverless Tiers]
+*** xref:reference:tiers/serverless-regions.adoc[]
 *** xref:reference:tiers/byoc-tiers.adoc[]
 *** xref:reference:tiers/dedicated-tiers.adoc[]
 ** xref:reference:api-reference.adoc[]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -429,6 +429,7 @@
 
 * xref:reference:index.adoc[Reference]
 ** xref:reference:tiers/index.adoc[Cloud Tiers and Regions]
+*** xref:reference:tiers/serverless-regions.adoc[Serverless Tiers]
 *** xref:reference:tiers/byoc-tiers.adoc[]
 *** xref:reference:tiers/dedicated-tiers.adoc[]
 ** xref:reference:api-reference.adoc[]

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -59,7 +59,7 @@ To create a Serverless cluster:
 
 . Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one. Refresh the page to see newly-created resource groups. 
 +
-Serverless clusters are currently available in certain AWS regions. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
+Serverless clusters are currently available in certain xref:reference:tiers/serverless-regions.adoc[AWS regions]. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
 
 . Go to the *Topics* page to create a topic. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -59,7 +59,7 @@ To create a Serverless cluster:
 
 . Enter a cluster name, then select the resource group. If you don't have an existing resource group, you can create one. Refresh the page to see newly-created resource groups. 
 +
-Serverless clusters are currently available in certain xref:reference:tiers/serverless-regions.adoc[AWS regions]. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
+Serverless clusters are available in the AWS regions listed in xref:reference:tiers/serverless-regions.adoc[Serverless regions]. Redpanda expects your applications to be deployed in the same AWS region. For best performance, select the region closest to your applications. Serverless is not guaranteed to be pinned to a particular availability zone within that region.
 
 . Go to the *Topics* page to create a topic. Under the *Actions* dropdown, you can produce messages to it. Add team members and grant them access with ACLs on the *Security* page. 
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Support for additional regions
 
-Serverless clusters now support the following xref:reference:tiers/serverless-regions.adoc[AWS regions]: ap-northeast-1 (Tokyo), ap-southeast-1 (Singapore), and eu-west-2 (London).
+Serverless clusters now support the following new xref:reference:tiers/serverless-regions.adoc[regions on AWS]: ap-northeast-1 (Tokyo), ap-southeast-1 (Singapore), and eu-west-2 (London).
 
 == May 2025
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -7,6 +7,12 @@
 
 This page lists new features added to Redpanda Cloud.
 
+== June 2025
+
+=== Support for additional regions
+
+Serverless clusters now support the following xref:reference:tiers/serverless-regions.adoc[AWS regions]: ap-northeast-1 (Toyko), ap-southeast-1 (Singapore), and eu-west-2 (London).
+
 == May 2025
 
 === Serverless Standard: deprecated

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -1,5 +1,5 @@
 = What's New in Redpanda Cloud
-:description: Summary of new features in Redpanada Cloud.
+:description: Summary of new features in Redpanda Cloud.
 :tag-pipeline-service: api:ROOT:cloud-dataplane-api.adoc#tag--Redpanda-Connect-Pipeline
 :page-aliases: deploy:deployment-option/cloud/whats-new-cloud.adoc
 :page-toclevels: 1

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Support for additional regions
 
-Serverless clusters now support the following xref:reference:tiers/serverless-regions.adoc[AWS regions]: ap-northeast-1 (Toyko), ap-southeast-1 (Singapore), and eu-west-2 (London).
+Serverless clusters now support the following xref:reference:tiers/serverless-regions.adoc[AWS regions]: ap-northeast-1 (Tokyo), ap-southeast-1 (Singapore), and eu-west-2 (London).
 
 == May 2025
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -278,21 +278,13 @@ TIP: When using a shell substitution variable for the token, use double quotes t
             "cloud_provider": "CLOUD_PROVIDER_AWS",
             "available": true
         },
-        {
-            "name": "us-east-1",
-            "display_name": "us-east-1",
-            "default_timezone": {
-                "id": "America/New_York",
-                "version": ""
-            },
-            "cloud_provider": "CLOUD_PROVIDER_AWS",
-            "available": true
-        }
+        ...
     ],
     "next_page_token": ""
 }
 ----
 
+You can also see a list of supported regions in xref:reference:tiers/serverless-regions.adoc[Serverless regions].
 
 === Create a new serverless cluster
 

--- a/modules/reference/pages/tiers/index.adoc
+++ b/modules/reference/pages/tiers/index.adoc
@@ -1,3 +1,3 @@
 = Tiers and Regions
-:description: When you create a BYOC or Dedicated cluster, you select your region and usage tier. Each tier provides guaranteed workload configurations for throughput, partitions (pre-replication), and connections.
+:description: When you create a cluster, you select your region. For BYOC and Dedicated clusters, you also select a usage tier, which provides guaranteed workload configurations for throughput, partitions (pre-replication), and connections.
 :page-layout: index

--- a/modules/reference/pages/tiers/serverless-regions.adoc
+++ b/modules/reference/pages/tiers/serverless-regions.adoc
@@ -1,0 +1,24 @@
+= Serverless Regions
+:description: Learn about supported regions for Serverless clusters. 
+
+
+== Serverless supported regions
+
+[tabs]
+====
+Amazon Web Services (AWS)::
++
+--
+|=== 
+| Region 
+
+| ap-northeast-1
+| ap-south-1
+| ap-southeast-1
+| eu-central-1
+| eu-west-2
+| us-east-1
+| us-west-2
+|===
+--
+====


### PR DESCRIPTION
## Description
This pull request adds supported regions for Serverless clusters. The changes include adding a new page for Serverless regions, updating references to these regions across various files, and enhancing descriptions for cluster creation.

### Updates to Serverless cluster regions:

* [`modules/reference/pages/tiers/serverless-regions.adoc`](diffhunk://#diff-5965ea26b4c5921a3afc0872272414398517542637a059a49c470af9d243d955R1-R24): Added a new page detailing supported regions for Serverless clusters, including AWS regions such as ap-northeast-1, ap-south-1, ap-southeast-1, eu-central-1, eu-west-2, us-east-1, and us-west-2.

### Documentation enhancements:

* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R432): Added a new navigation entry for the Serverless Regions page under the Reference section.
* [`modules/get-started/pages/cluster-types/serverless.adoc`](diffhunk://#diff-b9ada45e986054dd3c87aefcc43f539e63aff7eb5e016458549138ad6445ac73L62-R62): Updated the description of Serverless cluster availability to reference the new Serverless regions page for AWS regions.
* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R10-R15): Added a June 2025 entry announcing support for additional AWS regions for Serverless clusters, including Tokyo, Singapore, and London.

### General improvements:

* [`modules/reference/pages/tiers/index.adoc`](diffhunk://#diff-db252f7a631983a14caed9b4554321b538f66bb44cbbf8b78d4e15c43dc74c92L2-R2): Enhanced the description to clarify the selection process for regions and tiers when creating clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1415
Review deadline:

## Page previews
[What's New](https://deploy-preview-315--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[Serverless Regions](https://deploy-preview-315--rp-cloud.netlify.app/redpanda-cloud/reference/tiers/serverless-regions/)
[Create a Serverless cluster](https://deploy-preview-315--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#create-a-serverless-cluster)
[Control Plane API: Choose a region](https://deploy-preview-315--rp-cloud.netlify.app/redpanda-cloud/manage/api/cloud-serverless-controlplane-api/#choose-a-region)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)