### PR TITLE
DOC-1447 replace ciphersuites

### DIFF
--- a/modules/security/pages/cloud-encryption.adoc
+++ b/modules/security/pages/cloud-encryption.adoc
@@ -39,36 +39,18 @@ Preferred TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
 Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
 Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
 Accepted  TLSv1.3  128 bits  TLS_AES_128_CCM_SHA256        Curve 25519 DHE 253
+Preferred TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
+Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256
 Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
-Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-GCM-SHA384     DHE 2048 bits
-Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
-Accepted  TLSv1.2  256 bits  DHE-RSA-CHACHA20-POLY1305     DHE 2048 bits
-Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-CCM            DHE 2048 bits
-Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
-Accepted  TLSv1.2  128 bits  DHE-RSA-AES128-GCM-SHA256     DHE 2048 bits
-Accepted  TLSv1.2  128 bits  DHE-RSA-AES128-CCM            DHE 2048 bits
-Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.2  128 bits  DHE-RSA-AES128-SHA            DHE 2048 bits
 Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384
-Accepted  TLSv1.2  256 bits  AES256-CCM
-Preferred TLSv1.2  128 bits  AES128-GCM-SHA256
-Accepted  TLSv1.2  128 bits  AES128-CCM
-Accepted  TLSv1.2  256 bits  AES256-SHA
+Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
+Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
 Accepted  TLSv1.2  128 bits  AES128-SHA
-Preferred TLSv1.1  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.1  256 bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.1  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.1  128 bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  TLSv1.1  256 bits  AES256-SHA
-Accepted  TLSv1.1  128 bits  AES128-SHA
-Preferred TLSv1.0  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.0  256 bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.0  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.0  128 bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  TLSv1.0  256 bits  AES256-SHA
-Accepted  TLSv1.0  128 bits  AES128-SHA
+Accepted  TLSv1.2  128 bits  AES128-CCM
+Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
+Accepted  TLSv1.2  256 bits  AES256-SHA
+Accepted  TLSv1.2  256 bits  AES256-CCM
+
 Server Key Exchange Group(s):
 TLSv1.3  128 bits  secp256r1 (NIST P-256)
 TLSv1.3  192 bits  secp384r1 (NIST P-384)


### PR DESCRIPTION
## Description
This pull request updates the encryption protocol preferences and accepted cipher suites for TLS versions in the `modules/security/pages/cloud-encryption.adoc` file. The changes prioritize modern and secure configurations while removing support for older and less secure options.

### Updates to TLS protocol preferences and cipher suites:

* **TLSv1.2 Enhancements**:
  - Added `Preferred TLSv1.2 128 bits ECDHE-RSA-AES128-GCM-SHA256` and `Accepted TLSv1.2 128 bits AES128-GCM-SHA256` to the list of supported cipher suites.
  - Reintroduced `Accepted TLSv1.2 256 bits AES256-CCM` and `Accepted TLSv1.2 256 bits ECDHE-RSA-AES256-SHA`.

* **Removal of Legacy Support**:
  - Removed all cipher suites for TLSv1.0 and TLSv1.1, including `Preferred TLSv1.0 256 bits ECDHE-RSA-AES256-SHA` and `Accepted TLSv1.1 128 bits AES128-SHA`.
  - Dropped support for weaker TLSv1.2 cipher suites such as `DHE-RSA-AES256-GCM-SHA384` and `DHE-RSA

Resolves https://redpandadata.atlassian.net/browse/DOC-1447
Review deadline:

## Page previews
[Data in transit encryption](https://deploy-preview-327--rp-cloud.netlify.app/redpanda-cloud/security/cloud-encryption/#data-in-transit-encryption)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)