### PR TITLE
DOC-1351 Serverless connection limit

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -13,18 +13,18 @@ Make sure you have the latest version of `rpk`. See xref:get-started:rpk-install
 
 == Serverless usage limits
 
-Each Serverless cluster has the following limits:
+Each Serverless cluster can handle:
 
-* Ingress: 100 MB/s
-* Egress: 300 MB/s
-* Partitions: 5,000 
-* Message size: 20 MB
-* Retention: unlimited
-* Storage: unlimited
-* Users: 30
-* ACLs: 120
-* Consumer groups: 200
-* Connections: 10,000 
+* **Ingress**: 100 MB/s
+* **Egress**: 300 MB/s
+* **Partitions**: 5,000 
+* **Message size**: 20 MB
+* **Retention**: unlimited
+* **Storage**: unlimited
+* **Users**: 30
+* **ACLs**: 120
+* **Consumer groups**: 200
+* **Connections**: 10,000 
 
 
 [NOTE]
@@ -40,7 +40,7 @@ include::get-started:partial$get-started-serverless.adoc[]
 
 == Explore your trial cluster
 
-After you click to start a trial, Redpanda instantly prepares an account for you. Your account includes a `welcome` cluster with a `hello-world` demo topic you can explore. 
+After you start a trial, Redpanda instantly prepares an account for you. Your account includes a `welcome` cluster with a `hello-world` demo topic you can explore. It includes sample data so you can see how real-time messaging works before sending your own data.
 
 Follow the steps in the UI to use `rpk` to interact with your cluster from the command line:
 
@@ -88,7 +88,7 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 == Supported features
 
 * Redpanda Serverless supports the Kafka API. 
-* Serverless clusters work with all Kafka clients. For more information, see xref:develop:kafka-clients.adoc[].
+* Serverless clusters work with all Kafka clients. See xref:develop:kafka-clients.adoc[].
 * Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
 * xref:develop:connect/about.adoc[Redpanda Connect] is integrated with Serverless as a beta feature for testing and feedback. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications.
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -17,7 +17,7 @@ Each Serverless cluster has the following limits:
 
 * Ingress: 100 MB/s
 * Egress: 300 MB/s
-* Partitions: 5000 
+* Partitions: 5,000 
 * Message size: 20 MB
 * Retention: unlimited
 * Storage: unlimited

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -26,7 +26,13 @@ Each Serverless cluster has the following limits:
 * Consumer groups: 200
 * Connections: 10,000 
 
-NOTE: The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.
+
+[NOTE]
+==== 
+* The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.
+* Connections are regulated per broker for best performance. For example, with 3 brokers, there could be up to approximately 3,330 connections per broker.
+
+====
 
 == Get started with Serverless
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -24,6 +24,7 @@ Each Serverless cluster has the following limits:
 * Users: 30
 * ACLs: 120
 * Consumer groups: 200
+* Connections: 10,000 
 
 NOTE: The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -27,12 +27,7 @@ Each Serverless cluster can handle:
 * **Connections**: 10,000 
 
 
-[NOTE]
-==== 
-* The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.
-* Connections are regulated per broker for best performance. For example, with 3 brokers, there could be up to approximately 3,330 connections per broker.
-
-====
+NOTE: The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.
 
 == Get started with Serverless
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -7,6 +7,12 @@
 
 This page lists new features added to Redpanda Cloud.
 
+== July 2025
+
+=== Serverless cluster connections
+
+xref:get-started:cluster-types/serverless.adoc[Serverless] clusters have a new usage limit of 10,000 connections.
+
 == June 2025
 
 === Schema Registry UI for Serverless

--- a/modules/reference/pages/tiers/index.adoc
+++ b/modules/reference/pages/tiers/index.adoc
@@ -1,3 +1,3 @@
 = Tiers and Regions
-:description: When you create a cluster, you select your region. For BYOC and Dedicated clusters, you also select a usage tier, which provides guaranteed workload configurations for throughput, partitions (pre-replication), and connections.
+:description: When you create a cluster, you select your region. For BYOC and Dedicated clusters, you also select a usage tier, which provides tested workload configurations for throughput, partitions (pre-replication), and connections.
 :page-layout: index


### PR DESCRIPTION
## Description
This pull request adds a new limit to the Serverless cluster documentation.

Documentation update:

* [`modules/get-started/pages/cluster-types/serverless.adoc`](diffhunk://#diff-b9ada45e986054dd3c87aefcc43f539e63aff7eb5e016458549138ad6445ac73R27): Added a new limit for "Connections" with a maximum of 10,000, under the "Each Serverless cluster has the following limits:" section.

Resolves https://redpandadata.atlassian.net/browse/DOC-1351
Review deadline:

## Page previews
[Serverless usage limits](https://deploy-preview-340--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#serverless-usage-limits)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)