### PR TITLE
Update azure-private-link.adoc - use private DNS command

### DIFF
--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -274,7 +274,7 @@ az network private-dns link vnet create \
 . Create a wildcard record in the private DNS zone.
 +
 ```
-az network dns record-set a add-record \
+az network private-dns record-set a add-record \
     --resource-group <azure-pl-endpoint-resource-group-name> \
     --zone-name redpanda-$CLUSTER_ID \
     --record-set-name "*" \


### PR DESCRIPTION
## Description

We should be using the private dns subcommand instead of public. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)