### PR TITLE
DOC-1448 update rpk transform in cloud overview

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [DOC-1407-single-source-additions-for-Cloud, v/*, api, shared, site-search]
+    branches: [main, v/*, api, shared, site-search]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -254,7 +254,6 @@ Redpanda Cloud deployments do not support the following functionality available 
 ** `rpk iotune`
 ** `rpk redpanda`
 ** `rpk topic describe-storage` (All other `rpk topic` commands are supported on both Redpanda Cloud and Self Managed.)
-** `rpk transform` (This is in beta for Redpanda Cloud.)
 +
 NOTE: The `rpk cloud` commands are not supported in Self-Managed deployments.
 


### PR DESCRIPTION
## Description
This pull request updates the `local-antora-playbook.yml` file to reflect changes in branch naming conventions and modifies the `cloud-overview.adoc` file to remove outdated information about beta features in Redpanda Cloud.

### Updates to branch naming conventions:
* [`local-antora-playbook.yml`](diffhunk://#diff-430ed78ec72afb78849cef359188c9b20a3dde4623593958cba0dfb974cb2ac9L18-R18): Changed the branch list for the `redpanda-data/documentation` repository to use `main` instead of the previously specific branch `DOC-1407-single-source-additions-for-Cloud`.

### Documentation adjustments:
* [`modules/get-started/pages/cloud-overview.adoc`](diffhunk://#diff-10401c3a5fb2293775dd5cfed082eea9183cddd81dbd8664ab04e35c1f407b0bL257): Removed the mention of `rpk transform` being in beta for Redpanda Cloud, as this information is no longer relevant.

Resolves https://redpandadata.atlassian.net/browse/DOC-1448
Review deadline:

## Page previews
[Cloud overview](https://deploy-preview-328--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-cloud-vs-self-managed-feature-compatibility)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)