### PR TITLE
DOC-1507. Add Azure CLI and Subscription

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -15,7 +15,11 @@ Before you deploy a BYOC cluster on Azure, check all prerequisites to ensure tha
 ===  Configure Azure CLI
 
 * https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Install the Azure CLI^].
-* https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli[Sign in^] with the Azure CLI.
+* https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli[Sign in^] with the Azure CLI:
++
+```
+az login
+```
 * Set the desired subscription for the Azure CLI:
 +
 ```

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -82,9 +82,9 @@ az network watcher configure --resource-group 'NetworkWatcherRG' --locations '<r
 
 Confirm that the Azure subscription has enough virtual CPUs (vCPUs) per instance family and total regional vCPUs in the region where you will use Redpanda:
 
-* Standard_D2d_v5 vCPUs:  12  (3 Redpanda broker nodes + extra capacity for 3 more nodes that could be utilized temporarily during tier 1 maintenance)
-* Standard_D2ads_v5 vCPUs: 8  (2 Redpanda utility nodes)
-* Standard_D2_v3 vCPUs:    2  (1 Redpanda agent node)
+* Standard Ddv5-series vCPUs:  12  (3 Redpanda broker nodes + extra capacity for 3 more nodes that could be utilized temporarily during tier 1 maintenance)
+* Standard Dadsv5-series vCPUs: 8  (2 Redpanda utility nodes)
+* Standard Dv3-series vCPUs:    2  (1 Redpanda agent node)
 
 See the https://learn.microsoft.com/en-us/azure/quotas/view-quotas[Microsoft documentation^].
 
@@ -118,8 +118,6 @@ virtualMachines  eastus2      Standard_D2d_v5    1,2,3    NotAvailableForSubscri
 ----
 
 If you see restrictions, https://learn.microsoft.com/en-us/troubleshoot/azure/general/region-access-request-process[open a Microsoft support request^] to remove them. 
-
-NOTE: For BYOVNet clusters, you may need to specify zones in the region-prefixed format. For example, if you're working in the `eastus2` region with zones `1,2,3`, you would reference them as `eastus2-az1`, `eastus2-az2`, and `eastus2-az3` respectively.
 
 === Prerequisite checklist
 

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -12,6 +12,15 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 Before you deploy a BYOC cluster on Azure, check all prerequisites to ensure that your Azure subscription meets requirements.
 
+===  Azure CLI
+
+* https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Install the Azure CLI] according to instructions
+* https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli[Sign in] with the Azure CLI
+* Set the desired subscription for the Azure CLI. To set the subscription, run:
+```
+az account set --subscription <subscription-name>
+```
+
 === Verify rpk version
 
 Confirm you have a minimum version of Redpanda `rpk` v24.1. See xref:manage:rpk/rpk-install.adoc[].
@@ -84,7 +93,7 @@ Ensure your subscription has access to the required VM sizes in the region where
 [source,bash]
 ----
 # Replace eastus2 with your target region
-az vm list-skus -l eastus2 --zone --size Standard_D2ads_v5 --output table
+az vm list-skus -l eastus2 --zone --size Standard_D2d_v5 --output table
 ----
 
 .Example output (no restrictions: good)
@@ -92,7 +101,7 @@ az vm list-skus -l eastus2 --zone --size Standard_D2ads_v5 --output table
 ----
 ResourceType     Locations    Name               Zones    Restrictions
 ---------------  -----------  ---------------    -------  ------------
-virtualMachines  eastus2      Standard_D2ads_v5  1,2,3    None
+virtualMachines  eastus2      Standard_D2d_v5    1,2,3    None
 ----
 
 .Example output (with restrictions: needs attention)
@@ -100,7 +109,7 @@ virtualMachines  eastus2      Standard_D2ads_v5  1,2,3    None
 ----
 ResourceType     Locations    Name               Zones    Restrictions
 ---------------  -----------  ---------------    -------  ------------
-virtualMachines  eastus2      Standard_D2ads_v5  1,2,3    NotAvailableForSubscription
+virtualMachines  eastus2      Standard_D2d_v5    1,2,3    NotAvailableForSubscription
 ----
 
 If you see restrictions, https://learn.microsoft.com/en-us/troubleshoot/azure/general/region-access-request-process[open a Microsoft support request^] to remove them. 

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -12,11 +12,12 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 Before you deploy a BYOC cluster on Azure, check all prerequisites to ensure that your Azure subscription meets requirements.
 
-===  Azure CLI
+===  Configure Azure CLI
 
-* https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Install the Azure CLI] according to instructions
-* https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli[Sign in] with the Azure CLI
-* Set the desired subscription for the Azure CLI. To set the subscription, run:
+* https://learn.microsoft.com/en-us/cli/azure/install-azure-cli[Install the Azure CLI^].
+* https://learn.microsoft.com/en-us/cli/azure/authenticate-azure-cli[Sign in^] with the Azure CLI.
+* Set the desired subscription for the Azure CLI:
++
 ```
 az account set --subscription <subscription-name>
 ```
@@ -77,9 +78,9 @@ az network watcher configure --resource-group 'NetworkWatcherRG' --locations '<r
 
 Confirm that the Azure subscription has enough virtual CPUs (vCPUs) per instance family and total regional vCPUs in the region where you will use Redpanda:
 
-* Standard Ddv5-series vCPUs:  12  (3 Redpanda broker nodes + extra capacity for 3 more nodes that could be utilized temporarily during tier 1 maintenance)
-* Standard Dadsv5-series vCPUs: 8  (2 Redpanda utility nodes)
-* Standard Dv3-series vCPUs:    2  (1 Redpanda agent node)
+* Standard_D2d_v5 vCPUs:  12  (3 Redpanda broker nodes + extra capacity for 3 more nodes that could be utilized temporarily during tier 1 maintenance)
+* Standard_D2ads_v5 vCPUs: 8  (2 Redpanda utility nodes)
+* Standard_D2_v3 vCPUs:    2  (1 Redpanda agent node)
 
 See the https://learn.microsoft.com/en-us/azure/quotas/view-quotas[Microsoft documentation^].
 
@@ -113,6 +114,8 @@ virtualMachines  eastus2      Standard_D2d_v5    1,2,3    NotAvailableForSubscri
 ----
 
 If you see restrictions, https://learn.microsoft.com/en-us/troubleshoot/azure/general/region-access-request-process[open a Microsoft support request^] to remove them. 
+
+NOTE: For BYOVNet clusters, you may need to specify zones in the region-prefixed format. For example, if you're working in the `eastus2` region with zones `1,2,3`, you would reference them as `eastus2-az1`, `eastus2-az2`, and `eastus2-az3` respectively.
 
 === Prerequisite checklist
 


### PR DESCRIPTION
## Description
This pull request updates the documentation for deploying BYOC clusters on Azure. The changes include adding instructions for setting up the Azure CLI and updating the VM size used in example commands and outputs.

### Additions to Azure CLI setup:

* Added instructions for installing, signing in, and setting the subscription in the Azure CLI to ensure proper configuration before deploying a BYOC cluster. (`modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc`, [modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adocR15-R23](diffhunk://#diff-ab3280e96d3ffa280051aecc61f4c7f00de0e17b39e1d392895d15d6cd999dfaR15-R23))

### Updates to VM size examples:

* Updated the VM size in example commands and outputs from `Standard_D2ads_v5` to `Standard_D2d_v5` to reflect the correct VM size for deployment. (`modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc`, [modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adocL87-R112](diffhunk://#diff-ab3280e96d3ffa280051aecc61f4c7f00de0e17b39e1d392895d15d6cd999dfaL87-R112))

Resolves https://redpandadata.atlassian.net/browse/DOC-1507
Review deadline:

## Page previews
https://deploy-preview-356--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/azure/create-byoc-cluster-azure/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)