### PR TITLE
DOC-1452 SR UI supported in Serverless

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -90,7 +90,6 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 Not all features included in BYOC clusters are available in Serverless. For example, the following features are not supported:
 
 * HTTP Proxy API
-* Schema Registry UI (API is supported)
 * Ability to export metrics to a third-party monitoring system
 * Kafka Connect 
 * Private networking (VPC peering or AWS PrivateLink)

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,10 @@ This page lists new features added to Redpanda Cloud.
 
 == June 2025
 
+=== Schema Registry UI for Serverless
+
+The xref:manage:schema-reg/schema-reg-ui.adoc[Schema Registry UI] is now available for Serverless clusters. 
+
 === Amazon VPC Transit Gateway
 
 For BYOC and BYOVPC clusters on AWS, you can set up an xref:networking:byoc/aws/transit-gateway.adoc[Amazon VPC Transit Gateway] to connect VPCs to Redpanda services while maintaining control over network traffic. 


### PR DESCRIPTION
## Description
This pull request removes the mention of the unsupported Schema Registry UI in the Serverless cluster limitations and adds a note about its availability in the "What's New" section.

Updates to Serverless cluster features:

* [`modules/get-started/pages/cluster-types/serverless.adoc`](diffhunk://#diff-b9ada45e986054dd3c87aefcc43f539e63aff7eb5e016458549138ad6445ac73L93): Removed the mention of the Schema Registry UI being unsupported in Serverless clusters.

Documentation additions:

* [`modules/get-started/pages/whats-new-cloud.adoc`](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3R12-R15): Added a note in the "What's New" section announcing the availability of the Schema Registry UI for Serverless clusters.

Resolves https://redpandadata.atlassian.net/browse/DOC-1452
Review deadline:

## Page previews
What's New
Unsupported features for Serverless

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)