### PR TITLE
DOC-1553 Improve components navigation UX by defaulting to catalog

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -89,7 +89,6 @@
 *** xref:develop:connect/configuration/unit_testing.adoc[]
 
 ** xref:develop:connect/components/about.adoc[]
-*** xref:develop:connect/components/catalog.adoc[]
 *** xref:develop:connect/components/inputs/about.adoc[]
 **** xref:develop:connect/components/inputs/amqp_0_9.adoc[]
 **** xref:develop:connect/components/inputs/aws_kinesis.adoc[]

--- a/modules/develop/pages/connect/about.adoc
+++ b/modules/develop/pages/connect/about.adoc
@@ -4,7 +4,7 @@
 
 Redpanda Connect in Redpanda Cloud lets you quickly build and deploy streaming data pipelines on your clusters from a fully-integrated UI or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. 
 
-Choose from a xref:develop:connect/components/catalog.adoc[wide range of connectors] to suit your use case, including connectors to: 
+Choose from a xref:develop:connect/components/about.adoc[wide range of connectors] to suit your use case, including connectors to: 
 
 * Integrate data sources (xref:components:inputs/about.adoc[inputs])
 * Write to data sinks (xref:components:outputs/about.adoc[outputs])

--- a/modules/develop/pages/connect/components/about.adoc
+++ b/modules/develop/pages/connect/components/about.adoc
@@ -1,3 +1,4 @@
-= Components
-:page-aliases: components:about.adoc
+= Components Catalog
+:page-aliases: components:about.adoc, develop:connect/components/catalog.adoc, components:catalog.adoc
+
 include::redpanda-connect:components:about.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/catalog.adoc
+++ b/modules/develop/pages/connect/components/catalog.adoc
@@ -1,8 +1,0 @@
-= Connector Catalog
-:description: A searchable list of connectors available for use in Redpanda Cloud.
-
-Connectors listed in this catalog are available to use and fully supported in Redpanda Cloud. All other Redpanda Connect connectors are currently blocked.
-
-Search for connectors for your use case.
-
-component_table::[]

--- a/modules/develop/pages/connect/configuration/contextual-variables.adoc
+++ b/modules/develop/pages/connect/configuration/contextual-variables.adoc
@@ -84,4 +84,4 @@ output:
 
 * Learn how to xref:develop:connect/configuration/secret-management.adoc[add secrets to your pipeline].
 * Try one of our xref:cookbooks:index.adoc[Redpanda Connect cookbooks].
-* Choose xref:develop:connect/components/catalog.adoc[connectors for your use case].
+* Choose xref:develop:connect/components/about.adoc[connectors for your use case].

--- a/modules/develop/pages/connect/connect-quickstart.adoc
+++ b/modules/develop/pages/connect/connect-quickstart.adoc
@@ -234,7 +234,7 @@ When you've finished experimenting with your data pipeline, you can delete the p
 == Suggested reading
 
 * Try one of our xref:cookbooks:index.adoc[Redpanda Connect cookbooks]. 
-* Choose xref:develop:connect/components/catalog.adoc[connectors for your use case].
+* Choose xref:develop:connect/components/about.adoc[connectors for your use case].
 * Learn how to xref:develop:connect/configuration/secret-management.adoc[add secrets to your pipeline].
 * Learn how to xref:develop:connect/configuration/monitor-connect.adoc[monitor a data pipeline on a BYOC or Dedicated cluster].
 * Learn how to xref:develop:connect/configuration/scale-pipelines.adoc[manually scale resources for a pipeline].

--- a/modules/get-started/pages/cluster-types/byoc/gcp/enable-rpcn-byovpc-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/enable-rpcn-byovpc-gcp.adoc
@@ -115,7 +115,7 @@ curl -v -X PATCH \
 
 == Next steps
 
-* Choose xref:develop:connect/components/catalog.adoc[connectors for your use case].
+* Choose xref:develop:connect/components/about.adoc[connectors for your use case].
 * Learn how to xref:redpanda-connect:guides:getting_started.adoc[configure, test, and run a data pipeline locally].
 * Try the xref:develop:connect/connect-quickstart.adoc[Redpanda Connect quickstart].
 * Try one of our xref:cookbooks:index.adoc[Redpanda Connect cookbooks].

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -281,7 +281,7 @@ Redpanda Cloud now offers greater flexibility to schedule upgrades to your clust
 
 === Redpanda Connect: LA for BYOC, beta for Serverless
 
-xref:develop:connect/about.adoc[Redpanda Connect] is now integrated into Redpanda Cloud and available as a fully-managed service. This is a limited availability (LA) release for BYOC and a beta release for Serverless. xref:develop:connect/components/catalog.adoc[Choose from a range of connectors, processors, and other components] to quickly build and deploy streaming data pipelines or AI applications from the xref:develop:connect/connect-quickstart.adoc[Cloud UI] or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
+xref:develop:connect/about.adoc[Redpanda Connect] is now integrated into Redpanda Cloud and available as a fully-managed service. This is a limited availability (LA) release for BYOC and a beta release for Serverless. xref:develop:connect/components/about.adoc[Choose from a range of connectors, processors, and other components] to quickly build and deploy streaming data pipelines or AI applications from the xref:develop:connect/connect-quickstart.adoc[Cloud UI] or using the pass:a,m[xref:{tag-pipeline-service}[Data Plane API\]]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
 
 For more detailed information about recent component updates, see xref:redpanda-connect:ROOT:whats_new_rpcn.adoc[What's New in Redpanda Connect].
 


### PR DESCRIPTION
- Show component catalog table immediately when clicking Components
- Update navigation and fix all cross-references
- Align with user expectations for catalog functionality

## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1553

This pull request updates the documentation for Redpanda Connect by consolidating and simplifying the connector catalog pages, removing redundancy, and updating all references to the connector catalog throughout the docs. The changes ensure that users are directed to the correct and up-to-date catalog location and improve navigation consistency.

Documentation structure and navigation updates:

* Removed the redundant `catalog.adoc` file and merged its content and references into `about.adoc`, now renamed and aliased as "Components Catalog" for clarity and backward compatibility. (`modules/develop/pages/connect/components/catalog.adoc`, `modules/develop/pages/connect/components/about.adoc`) [[1]](diffhunk://#diff-6f502cb74ad63bdc1722dc87315632e59dfa73464da3bdcc2150072ab320f554L1-L8) [[2]](diffhunk://#diff-f1b5921f8179fd141c591c7f157a1702db0b5754b0ad1d263e3fe681452347d9L1-R3)
* Updated the navigation sidebar by removing the direct link to the old catalog and ensuring the components section points to the new consolidated catalog page. (`modules/ROOT/nav.adoc`)

Reference and link updates:

* Replaced all links to the old `catalog.adoc` with references to the new `about.adoc` catalog page across documentation, including quickstarts, contextual variable guides, and cluster setup instructions. (`modules/develop/pages/connect/about.adoc`, `modules/develop/pages/connect/configuration/contextual-variables.adoc`, `modules/develop/pages/connect/connect-quickstart.adoc`, `modules/get-started/pages/cluster-types/byoc/gcp/enable-rpcn-byovpc-gcp.adoc`, `modules/get-started/pages/whats-new-cloud.adoc`) [[1]](diffhunk://#diff-faaa9465712a6fbdbf0e6af70aff221c083d086f1e3da949e568bf42c232cb14L7-R7) [[2]](diffhunk://#diff-9cef0d0b340b73bb206de44e610d003e4234e3dcfc1f7f60b015a149a095fee7L87-R87) [[3]](diffhunk://#diff-cbf1d8510237891fb1314335f4d1d0b3729918d3e82b1538cf71358cf5cec3c4L237-R237) [[4]](diffhunk://#diff-1750b517c0594e768ebecf4c4f27378e783a604210ed036995ddf32b983716a1L118-R118) [[5]](diffhunk://#diff-825e3d404929927e196111eaa92a310ee71d39aa9310418f56a55099a3a3f7c3L284-R284)

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)