### PR TITLE
DOC-1511 add south-north port

### DIFF
--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -135,7 +135,7 @@ The following network port is used for outgoing network connections outside the 
 | Service | Port
 
 | Control plane, breakglass, artifact repository, and telemetry
-|443,80/tcp
+| 443,80/tcp
 |===
 
 == Private service connectivity network ports

--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -66,7 +66,7 @@ This section lists the external ports on which Redpanda Cloud components communi
 
 | North-south | External client access | 30092, 9092, 30081, 30082, 443
 | East-west | Internal cluster communication | 30092, 9092, 8081, 8082, 33145, 30644, 8083
-| South-north | Outgoing connections | 443
+| South-north | Outgoing connections | 443, 80
 |===
 
 NOTE: Redpanda also uses some ports for internal communication inside the cluster, including ports 80 and 9644. 

--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -135,7 +135,7 @@ The following network port is used for outgoing network connections outside the 
 | Service | Port
 
 | Control plane, breakglass, artifact repository, and telemetry
-| 443/tcp
+|443,80/tcp
 |===
 
 == Private service connectivity network ports

--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -135,7 +135,7 @@ The following network port is used for outgoing network connections outside the 
 | Service | Port
 
 | Control plane, breakglass, artifact repository, and telemetry
-| 443,80/tcp
+| 443/tcp, 80/tcp
 |===
 
 == Private service connectivity network ports


### PR DESCRIPTION
## Description
This pull request updates the documentation in `modules/networking/pages/cloud-security-network.adoc` to clarify the network ports used for outgoing connections.

* Updated the network port information for the control plane, breakglass, artifact repository, and telemetry services to include both `443/tcp` and `80/tcp`.

Resolves https://redpandadata.atlassian.net/browse/DOC-1511
Review deadline:

## Page previews
[Network ports](https://deploy-preview-360--rp-cloud.netlify.app/redpanda-cloud/networking/cloud-security-network/#network-ports)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)