### PR TITLE
Add Databricks pages in Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: ['DOC-1045-databricks-ga', v/*, api, shared, site-search]
+    branches: [main, v/*, api, shared, site-search]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, api, shared, site-search]
+    branches: ['DOC-1045-databricks-ga', v/*, api, shared, site-search]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -398,6 +398,7 @@
 *** xref:manage:iceberg/choose-iceberg-mode.adoc[Choose Iceberg Mode]
 *** xref:manage:iceberg/use-iceberg-catalogs.adoc[]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[]
+*** xref:manage:iceberg/iceberg-topics-databricks-unity.adoc[Query Iceberg Topics with Databricks Unity Catalog]
 *** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Query Iceberg Topics with Snowflake]
 ** xref:manage:schema-reg/index.adoc[Schema Registry]
 *** xref:manage:schema-reg/schema-reg-overview.adoc[]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -1,5 +1,6 @@
 = Query Iceberg Topics using Databricks and Unity Catalog
 :description: Add Redpanda topics as Iceberg tables that you can query in Databricks managed by Unity Catalog.
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+:page-beta: true
 
 include::ROOT:manage:iceberg/iceberg-topics-databricks-unity.adoc[tag=single-source]

--- a/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc
@@ -1,0 +1,5 @@
+= Query Iceberg Topics using Databricks and Unity Catalog
+:description: Add Redpanda topics as Iceberg tables that you can query in Databricks managed by Unity Catalog.
+:page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+
+include::ROOT:manage:iceberg/iceberg-topics-databricks-unity.adoc[tag=single-source]


### PR DESCRIPTION
## Description

This pull request introduces updates to documentation related to Iceberg integration with Databricks Unity Catalog and modifies the Antora playbook configuration. The changes include adding new documentation pages, updating navigation links, and adjusting branch references in the playbook.

### Documentation updates:

* [`modules/ROOT/nav.adoc`](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R401): Added a new navigation link for querying Iceberg topics with Databricks Unity Catalog.
* [`modules/manage/pages/iceberg/iceberg-topics-databricks-unity.adoc`](diffhunk://#diff-a8cc69134db34c0afe324812dbe0c1c9ec51c399f09a25e0c32d137913f81791R1-R5): Introduced a new documentation page for querying Redpanda topics as Iceberg tables in Databricks managed by Unity Catalog.

### Antora playbook configuration:

* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L18-R18): Updated branch references for the `documentation` repository to include `'DOC-1045-databricks-ga'`.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline: 11 June

## Page previews

https://deploy-preview-321--rp-cloud.netlify.app/redpanda-cloud/manage/iceberg/iceberg-topics-databricks-unity/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)