### PR TITLE
docs: fix serveless example

### DIFF
--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -295,9 +295,11 @@ Create a Serverless cluster by making a request to xref:api:ROOT:cloud-controlpl
 curl -H 'Content-Type: application/json' \
 -H "Authorization: Bearer <token>" \
 -d '{
-  "name": <serverless-cluster-name>,
-  "resource_group_id": <resource-group-id>,
-  "serverless_region": "us-east-1"
+  "serverless_cluster": {
+    "name": "<serverless-cluster-name>",
+    "resource_group_id": "<resource-group-id>",
+    "serverless_region": "us-east-1"
+  }
 }' -X POST https://api.redpanda.com/v1/serverless/clusters
 ----
 


### PR DESCRIPTION
## Description

Resolves https://github.com/redpanda-data/cloud-docs/issues/273
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)