### PR TITLE
DOC-1487 apply coderabbit cloud-docs suggestions

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -330,8 +330,8 @@
 **** xref:develop:connect/components/metrics/none.adoc[]
 **** xref:develop:connect/components/metrics/prometheus.adoc[]
 
-*** xref:develop:connect/components/logger/about.adoc[]
 *** xref:develop:connect/components/redpanda/about.adoc[Redpanda]
+*** xref:develop:connect/components/logger/about.adoc[]
 
 ** xref:develop:connect/guides/index.adoc[]
 *** xref:develop:connect/guides/bloblang/about.adoc[]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -52,7 +52,7 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 ==== Bring Your Own Network (BYOVPC/BYOVNet) 
 
-BYOVPC or BYOVNet clusters allow you to deploy the Redpanda glossterm:data plane[] into your existing VPC (for AWS or GCP) or VNet (for Azure) and take full control of managing the networking lifecycle. Compared to standard BYOC, BYOVPC/BYOVNet provides more security, but the configuration is more complex. See <<Shared responsibility model>>.
+BYOVPC or BYOVNet clusters allow you to deploy the Redpanda glossterm:data plane[] into your existing VPC (for AWS or GCP) or VNet (for Azure) and take full control of the networking lifecycle. Compared to standard BYOC, BYOVPC/BYOVNet provides more security, but the configuration is more complex. See <<Shared responsibility model>>.
 
 The BYOC infrastructure that Redpanda manages should not be used to deploy any other workloads.
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc
@@ -448,7 +448,7 @@ EOF
 +
 TIP: See the full list of zones and tiers available with each provider in the xref:api:ROOT:cloud-controlplane-api.adoc#api-description[Control Plane API reference].
 
-. Make a Cloud API call to create a Redpanda network and get the network ID from the response in JSON `.operation.metadata.network_id`.
+. Make a Cloud API call to create a Redpanda cluster and get the network ID from the response in JSON `.operation.metadata.network_id`.
 +
 ```bash
 export REDPANDA_ID=$(curl -X POST "https://api.redpanda.com/v1/clusters" \

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -44,7 +44,7 @@ gcloud compute networks subnets create <primary-subnet-name> \
     --network <shared-vpc-name> \
     --range 10.0.0.0/24 \
     --region <region> \
-    --secondary-range <secondary-ipv4-range-name-for-pods>=10.0.8.0/21,<secondary-ipv2-range-name-for-services>=10.0.1.0/24
+    --secondary-range <secondary-ipv4-range-name-for-pods>=10.0.8.0/21,<secondary-ipv4-range-name-for-services>=10.0.1.0/24
 ```
 +
 Additionally, a /28 CIDR is required for the GKE master IP addresses. This CIDR is not used in the GCP networking configuration, but is input into the Redpanda UI; for example, 10.0.7.240/28.

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -82,8 +82,7 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 
 == Supported features
 
-* Redpanda Serverless supports the Kafka API. 
-* Serverless clusters work with all Kafka clients. See xref:develop:kafka-clients.adoc[].
+* Redpanda Serverless supports the Kafka API. Serverless clusters work with all Kafka clients. See xref:develop:kafka-clients.adoc[].
 * Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
 * xref:develop:connect/about.adoc[Redpanda Connect] is integrated with Serverless as a beta feature for testing and feedback. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications.
 

--- a/modules/manage/pages/monitor-cloud.adoc
+++ b/modules/manage/pages/monitor-cloud.adoc
@@ -73,7 +73,7 @@ image::https://github.com/redpanda-data/observability/blob/main/docs/images/Ops%
 
 It includes https://github.com/redpanda-data/observability#grafana-dashboards[example Grafana dashboards^] and a https://github.com/redpanda-data/observability#sandbox-environment[sandbox environment^] in which you launch a Dockerized Redpanda cluster and create a custom workload to monitor with dashboards.
 
-== Monitor for health and performance
+== Monitor health and performance
 
 include::ROOT:manage:partial$monitor-health.adoc[tag=single-source]
 

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -45,7 +45,7 @@ export RESOURCE_GROUP_ID=<uuid>
 
 . Call xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/networks[`POST /v1/networks`] to create a network.
 +
-Make sure to supply your own values in the following example request. The example uses a BYOC cluser. For a Dedicated cluster, set `"cluster_type": "TYPE_DEDICATED"`. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
+Make sure to supply your own values in the following example request. The example uses a BYOC cluster. For a Dedicated cluster, set `"cluster_type": "TYPE_DEDICATED"`. Store the network ID (`network_id`) after the network is created to check whether you can proceed to cluster creation.
 +
 --
 - `name`

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -37,7 +37,7 @@ gcloud compute firewall-rules create redpanda-psc \
 network_post_body=`cat << EOF
 {
     "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "cluster_type": "DEDICATED",
+    "cluster_type": "TYPE_DEDICATED",
     "name": "<shared-vpc-name>",
     "resource_group_id": "$RESOURCE_GROUP_ID",
     "region": "<region>",
@@ -83,7 +83,7 @@ export CLUSTER_POST_BODY=`cat << EOF
 {
     "cloud_provider": "CLOUD_PROVIDER_GCP",
     "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "type": "DEDICATED",
+    "type": "TYPE_DEDICATED",
     "name": "<cluster-name>",
     "resource_group_id": "$RESOURCE_GROUP_ID",
     "network_id": "$NETWORK_ID",

--- a/modules/networking/partials/psc-api2.adoc
+++ b/modules/networking/partials/psc-api2.adoc
@@ -41,7 +41,7 @@ Make a xref:api:ROOT:cloud-controlplane-api.adoc#patch-/v1/clusters/-cluster.id-
 CLUSTER_PATCH_BODY=`cat << EOF
 {
     "gcp_private_service_connect": {
-        "enabled": false,
+        "enabled": false
     }
 }
 EOF`

--- a/modules/security/pages/cloud-encryption.adoc
+++ b/modules/security/pages/cloud-encryption.adoc
@@ -22,7 +22,7 @@ and periodically rotated managed master key (SSE-S3). The block cipher uses AES-
 == Data in transit encryption
 
 All network traffic transporting customer data is encrypted in transit using
-asymmetric encryption with TLS 1.2. The network connection to the control plane
+asymmetric encryption with TLS 1.2 and TLS 1.3. The network connection to the control plane
 is also TLS 1.2 encrypted.
 
 Data plane TLS certificates are generated and signed by


### PR DESCRIPTION
## Description
This pull request includes a variety of documentation updates and corrections across multiple files, focusing on improving clarity, fixing typographical errors, and ensuring consistency in terminology. Below are the most important changes grouped by theme:

### Terminology and Typographical Fixes:
* Corrected the term "BYOC cluser" to "BYOC cluster" in `modules/networking/pages/aws-privatelink.adoc`.
* Standardized the term "DEDICATED" to "TYPE_DEDICATED" in `modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc`. [[1]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409L40-R40) [[2]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409L86-R86)

### Content Clarifications:
* Updated the description for creating a Redpanda cluster to clarify the JSON response in `modules/get-started/pages/cluster-types/byoc/azure/vnet-azure.adoc`.
* Enhanced encryption details to include TLS 1.3 alongside TLS 1.2 in `modules/security/pages/cloud-encryption.adoc`.

### Formatting and Structural Adjustments:
* Reorganized a section heading from "Monitor for health and performance" to "Monitor health and performance" in `modules/manage/pages/monitor-cloud.adoc` for better readability.

These updates improve the overall accuracy and readability of the documentation.

Resolves https://redpandadata.atlassian.net/browse/DOC-1487
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)