### PR TITLE
DOC-1335 AWS transit gateway

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -30,6 +30,7 @@
 **** xref:networking:byoc/aws/vpc-peering-aws.adoc[Add a Peering Connection]
 **** xref:networking:configure-privatelink-in-cloud-ui.adoc[Configure PrivateLink in the Cloud UI]
 **** xref:networking:aws-privatelink.adoc[Configure PrivateLink with the Cloud API]
+**** xref:networking:byoc/aws/transit-gateway.adoc[Add a Transit Gateway]
 *** xref:networking:byoc/azure/index.adoc[Azure]
 **** xref:networking:azure-private-link.adoc[]
 *** xref:networking:byoc/gcp/index.adoc[GCP]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added to Redpanda Cloud.
 
 == June 2025
 
+=== Amazon VPC Transit Gateway
+
+For BYOC and BYOVPC clusters on AWS, you can set up an xref:networking:byoc/aws/transit-gateway.adoc[Amazon VPC Transit Gateway^] to connect VPCs to Redpanda services while maintaining control over network traffic. 
+
 === Support for additional regions
 
 Serverless clusters now support the following new xref:reference:tiers/serverless-regions.adoc[regions on AWS]: ap-northeast-1 (Tokyo), ap-southeast-1 (Singapore), and eu-west-2 (London).

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -11,7 +11,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Amazon VPC Transit Gateway
 
-For BYOC and BYOVPC clusters on AWS, you can set up an xref:networking:byoc/aws/transit-gateway.adoc[Amazon VPC Transit Gateway^] to connect VPCs to Redpanda services while maintaining control over network traffic. 
+For BYOC and BYOVPC clusters on AWS, you can set up an xref:networking:byoc/aws/transit-gateway.adoc[Amazon VPC Transit Gateway] to connect VPCs to Redpanda services while maintaining control over network traffic. 
 
 === Support for additional regions
 

--- a/modules/networking/pages/byoc/aws/transit-gateway.adoc
+++ b/modules/networking/pages/byoc/aws/transit-gateway.adoc
@@ -1,0 +1,22 @@
+= Add Amazon VPC Transit Gateway
+:description: Use a transit gateway to connect your BYOC cluster to AWS VPCs or on-premises networks.
+
+You can set up an https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html[Amazon VPC Transit Gateway^] to connect VPCs to Redpanda services while maintaining control over network traffic. The transit gateway acts as a central hub for routing traffic between VPCs, enabling communication between a Redpanda cluster and client applications hosted in different VPCs that can be in different AWS accounts.
+
+AWS Transit Gateway is available for BYOC and BYOVPC clusters.  
+
+== Set up Amazon VPC Transit Gateway
+
+To set up Amazon VPC Transit Gateway for Redpanda:
+
+. Create a transit gateway in your AWS account.
+. Create transit gateway attachments to the VPC hosting Redpanda and the VPC that will communicate to Redpanda (where producer or consumer resides).
+. Update the transit gateway route table with the new routes for Transit Gateway attachments.
+
+For detailed instructions, see the https://docs.aws.amazon.com/vpc/latest/tgw/tgw-transit-gateways.html[AWS Transit Gateways documentation^].
+
+== Example
+
+The https://github.com/redpanda-data/cloud-examples/blob/9e2083e4bd8392e288ab6991b2a5a9b77a5fb0c5/aws-transit-gateway/README.md[Redpanda Cloud Examples repository^] provides sample Terraform code to set up and manage an Amazon VPC Transit Gateway for accessing Redpanda services across multiple VPCs. It includes steps for when the Redpanda cluster and client applications are hosted in the same AWS account and in different AWS accounts.
+
+NOTE: Your implementation may differ depending on the networking configuration within your VPCs.

--- a/modules/networking/pages/byoc/aws/transit-gateway.adoc
+++ b/modules/networking/pages/byoc/aws/transit-gateway.adoc
@@ -10,8 +10,8 @@ AWS Transit Gateway is available for BYOC and BYOVPC clusters.
 To set up Amazon VPC Transit Gateway for Redpanda:
 
 . Create a transit gateway in your AWS account.
-. Create transit gateway attachments to the VPC hosting Redpanda and the VPC that will communicate to Redpanda (where producer or consumer resides).
-. Update the transit gateway route table with the new routes for Transit Gateway attachments.
+. Create transit gateway attachments to the VPC hosting Redpanda and the VPC that will communicate to Redpanda (where the producer or consumer resides).
+. Update the transit gateway route table with the new routes for transit gateway attachments.
 
 For detailed instructions, see the https://docs.aws.amazon.com/vpc/latest/tgw/tgw-transit-gateways.html[AWS Transit Gateways documentation^].
 

--- a/modules/networking/pages/byoc/aws/transit-gateway.adoc
+++ b/modules/networking/pages/byoc/aws/transit-gateway.adoc
@@ -1,7 +1,7 @@
 = Add Amazon VPC Transit Gateway
 :description: Use a transit gateway to connect your BYOC cluster to AWS VPCs or on-premises networks.
 
-You can set up an https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html[Amazon VPC Transit Gateway^] to connect VPCs to Redpanda services while maintaining control over network traffic. The transit gateway acts as a central hub for routing traffic between VPCs, enabling communication between a Redpanda cluster and client applications hosted in different VPCs that can be in different AWS accounts.
+You can set up an https://docs.aws.amazon.com/vpc/latest/tgw/what-is-transit-gateway.html[Amazon VPC Transit Gateway^] to connect your internal VPCs to Redpanda services while maintaining full control over network traffic. The transit gateway acts as a central hub for routing traffic between VPCs, enabling communication between a Redpanda cluster and client applications hosted in different VPCs that can be in different AWS accounts.
 
 AWS Transit Gateway is available for BYOC and BYOVPC clusters.  
 


### PR DESCRIPTION
## Description
This pull request introduces documentation updates to support the new Amazon VPC Transit Gateway feature for BYOC and BYOVPC clusters on AWS. The changes include adding a dedicated page for setup instructions, updating navigation links, and highlighting the feature in the "What's New" section.

Please see the README edits here: https://github.com/redpanda-data/cloud-examples/pull/54

### Documentation updates for Amazon VPC Transit Gateway:

* **New dedicated page for Transit Gateway setup**:
  Added `modules/networking/pages/byoc/aws/transit-gateway.adoc` with detailed instructions on setting up an Amazon VPC Transit Gateway, including an example using Terraform code from the Redpanda Cloud Examples repository.

* **Navigation update**:
  Updated the `modules/ROOT/nav.adoc` file to include a link to the new Transit Gateway documentation under the AWS networking section.

* **Feature announcement**:
  Updated the "What's New" section in `modules/get-started/pages/whats-new-cloud.adoc` to announce the availability of the Amazon VPC Transit Gateway feature for BYOC and BYOVPC clusters on AWS.

Resolves https://redpandadata.atlassian.net/browse/DOC-1335
Review deadline:

## Page previews
[What's New](https://deploy-preview-316--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[Amazon VPC Transit Gateway](https://deploy-preview-316--rp-cloud.netlify.app/redpanda-cloud/networking/byoc/aws/transit-gateway/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)