### PR TITLE
DOC-1444 use different property in cluster config example

### DIFF
--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -28,11 +28,11 @@ You can set cluster configuration properties using the `rpk` command-line tool o
 --
 Use `rpk cluster config` to set cluster properties. 
 
-For example, to enable data transforms, set xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`:
+For example, to enable audit logging, set xref:reference:properties/cluster-properties.adoc#audit_enabled[`audit_enabled`] to `true`:
 
 [source,bash]
 ----
-rpk cluster config set data_transforms_enabled true
+rpk cluster config set audit_enabled true
 ----
 
 To set a cluster property with a secret, you must use the following notation:
@@ -55,7 +55,7 @@ Use the Cloud API to set cluster properties:
 
 * Update a cluster by making a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /v1/clusters/{cluster.id}`] request, passing the cluster ID as a parameter. Include the properties to update in the request body.
 
-For example, to set xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`] to `true`:
+For example, to set xref:reference:properties/cluster-properties.adoc#audit_enabled[`audit_enabled`] to `true`:
 
 [source,bash]
 ----
@@ -74,7 +74,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
   "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
  -H 'accept: application/json'\
  -H 'content-type: application/json' \
- -d '{"cluster_configuration":{"custom_properties": {"data_transforms_enabled":true}}}'
+ -d '{"cluster_configuration":{"custom_properties": {"audit_enabled":true}}}'
 ----
 
 The xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-[`PATCH /clusters/{cluster.id}`] request returns the ID of a long-running operation. You can check the status of the operation by polling the xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/operations/-id-[`GET /operations/\{id}`] endpoint.
@@ -111,11 +111,11 @@ You can see the value of a cluster configuration property using `rpk` or the Clo
 --
 Use `rpk cluster config get` to view the current cluster property value. 
 
-For example, to view the current value of xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`], run:
+For example, to view the current value of xref:reference:properties/cluster-properties.adoc#audit_enabled[`audit_enabled`], run:
 
 [source,bash]
 ----    
-rpk cluster config get data_transforms_enabled
+rpk cluster config get audit_enabled
 ----    
 
 
@@ -125,7 +125,7 @@ Cloud API::
 --
 Use the Cloud API to get the current configuration property values for a cluster.
 
-Make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /clusters/{cluster.id}`] request, passing the cluster ID as a parameter. The response body contains the current `computed_properties` values. For example, to get the current value of xref:reference:properties/cluster-properties.adoc#data_transforms_enabled[`data_transforms_enabled`]:
+Make a xref:api:ROOT:cloud-controlplane-api.adoc#get-/v1/clusters/-id-[`GET /clusters/{cluster.id}`] request, passing the cluster ID as a parameter. The response body contains the current `computed_properties` values. For example, to get the current value of xref:reference:properties/cluster-properties.adoc#audit_enabled[`audit_enabled`]:
 
 [source,bash]
 ----


### PR DESCRIPTION
## Description
This pull request updates the documentation in `modules/manage/pages/cluster-maintenance/config-cluster.adoc` to replace references to the `data_transforms_enabled` cluster property with the `audit_enabled` property. The changes ensure consistency across examples and instructions for setting and retrieving cluster configuration properties.

### Documentation updates:

* Updated examples to use `audit_enabled` instead of `data_transforms_enabled` in instructions for setting cluster properties with `rpk` (`rpk cluster config set`) and Cloud API (`PATCH /v1/clusters/{cluster.id}`). [[1]](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL31-R35) [[2]](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL58-R58) [[3]](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL77-R77)

* Updated examples to use `audit_enabled` instead of `data_transforms_enabled` in instructions for retrieving cluster property values with `rpk` (`rpk cluster config get`) and Cloud API (`GET /clusters/{cluster.id}`). [[1]](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL114-R118) [[2]](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL128-R128)

Resolves https://redpandadata.atlassian.net/browse/DOC-1444
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)