### PR TITLE
Fix cURL request for API authentication

### DIFF
--- a/modules/manage/pages/api/cloud-api-authentication.adoc
+++ b/modules/manage/pages/api/cloud-api-authentication.adoc
@@ -23,11 +23,13 @@ NOTE: Service accounts have administrative privileges by default. Cloud user rol
 . Make a POST request to `\https://auth.prd.cloud.redpanda.com/oauth/token` with the ID and secret in the request body. 
 +
 ```bash
-curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
-    -H "content-type: application/x-www-form-urlencoded" \
-    -d "grant_type=client_credentials" \
-    -d "client_id=<client-id>" \
-    -d "client_secret=<client-secret>"
+curl --request POST \
+  --url 'https://auth.prd.cloud.redpanda.com/oauth/token' \
+  --header 'content-type: application/x-www-form-urlencoded' \
+  --data grant_type=client_credentials \
+  --data client_id=<client-id> \
+  --data client_secret=<client-secret> \
+  --data audience=cloudv2-production.redpanda.cloud
 ```
 +
 The request response provides an access token that remains valid for one hour.


### PR DESCRIPTION
## Description

Review deadline: Jun 19

After testing this process, I discovered that the cURL request was broken. This PR provides a fix.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)