### PR TITLE
DOC-241 doc all possible cluster states

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -382,6 +382,7 @@
 
 * xref:manage:index.adoc[Manage]
 ** xref:manage:cluster-maintenance/index.adoc[Cluster Maintenance]
+*** xref:manage:cluster-maintenance/cluster-state.adoc[]
 *** xref:manage:maintenance.adoc[]
 *** xref:manage:cluster-maintenance/config-cluster.adoc[]
 *** xref:manage:audit-logging.adoc[]

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -14,7 +14,7 @@ Serverless::
 |Creating |Cluster is in the process of having its control plane state created.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
 |Failed |Cluster was unable to enter the ready state from either the creating or placing states.
-|Placing |Serverless cluster is in the process of being placed on a cell with sufficient resources in the data plane.
+|Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
 |Suspended |cluster is running but blocks all external requests.
 |Unspecified |
@@ -31,7 +31,6 @@ BYOC::
 |Deleted |Cluster is soft deleted.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.   
-|Deploy agent |Redpanda Cloud has been deployed
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
 |Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
 |Ready |Cluster is running and accepting external requests.

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -14,8 +14,8 @@ Serverless::
 |Creating |Cluster is in the process of having its control plane state created.
 |Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
-|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
+|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states.
 |Suspended |Cluster is running but blocks all external requests.
 |===
 --
@@ -28,11 +28,11 @@ BYOC/Dedicated::
 |Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.  
 |Creating |Cluster is in the process of having its control plane state created.
 |Ready |Cluster is running and accepting external requests.
-|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
-|Suspended |Cluster is running but blocks all external requests.
 |Upgrading |Cluster is undergoing a rolling upgrade or a scale-up/scale-down operation.
+|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
+|Suspended |Cluster is running but blocks all external requests.
 |===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -1,0 +1,64 @@
+= Cluster State
+:description: Learn about the current status of a cluster.
+
+Cluster state indicates the current status of a cluster. The cluster state is automatically updated by Redpanda Cloud and can be used to monitor the health and availability of the cluster.
+
+[tabs]
+=====
+Serverless::
++
+--
+[cols="1,4",options="header"]
+|===
+|State |Description
+|Creating |Cluster is in the process of having its control plane state created.
+|Deleted |Cluster is deleted.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|Failed |Cluster was unable to enter the ready state from either the creating or placing states.
+|Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
+|Ready |Cluster is running and accepting external requests.
+|Suspended |Cluster is running but blocks all external requests.
+|Unrecognized |
+|Unspecified |
+|===
+--
+BYOC::
++
+--
+[cols="1,4",options="header"]
+|===
+|State |Description
+|Creating |Cluster is in the process of having its control plane state created.
+|Creating agent |
+|Deleted |Cluster is deleted.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|Delete agent |
+|Deploy agent |Redpanda Cloud has been deployed
+|Failed |Cluster was unable to enter the ready state from either the creating or the creating_agent states.
+|Ready |Cluster is running and accepting external requests.
+|Resizing |
+|Suspended |Cluster is running but blocks all external requests.
+|Unknown |
+|Upgrading |
+|===
+--
+Dedicated::
++
+--
+[cols="1,4",options="header"]
+|===
+|State |Description
+|Creating |Cluster is in the process of having its control plane state created.
+|Creating agent |
+|Deleted |Cluster is deleted.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|Delete agent |
+|Failed |Cluster was unable to enter the ready state from either the creating or the creating_agent states.
+|Ready |Cluster is running and accepting external requests.
+|Resizing |
+|Suspended |Cluster is running but blocks all external requests.
+|Unknown |
+|Upgrading |
+|===
+--
+=====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -29,12 +29,10 @@ BYOC/Dedicated::
 |Creating |Cluster is in the process of having its control plane state created.
 |Ready |Cluster is running and accepting external requests.
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
-|Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
-|Deleted |Cluster is soft deleted.
 |Suspended |Cluster is running but blocks all external requests.
-|Upgrading |Cluster is undergoing a rolling upgrade.
+|Upgrading |Cluster is undergoing a rolling upgrade or a scale-up/scale-down operation.
 |===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -1,7 +1,7 @@
 = Cluster State
 :description: Learn about the current status of a cluster.
 
-The cluster state shows the current status of a cluster. Redpanda Cloud updates this state automatically, allowing you to monitor a cluster's health and availability.
+The cluster state shows the current status of a cluster. Redpanda Cloud updates the state automatically, allowing you to monitor a cluster's health and availability.
 
 [tabs]
 =====
@@ -11,14 +11,14 @@ Serverless::
 [cols="1,4",options="header"]
 |===
 |State |Description
-|Creating |Cluster is in the process of having its control plane state created.
-|Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
-|Ready |Cluster is running and accepting external requests.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
-|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states. +
+|*Creating* |Cluster is in the process of having its control plane state created.
+|*Placing* |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
+|*Ready* |Cluster is running and accepting external requests.
+|*Deleting* |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|*Failed* |Cluster was unable to enter the *Ready* state from either the *Creating* or *Placing* states. +
 Try re-creating the cluster.
-|Suspended |Cluster is running but blocks all external requests. +
-This can happen when credits run out. Enter a credit card to return to the Ready state. 
+|*Suspended* |Cluster is running but blocks all external requests. +
+This can happen when credits run out. Enter a credit card to return to the *Ready* state.
 |===
 --
 BYOC/Dedicated::
@@ -27,16 +27,15 @@ BYOC/Dedicated::
 [cols="1,4",options="header"]
 |===
 |State |Description
-|Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.  
-|Creating |Cluster is in the process of having its control plane state created.
-|Ready |Cluster is running and accepting external requests.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
-|Upgrading |Cluster is undergoing a rolling upgrade or a scaling operation.
-|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states. +
+|*Creating agent* |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.  
+|*Creating* |Cluster is in the process of having its control plane state created.
+|*Ready* |Cluster is running and accepting external requests.
+|*Deleting* |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|*Deleting agent* |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
+|*Upgrading* |Cluster is undergoing a rolling upgrade or a scaling operation.
+|*Failed* |Cluster was unable to enter the *Ready* state from either the *Creating* or the *Creating agent* states. +
 Try re-creating the cluster.
-|Suspended |Cluster is running but blocks all external requests. +
+|*Suspended* |Cluster is running but blocks all external requests. +
 This can happen when credits run out. Enter a credit card to return to the *Ready* state.
-|===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -15,7 +15,7 @@ Serverless::
 |*Placing* |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |*Ready* |Cluster is running and accepting external requests.
 |*Deleting* |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|*Failed* |Cluster was unable to enter the *Ready* state from either the *Creating* or *Placing* states. +
+|*Failed* |Cluster is unable to enter the *Ready* state from either the *Creating* or *Placing* states. +
 Try re-creating the cluster.
 |*Suspended* |Cluster is running but blocks all external requests. +
 This can happen when credits run out. Enter a credit card to return to the *Ready* state.
@@ -31,9 +31,9 @@ BYOC/Dedicated::
 |*Creating* |Cluster is in the process of having its control plane state created.
 |*Ready* |Cluster is running and accepting external requests.
 |*Deleting* |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|*Deleting agent* |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
+|*Deleting agent* |Cluster is in the process of having its control plane state and Redpanda Cloud agent removed. 
 |*Upgrading* |Cluster is undergoing a rolling upgrade or a scaling operation.
-|*Failed* |Cluster was unable to enter the *Ready* state from either the *Creating* or the *Creating agent* states. +
+|*Failed* |Cluster is unable to enter the *Ready* state from either the *Creating* or the *Creating agent* states. +
 Try re-creating the cluster.
 |*Suspended* |Cluster is running but blocks all external requests. +
 This can happen when credits run out. Enter a credit card to return to the *Ready* state.

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -1,7 +1,7 @@
 = Cluster State
 :description: Learn about the current status of a cluster.
 
-Cluster state indicates the current status of a cluster. The cluster state is automatically updated by Redpanda Cloud and can be used to monitor the health and availability of the cluster.
+The cluster state shows the current status of a cluster. Redpanda Cloud updates this state automatically, allowing you to monitor a cluster's health and availability.
 
 [tabs]
 =====
@@ -20,7 +20,7 @@ Serverless::
 |Unspecified |
 |===
 --
-BYOC::
+BYOC/Dedicated::
 +
 --
 [cols="1,4",options="header"]
@@ -31,25 +31,6 @@ BYOC::
 |Deleted |Cluster is soft deleted.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.   
-|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
-|Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
-|Ready |Cluster is running and accepting external requests.
-|Suspended |Cluster is running but blocks all external requests.
-|Upgrading |Cluster is undergoing a rolling upgrade.
-|Unspecified |
-|===
---
-Dedicated::
-+
---
-[cols="1,4",options="header"]
-|===
-|State |Description
-|Creating |Cluster is in the process of having its control plane state created.
-|Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.   
-|Deleted |Cluster is soft deleted.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.  
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
 |Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
 |Ready |Cluster is running and accepting external requests.

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -30,8 +30,8 @@ BYOC/Dedicated::
 |Ready |Cluster is running and accepting external requests.
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
 |Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released. 
 |Deleted |Cluster is soft deleted.
 |Suspended |Cluster is running but blocks all external requests.
 |Upgrading |Cluster is undergoing a rolling upgrade.

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -32,7 +32,7 @@ BYOC/Dedicated::
 |Ready |Cluster is running and accepting external requests.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
-|Upgrading |Cluster is undergoing a rolling upgrade or a scale-up/scale-down operation.
+|Upgrading |Cluster is undergoing a rolling upgrade or a scaling operation.
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states. +
 Try re-creating the cluster.
 |Suspended |Cluster is running but blocks all external requests. +

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -36,7 +36,7 @@ BYOC/Dedicated::
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states. +
 Try re-creating the cluster.
 |Suspended |Cluster is running but blocks all external requests. +
-This can happen when credits run out. Enter a credit card to return to the Ready state.
+This can happen when credits run out. Enter a credit card to return to the *Ready* state.
 |===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -16,7 +16,7 @@ Serverless::
 |Failed |Cluster was unable to enter the ready state from either the creating or placing states.
 |Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
-|Suspended |cluster is running but blocks all external requests.
+|Suspended |Cluster is running but blocks all external requests.
 |Unspecified |
 |===
 --

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -15,7 +15,8 @@ Serverless::
 |Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
-|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states.
+|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states. +
+Try re-creating the cluster.
 |Suspended |Cluster is running but blocks all external requests. +
 This can happen when credits run out. Enter a credit card to return to the Ready state. 
 |===
@@ -32,7 +33,8 @@ BYOC/Dedicated::
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
 |Upgrading |Cluster is undergoing a rolling upgrade or a scale-up/scale-down operation.
-|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
+|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states. +
+Try re-creating the cluster.
 |Suspended |Cluster is running but blocks all external requests. +
 This can happen when credits run out. Enter a credit card to return to the Ready state.
 |===

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -17,7 +17,6 @@ Serverless::
 |Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
 |Suspended |Cluster is running but blocks all external requests.
-|Unspecified |
 |===
 --
 BYOC/Dedicated::
@@ -36,7 +35,6 @@ BYOC/Dedicated::
 |Ready |Cluster is running and accepting external requests.
 |Suspended |Cluster is running but blocks all external requests.
 |Upgrading |Cluster is undergoing a rolling upgrade.
-|Unspecified |
 |===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -12,10 +12,10 @@ Serverless::
 |===
 |State |Description
 |Creating |Cluster is in the process of having its control plane state created.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
-|Failed |Cluster was unable to enter the ready state from either the creating or placing states.
 |Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
+|Failed |Cluster was unable to enter the ready state from either the Creating or Placing states.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
 |Suspended |Cluster is running but blocks all external requests.
 |===
 --
@@ -25,14 +25,14 @@ BYOC/Dedicated::
 [cols="1,4",options="header"]
 |===
 |State |Description
-|Creating |Cluster is in the process of having its control plane state created.
 |Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.  
-|Deleted |Cluster is soft deleted.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.   
+|Creating |Cluster is in the process of having its control plane state created.
+|Ready |Cluster is running and accepting external requests.
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
 |Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
-|Ready |Cluster is running and accepting external requests.
+|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released. 
+|Deleted |Cluster is soft deleted.
 |Suspended |Cluster is running but blocks all external requests.
 |Upgrading |Cluster is undergoing a rolling upgrade.
 |===

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -12,13 +12,11 @@ Serverless::
 |===
 |State |Description
 |Creating |Cluster is in the process of having its control plane state created.
-|Deleted |Cluster is deleted.
-|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
+|Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
 |Failed |Cluster was unable to enter the ready state from either the creating or placing states.
-|Placing |Cluster is in the process of being placed on a cell with sufficient resources in the data plane.
+|Placing |Serverless cluster is in the process of being placed on a cell with sufficient resources in the data plane.
 |Ready |Cluster is running and accepting external requests.
-|Suspended |Cluster is running but blocks all external requests.
-|Unrecognized |
+|Suspended |cluster is running but blocks all external requests.
 |Unspecified |
 |===
 --
@@ -29,17 +27,17 @@ BYOC::
 |===
 |State |Description
 |Creating |Cluster is in the process of having its control plane state created.
-|Creating agent |
-|Deleted |Cluster is deleted.
+|Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.  
+|Deleted |Cluster is soft deleted.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|Delete agent |
+|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.   
 |Deploy agent |Redpanda Cloud has been deployed
-|Failed |Cluster was unable to enter the ready state from either the creating or the creating_agent states.
+|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
+|Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
 |Ready |Cluster is running and accepting external requests.
-|Resizing |
 |Suspended |Cluster is running but blocks all external requests.
-|Unknown |
-|Upgrading |
+|Upgrading |Cluster is undergoing a rolling upgrade.
+|Unspecified |
 |===
 --
 Dedicated::
@@ -49,16 +47,16 @@ Dedicated::
 |===
 |State |Description
 |Creating |Cluster is in the process of having its control plane state created.
-|Creating agent |
-|Deleted |Cluster is deleted.
+|Creating agent |Cluster is in the process of having its control plane state created, and the Redpanda Cloud agent is being deployed.   
+|Deleted |Cluster is soft deleted.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane are released.
-|Delete agent |
-|Failed |Cluster was unable to enter the ready state from either the creating or the creating_agent states.
+|Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed.  
+|Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
+|Node operation in progress |Cluster is undergoing a node operation, such as adding or removing nodes.
 |Ready |Cluster is running and accepting external requests.
-|Resizing |
 |Suspended |Cluster is running but blocks all external requests.
-|Unknown |
-|Upgrading |
+|Upgrading |Cluster is undergoing a rolling upgrade.
+|Unspecified |
 |===
 --
 =====

--- a/modules/manage/pages/cluster-maintenance/cluster-state.adoc
+++ b/modules/manage/pages/cluster-maintenance/cluster-state.adoc
@@ -16,7 +16,8 @@ Serverless::
 |Ready |Cluster is running and accepting external requests.
 |Deleting |Cluster is in the process of having its control plane state removed. Resources dedicated to the cluster in the data plane will be released.
 |Failed |Cluster was unable to enter the ready state from either the Creating or Placing states.
-|Suspended |Cluster is running but blocks all external requests.
+|Suspended |Cluster is running but blocks all external requests. +
+This can happen when credits run out. Enter a credit card to return to the Ready state. 
 |===
 --
 BYOC/Dedicated::
@@ -32,7 +33,8 @@ BYOC/Dedicated::
 |Deleting agent |Cluster is in the process of having its control plane state removed, and the Redpanda Cloud agent is being removed. 
 |Upgrading |Cluster is undergoing a rolling upgrade or a scale-up/scale-down operation.
 |Failed |Cluster was unable to enter the Ready state from either the Creating or the Creating agent states.
-|Suspended |Cluster is running but blocks all external requests.
+|Suspended |Cluster is running but blocks all external requests. +
+This can happen when credits run out. Enter a credit card to return to the Ready state.
 |===
 --
 =====


### PR DESCRIPTION
## Description
This pull request introduces a new section to the documentation about cluster states, providing descriptions of various states for different cluster types (Serverless, BYOC, and Dedicated). 

### Documentation updates:

* **Added a new "Cluster State" page**: This page explains the various states a cluster can be in, categorized by cluster types (Serverless, BYOC, Dedicated). It includes detailed descriptions of each state, such as "Creating," "Ready," "Suspended," and more.

* **Updated navigation to include the "Cluster State" page**: Added a new entry under the "Cluster Maintenance" section in the navigation (`modules/ROOT/nav.adoc`).

Resolves https://redpandadata.atlassian.net/browse/DOC-241
Review deadline:

## Page previews
[Cluster State](https://deploy-preview-323--rp-cloud.netlify.app/redpanda-cloud/manage/cluster-maintenance/cluster-state/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)