### PR TITLE
DOC-1478 update consumer group lag in Cloud

### DIFF
--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -13,7 +13,7 @@ NOTE: Some properties are read-only and cannot be changed. For example, `cluster
 
 * *Redpanda version 25.1.2+*: You can find the version on your cluster's Overview page in the Redpanda Cloud UI. 
 +
-To verify that you're logged into the control plane and have the correct `rpk` profile configured for your target cluster, run `rpk cloud login` and select your cluster.
+To verify that you're logged into the Redpanda control plane and have the correct `rpk` profile configured for your target cluster, run `rpk cloud login` and select your cluster.
 
 == Limitations
 


### PR DESCRIPTION
## Description
This pull request updates the documentation in `config-cluster.adoc` to clarify prerequisites for configuring cluster properties. The changes emphasize version requirements and provide additional instructions for verifying the `rpk` cloud context.

* Updated the prerequisites to highlight version requirements more clearly by reformatting and emphasizing `Redpanda` and `rpk` version numbers. (`[modules/manage/pages/cluster-maintenance/config-cluster.adocL12-R16](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL12-R16)`)
* Added instructions for verifying the `rpk` cloud context by running `rpk cloud login` and selecting the appropriate cluster. (`[modules/manage/pages/cluster-maintenance/config-cluster.adocL12-R16](diffhunk://#diff-c8fbb49e2369d966902a69910a95b4e432a6931f6efaf898897f416acbd9cd8dL12-R16)`)

Resolves https://redpandadata.atlassian.net/browse/DOC-1478
Review deadline:

## Page previews
[Configure Cluster Properties - Prerequisites](https://deploy-preview-347--rp-cloud.netlify.app/redpanda-cloud/manage/cluster-maintenance/config-cluster/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)