### PR TITLE
mTLS+SASL support on AWS

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -9,6 +9,12 @@ This page lists new features added to Redpanda Cloud.
 
 == July 2025
 
+=== mTLS and SASL authentication for Kafka API on AWS
+
+You can now enable mTLS and SASL authentication simultaneously for the Kafka API on AWS clusters. If you enable both mTLS and SASL on AWS clusters, Redpanda creates two distinct listeners: an mTLS listener operating on one port and a SASL listener operating on a different port.
+
+See xref:security:cloud-authentication.adoc#service-authentication[Authentication] for details on available authentication methods in Redpanda Cloud.
+
 === Redpanda Connect in Redpanda Cloud: GA
 
 xref:develop:connect/about.adoc[Redpanda Connect] is now generally available (GA) in all Redpanda Cloud clusters: BYOC (including BYOVPC/BYOVNet), Dedicated, and Serverless. 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -68,14 +68,17 @@ Each Redpanda Cloud data plane runs its own dedicated agent,
 which authenticates and connects against the control plane over a single TLS 1.2
 encrypted TCP connection.
 
-Different Redpanda APIs support different authentication methods. For GCP, you can simultaneously enable mTLS and SASL for Kafka API, and mTLS and Basic authentication for the HTTP APIs (HTTP Proxy and Schema Registry). If you enable both mTLS and SASL on GCP clusters, Redpanda creates two distinct listeners: an mTLS listener operating on one port and a SASL listener operating on a different port.
+Different Redpanda APIs support different authentication methods. For AWS and GCP, you can simultaneously enable mTLS and SASL for Kafka API, and mTLS and Basic authentication for the HTTP APIs (HTTP Proxy and Schema Registry). If you enable both mTLS and SASL on AWS and GCP clusters, Redpanda creates two distinct listeners: an mTLS listener operating on one port and a SASL listener operating on a different port.
 
 .Redpanda APIs authentication methods
 [%collapsible]
 |===
 |Cloud provider |API |Supported authentication methods
 
-.3+|AWS
+.3+a|AWS
+
+See <<enable-mtls-and-sasl,Enable mTLS and SASL>>.
+
 |Kafka API
 a|
 * SASL
@@ -163,7 +166,7 @@ If you want to enable mTLS authentication:
 * You must use the Cloud API to create a new mTLS-enabled cluster. 
 * You must also use the Cloud API to update an existing cluster to switch to mTLS authentication for Kafka API.
 * You can use the Cloud UI to update an existing cluster to switch to mTLS authentication for HTTP Proxy and Schema Registry only.
-* To enable mTLS and SASL (or Basic authentication) simultaneously on GCP clusters, you must use the Cloud API to create a new cluster or update an existing cluster.
+* To enable mTLS and SASL (or Basic authentication) simultaneously on AWS and GCP clusters, you must use the Cloud API to create a new cluster or update an existing cluster.
 
 To configure service authentication in your cluster using the Cloud API, you must have the following:
 
@@ -364,7 +367,7 @@ When the operation state is `COMPLETED`, you can <<verify-mtls,verify that mTLS 
 
 === Enable mTLS and SASL
 
-NOTE: Enabling mTLS and SASL simultaneously is available for GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
+NOTE: Enabling mTLS and SASL simultaneously is available for AWS and GCP clusters only. To unlock this feature for your account, contact your Customer Success Manager.
 
 You can choose to enable mTLS and SASL simultaneously for the Kafka API, and mTLS and Basic authentication for HTTP Proxy and Schema Registry. The `sasl` field in the API request examples toggle both SASL and Basic authentication. 
 


### PR DESCRIPTION
## Description

This pull request updates the documentation to include support for enabling mTLS and SASL authentication simultaneously for Kafka API on AWS clusters, in addition to GCP clusters. The changes clarify the authentication methods available for Redpanda Cloud and update instructions for configuring these features.

### New Feature Documentation Updates:

* Added a new section in `whats-new-cloud.adoc` announcing support for simultaneous mTLS and SASL authentication for Kafka API on AWS clusters. This includes details about the creation of distinct listeners for each authentication method.

### Authentication Configuration Updates:

* Updated `cloud-authentication.adoc` to include AWS clusters alongside GCP clusters for enabling simultaneous mTLS and SASL authentication for Kafka API and mTLS with Basic authentication for HTTP APIs. [[1]](diffhunk://#diff-f01ce5ea1d923cac2f4bb1fe202735176609bc68e75781e9879bba874d07901aL71-R81) [[2]](diffhunk://#diff-f01ce5ea1d923cac2f4bb1fe202735176609bc68e75781e9879bba874d07901aL166-R169) [[3]](diffhunk://#diff-f01ce5ea1d923cac2f4bb1fe202735176609bc68e75781e9879bba874d07901aL367-R370)

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)