### PR TITLE
Enable GCP global access

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -39,6 +39,7 @@
 **** xref:networking:byoc/gcp/vpc-peering-gcp.adoc[Add a Peering Connection]
 **** xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Configure Private Service Connect in the Cloud UI]
 **** xref:networking:gcp-private-service-connect.adoc[Configure Private Service Connect with the Cloud API]
+**** xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access]
 ** xref:networking:dedicated/index.adoc[Dedicated]
 *** xref:networking:dedicated/aws/index.adoc[AWS]
 **** xref:networking:dedicated/aws/vpc-peering.adoc[Add a Peering Connection]

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -8,8 +8,6 @@ NOTE: With standard BYOC clusters, Redpanda manages security policies and resour
 
 If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a new BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
 
-See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpanda Cloud architecture].
-
 == Create a BYOC cluster
 
 . Log in to https://cloud.redpanda.com[Redpanda Cloud^].

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -6,6 +6,8 @@ To create a Redpanda cluster in your virtual private cloud (VPC), follow the ins
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. For the highest level of security, you can manage these resources yourself with a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC cluster on GCP].
 
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a new BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+
 See also: xref:get-started:cloud-overview.adoc#redpanda-cloud-architecture[Redpanda Cloud architecture].
 
 == Create a BYOC cluster

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -6,7 +6,7 @@ To create a Redpanda cluster in your virtual private cloud (VPC), follow the ins
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. For the highest level of security, you can manage these resources yourself with a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC cluster on GCP].
 
-If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a new BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable Global Access during cluster creation using the Cloud API. For instructions, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
 
 == Create a BYOC cluster
 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -6,7 +6,7 @@ To create a Redpanda cluster in your virtual private cloud (VPC), follow the ins
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. For the highest level of security, you can manage these resources yourself with a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC cluster on GCP].
 
-If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable Global Access during cluster creation using the Cloud API. For instructions, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable Global Access during cluster creation using the Cloud API. To create a BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
 
 == Create a BYOC cluster
 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -6,7 +6,7 @@ To create a Redpanda cluster in your virtual private cloud (VPC), follow the ins
 
 NOTE: With standard BYOC clusters, Redpanda manages security policies and resources for your VPC, including subnetworks, service accounts, IAM roles, firewall rules, and storage buckets. For the highest level of security, you can manage these resources yourself with a xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC cluster on GCP].
 
-If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable Global Access during cluster creation using the Cloud API. To create a BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation using the Cloud API. To create a BYOC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
 
 == Create a BYOC cluster
 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -12,6 +12,8 @@ When you create a BYOVPC cluster, you specify your VPC and service account. The 
 * You maintain more control of your Google Cloud account, because Redpanda requires fewer permissions than standard BYOC clusters.
 * You control your security resources and policies, including subnets, service accounts, IAM roles, firewall rules, and storage buckets.
 
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a new BYOVPC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+
 == Prerequisites
 
 * A standalone GCP project is recommended. If your host project (where your VPC project is created) and your service project (where your Redpanda cluster is created) are in different projects, you must first provision a shared VPC in Google Cloud. For more information, see the https://cloud.google.com/vpc/docs/provisioning-shared-vpc[Google shared VPC documentation^]. 

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -12,7 +12,7 @@ When you create a BYOVPC cluster, you specify your VPC and service account. The 
 * You maintain more control of your Google Cloud account, because Redpanda requires fewer permissions than standard BYOC clusters.
 * You control your security resources and policies, including subnets, service accounts, IAM roles, firewall rules, and storage buckets.
 
-If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a new BYOVPC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
+If your clients need to connect from different GCP regions than where your cluster will be deployed, you must enable global access during cluster creation. To create a BYOVPC cluster with global access enabled, see xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access].
 
 == Prerequisites
 

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -90,7 +90,9 @@ Create a resource group by making a POST request to the xref:api:ROOT:cloud-cont
 curl -H 'Content-Type: application/json' \
 -H "Authorization: Bearer <token>" \
 -d '{
-  "name": "<resource-group-name>"
+  "resource_group": {
+    "name": "<resource-group-name>"
+  }
 }' -X POST https://api.redpanda.com/v1/resource-groups
 ----
 
@@ -107,12 +109,14 @@ ifdef::env-dedicated[]
 ----
 curl -d \
 '{
-  "cidr_block": "10.0.0.0/20",
-  "cloud_provider": "CLOUD_PROVIDER_GCP",
-  "cluster_type": "TYPE_DEDICATED",
-  "name": "<network-name>",
-  "resource_group_id": "<resource-group-id>",
-  "region": "us-west1"
+  "network": {
+    "cidr_block": "10.0.0.0/20",
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "cluster_type": "TYPE_DEDICATED",
+    "name": "<network-name>",
+    "resource_group_id": "<resource-group-id>",
+    "region": "us-west1"
+  }
 }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
 ----
 endif::[]
@@ -121,12 +125,14 @@ ifdef::env-byoc[]
 ----
 curl -d \
 '{
-  "cidr_block": "10.0.0.0/20",
-  "cloud_provider": "CLOUD_PROVIDER_GCP",
-  "cluster_type": "TYPE_BYOC",
-  "name": "<network-name>",
-  "resource_group_id": "<resource-group-id>",
-  "region": "us-west1"
+  "network": {
+    "cidr_block": "10.0.0.0/20",
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "cluster_type": "TYPE_BYOC",
+    "name": "<network-name>",
+    "resource_group_id": "<resource-group-id>",
+    "region": "us-west1"
+  }
 }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
 ----
 endif::[]
@@ -142,23 +148,25 @@ ifdef::env-dedicated[]
 ----
 curl -d \
 '{
-  "cloud_provider": "CLOUD_PROVIDER_GCP",
-  "connection_type": "CONNECTION_TYPE_PUBLIC",
-  "name": "my-new-cluster",
-  "resource_group_id": "<resource-group-id>",
-  "network_id": "<network-id>",
-  "region": "us-west1",
-  "throughput_tier": "tier-1-gcp-um4g",
-  "type": "TYPE_DEDICATED",
-  "zones": [
-    "us-west1-a",
-    "us-west1-b",
-    "us-west1-c"
-  ],
-  "cluster_configuration": {
-      "custom_properties": {
-        "audit_enabled":true
-      }
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PUBLIC",
+    "name": "my-new-cluster",
+    "resource_group_id": "<resource-group-id>",
+    "network_id": "<network-id>",
+    "region": "us-west1",
+    "throughput_tier": "tier-1-gcp-um4g",
+    "type": "TYPE_DEDICATED",
+    "zones": [
+      "us-west1-a",
+      "us-west1-b",
+      "us-west1-c"
+    ],
+    "cluster_configuration": {
+        "custom_properties": {
+          "audit_enabled":true
+        }
+    }
   }
 }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
 ----
@@ -168,22 +176,24 @@ ifdef::env-byoc[]
 ----
 curl -d \
 '{
-  "cloud_provider": "CLOUD_PROVIDER_GCP",
-  "connection_type": "CONNECTION_TYPE_PUBLIC",
-  "name": "my-new-cluster",
-  "resource_group_id": "<resource-group-id>",
-  "network_id": "<network-id>",
-  "region": "us-west1",
-  "throughput_tier": "tier-1-gcp-um4g",
-  "type": "TYPE_BYOC",
-  "zones": [
-    "us-west1-a",
-    "us-west1-b",
-    "us-west1-c"
-  ],
-  "cluster_configuration": {
-    "custom_properties": {
-      "audit_enabled":true
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PUBLIC",
+    "name": "my-new-cluster",
+    "resource_group_id": "<resource-group-id>",
+    "network_id": "<network-id>",
+    "region": "us-west1",
+    "throughput_tier": "tier-1-gcp-um4g",
+    "type": "TYPE_BYOC",
+    "zones": [
+      "us-west1-a",
+      "us-west1-b",
+      "us-west1-c"
+    ],
+    "cluster_configuration": {
+      "custom_properties": {
+        "audit_enabled":true
+      }
     }
   }
 }' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters

--- a/modules/manage/partials/controlplane-api.adoc
+++ b/modules/manage/partials/controlplane-api.adoc
@@ -117,7 +117,8 @@ curl -d \
     "resource_group_id": "<resource-group-id>",
     "region": "us-west1"
   }
-}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
+}' -H "Content-Type: application/json" \
+-H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
 ----
 endif::[]
 ifdef::env-byoc[]
@@ -133,7 +134,8 @@ curl -d \
     "resource_group_id": "<resource-group-id>",
     "region": "us-west1"
   }
-}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
+}' -H "Content-Type: application/json" \
+-H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/networks 
 ----
 endif::[]
 
@@ -168,7 +170,8 @@ curl -d \
         }
     }
   }
-}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
+}' -H "Content-Type: application/json" \
+-H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
 ----
 endif::[]
 ifdef::env-byoc[]
@@ -196,7 +199,8 @@ curl -d \
       }
     }
   }
-}' -H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
+}' -H "Content-Type: application/json" \
+-H "Authorization: Bearer <token>" -X POST https://api.redpanda.com/v1/clusters
 ----
 endif::[]
 

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -59,12 +59,14 @@ REGION=<aws_region>
 
 NETWORK_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_AWS",
-    "cluster_type": "TYPE_BYOC",
-    "name": "<my-private-link-network>",
-    "cidr_block": "<10.0.0.0/20>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "region": "$REGION"
+    "network": {
+        "cloud_provider": "CLOUD_PROVIDER_AWS",
+        "cluster_type": "TYPE_BYOC",
+        "name": "<my-private-link-network>",
+        "cidr_block": "<10.0.0.0/20>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "region": "$REGION"
+    }
 }
 EOF`
 
@@ -95,19 +97,21 @@ In the example below, make sure to set your own values for the following fields:
 ----
 CLUSTER_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_AWS",
-    "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "name": "<my-private-link-cluster>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "network_id": "$NETWORK_ID",
-    "region": "$REGION",
-    "zones": [ <zones> ],
-    "throughput_tier": "<tier>",
-    "type": "<type>",
-    "aws_private_link": {
-        "enabled": true,
-        "connect_console": true,
-        "allowed_principals": ["<principal_1>","<principal_2>"]
+    "cluster": {
+        "cloud_provider": "CLOUD_PROVIDER_AWS",
+        "connection_type": "CONNECTION_TYPE_PRIVATE",
+        "name": "<my-private-link-cluster>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "network_id": "$NETWORK_ID",
+        "region": "$REGION",
+        "zones": [ <zones> ],
+        "throughput_tier": "<tier>",
+        "type": "<type>",
+        "aws_private_link": {
+            "enabled": true,
+            "connect_console": true,
+            "allowed_principals": ["<principal_1>","<principal_2>"]
+        }
     }
 }
 EOF`

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -80,12 +80,14 @@ REGION=<azure-region>
 
 NETWORK_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_AZURE",
-    "cluster_type": "<cluster-type>",
-    "name": "<network-name>",
-    "cidr_block": "<10.0.0.0/20>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "region": "$REGION"
+    "network": {
+        "cloud_provider": "CLOUD_PROVIDER_AZURE",
+        "cluster_type": "<cluster-type>",
+        "name": "<network-name>",
+        "cidr_block": "<10.0.0.0/20>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "region": "$REGION"
+    }
 }
 EOF`
 
@@ -114,19 +116,21 @@ In the following example, make sure to set your own values for the following fie
 ----
 CLUSTER_POST_BODY=`cat << EOF
 {
-  "cloud_provider": "CLOUD_PROVIDER_AZURE",
-  "connection_type": "CONNECTION_TYPE_PRIVATE",
-  "name": "<name>",
-  "resource_group_id": "$RESOURCE_GROUP_ID",
-  "network_id": "$NETWORK_ID",
-  "region": "$REGION",
-  "throughput_tier": "<tier>",
-  "type": "<type>",
-  "zones": [ <zones> ],
-  "azure_private_link": { 
-      "allowed_subscriptions": ["$SOURCE_CONNECTION_SUBSCRIPTION_ID"],
-      "enabled": true,
-      "connect_console": true
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_AZURE",
+    "connection_type": "CONNECTION_TYPE_PRIVATE",
+    "name": "<name>",
+    "resource_group_id": "$RESOURCE_GROUP_ID",
+    "network_id": "$NETWORK_ID",
+    "region": "$REGION",
+    "throughput_tier": "<tier>",
+    "type": "<type>",
+    "zones": [ <zones> ],
+    "azure_private_link": { 
+        "allowed_subscriptions": ["$SOURCE_CONNECTION_SUBSCRIPTION_ID"],
+        "enabled": true,
+        "connect_console": true
+    }
   }
 }
 EOF`

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -1,0 +1,236 @@
+= Create a BYOC Cluster Enabled with Global Access 
+:description: Learn how to enable global access for new BYOC and BYOVPC clusters on GCP.
+
+You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP. Global access lets clients outside your cluster's region or VPC connect to your Redpanda cluster. This is useful for providing access to Redpanda for users and services distributed across different geographic locations.
+
+You can only enable global access as part of cluster creation, and not for running clusters.
+
+== Prerequisites
+
+* In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
+
+== Get a Cloud API access token
+
+include::networking:partial$private-links-api-access-token.adoc[]
+
+== Create a new cluster with global access
+
+=== Create a resource group
+
+Make a request to the `POST /v1/resource-groups` endpoint and store the ID of the resource group you create.
+
+[,bash]
+----
+export RESOURCE_GROUP_ID=$(curl -X POST \
+  https://api.redpanda.com/v1/resource-groups \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{
+    "resource_group": {
+      "name": "<resource-group-name>"
+    }
+  }' | jq -r '.resource_group.id')
+----
+
+
+If you're creating a BYOVPC cluster, continue to the next section. Otherwise, if you're creating a standard BYOC cluster, skip ahead to <<create-a-network>>.
+
+=== Configure customer-managed resources for BYOVPC
+
+. Before you proceed, check the xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#prerequisites[prerequisites and limitations] for new BYOVPC clusters on GCP.
+. Follow the steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-your-vpc[configure your VPC] with the required permissions and firewall rules.
+. Follow the next steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-the-service-project[configure the service project] and service account bindings.
+
+=== Create a network
+
+Make a request to the `POST /v1/networks` endpoint and store the ID of the network you create.
+
+* For standard BYOC clusters, run: 
++
+[,bash]
+----
+NETWORK_POST_BODY=`cat << EOF
+{
+  "network": {
+    "name": "<byoc-network-name>",
+    "resource_group_id": "$RESOURCE_GROUP_ID",
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "cluster_type": "TYPE_BYOC",
+    "region": "<gcp-region>",
+    "cidr_block": "10.0.0.0/20"
+  }
+}
+EOF`
+
+export NETWORK_ID=$(curl -vv -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$NETWORK_POST_BODY" https://api.redpanda.com/v1/networks | jq -r '.operation.metadata.network_id')
+----
+
+* For BYOVPC clusters, you also make a request to the `POST /v1/networks` endpoint, with a different request body:
++
+[,bash]
+----
+NETWORK_POST_BODY=`cat << EOF
+{
+  "network": {
+    "name": "<shared-vpc-name>",
+    "resource_group_id": "$RESOURCE_GROUP_ID",
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "cluster_type": "TYPE_BYOC",
+    "region": "<gcp-region>",
+    "customer_managed_resources": {
+        "gcp": {
+            "network_name": "<byovpc-network-name>",
+            "network_project_id": "<byovpc-network-gcp-project-id>",
+            "management_bucket": { "name" : "<byovpc-management-bucket>" }
+        }
+    }
+}
+EOF`
+
+export NETWORK_ID=$(curl -vv -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$NETWORK_POST_BODY" https://api.redpanda.com/v1/networks | jq -r '.operation.metadata.network_id')
+----
++
+Replace the following placeholder variables for the request body:
++
+--
+- `<shared-vpc-name>`: The name for the Redpanda network. 
+- `<gcp-region>`: The GCP region where the network will be created.
+- `<byovpc-network-gcp-project-id>`: The ID of the GCP project where your VPC is created.
+- `<byovpc-network-name>`: The name of your VPC.
+- `<byovpc-management-bucket>`: The name of the Google Storage bucket you created for the cluster.
+--
+
+Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/{operation_id}` endpoint.
+
+=== Create a cluster with global access enabled
+
+Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled.
+
+* For BYOC clusters, run:
++
+[,bash]
+----
+CLUSTER_POST_BODY=`cat << EOF
+{
+  "cluster": {
+    "name": "<cluster-name>",
+    "resource_group_id": "$RESOURCE_GROUP_ID",
+    "network_id": "$NETWORK_ID",
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "type": "TYPE_BYOC",
+    "region": "<gcp-region>",
+    "zones": <gcp-zones>,
+    "throughput_tier": "<usage-tier>",
+    "gcp_enable_global_access": true
+  }
+}
+EOF`
+
+export CLUSTER_ID=$(curl -X POST \
+  https://api.redpanda.com/v1/clusters \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -H 'content-type: application/json' \
+  -d "$CLUSTER_POST_BODY" | jq -r '.operation.metadata.cluster_id')
+----
++
+Replace the following placeholder variables for the request body:
++
+--
+- `<cluster-name>`: The name for the Redpanda cluster.
+- `<gcp-region>`: The GCP region where the cluster will be created.
+- `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
+- `<usage-tier>`: Choose a Redpanda Cloud cluster tier. For example, `tier-1-gcp-v2-x86`.
+--
+
+* For BYOVPC clusters, you also make a request to the `POST /v1/clusters` endpoint, with a different request body:
++
+[,bash]
+----
+export CLUSTER_POST_BODY=`cat << EOF
+{
+  "cluster": {
+    "cloud_provider": "CLOUD_PROVIDER_GCP",
+    "connection_type": "CONNECTION_TYPE_PRIVATE",
+    "type": "TYPE_BYOC",
+    "name": "<cluster-name>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "network_id": "$NETWORK_ID",
+        "region": "<gcp-region>",
+        "zones": <gcp-zones>,
+        "throughput_tier": "<usage-tier>",
+        "redpanda_version": "<redpanda-version>",
+        "gcp_enable_global_access": true,
+        "customer_managed_resources": {
+            "gcp": {
+                "subnet": {
+                    "name":"<byovpc-subnet-name>",
+                    "secondary_ipv4_range_pods": { 
+                        "name": "<byovpc-subnet-pods-range-name>" 
+                    },
+                    "secondary_ipv4_range_services": { 
+                        "name": "<byovpc-subnet-services-range-name>" 
+                    },
+                    "k8s_master_ipv4_range": "<byovpc-subnet-master-range>"
+                },
+                "agent_service_account": { 
+                    "email": "<byovpc-agent-service-acc-email>" 
+                },
+                "connector_service_account": { 
+                    "email": "<byovpc-connectors-service-acc-email>" 
+                },
+                "console_service_account": { 
+                    "email": "<byovpc-console-service-acc-email>" 
+                },
+                "redpanda_cluster_service_account": { 
+                    "email": "<byovpc-redpanda-service-acc-email>" 
+                },
+                "gke_service_account": { 
+                    "email": "<byovpc-gke-service-acc-email>" 
+                },
+                "tiered_storage_bucket": { 
+                    "name" : "<byovpc-tiered-storage-bucket>" 
+                }
+            }
+        }
+    }
+}
+EOF`
+
+export CLUSTER_ID=$(curl -vv -X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $AUTH_TOKEN" \
+-d "$CLUSTER_POST_BODY" https://api.redpanda.com/v1/clusters | jq -r '.operation.metadata.cluster_id')
+----
++
+Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent the customer-managed resources that you set up previously:
++
+--
+- `<cluster-name>`: Provide a name for the new cluster.
+- `<gcp-region>`: Choose a GCP region where the network will be created.
+- `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
+- `<usage-tier>`: Choose a Redpanda Cloud cluster tier. For example, `tier-1-gcp-v2-x86`.
+- `<redpanda-version>`: Choose the Redpanda Cloud version.
+- `<byovpc-subnet-name>`: The name of the GCP subnet that was created for the cluster.
+- `<byovpc-subnet-pods-range-name>`: The name of the IPv4 range designated for K8s pods.
+- `<byovpc-subnet-services-range-name>`: The name of the IPv4 range designated for services.
+- `<byovpc-subnet-master-range>`: The master IPv4 range.
+- `<psc-nat-subnet-name>`: The name of the GCP subnet that was created for Private Service Connect NAT.
+- `<byovpc-agent-service-acc-email>`: The email for the agent service account.
+- `<byovpc-connectors-service-acc-email>`: The email for the connectors service account.
+- `<byovpc-console-service-acc-email>`: The email for the Console service account.
+- `<byovpc-redpanda-service-acc-email>`: The email for the Redpanda service account.
+- `<byovpc-gke-service-acc-email>`: The email for the GKE service account.
+- `<byovpc-tiered-storage-bucket>`: The name of the Google Storage bucket to use for Tiered Storage.
+--
+
+* Run `rpk cloud byoc gcp apply`:
++
+```bash
+rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<gcp-service-project-id>'
+```

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -108,7 +108,7 @@ Replace the following placeholder variables for the request body:
 - `<byovpc-management-bucket>`: The name of the Google Storage bucket you created for the cluster.
 --
 
-Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/{operation_id}` endpoint.
+Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/\{operation_id}` endpoint.
 
 === Create a cluster with global access enabled
 

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -1,15 +1,17 @@
-= Create a BYOC Cluster Enabled with Global Access 
+= Enable Global Access 
 :description: Learn how to enable global access for new BYOC and BYOVPC clusters on GCP.
 
 By default, the seed load balancer for a cluster on GCP only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable global access.
 
-Global access lets the seed load balancer accept connections from clients outside your cluster's region, then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
-
-You can only enable global access as part of cluster creation, and not for running clusters.
+Global access lets the seed load balancer accept connections from clients outside your cluster's region, then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
 
 == Prerequisites
 
 In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to create a resource group, network, and cluster with global access enabled on GCP. 
+
+== Limitations
+
+You can only use the Cloud API to enable global access as part of cluster creation, and not on existing clusters. Enabling global access on a running cluster requires recreating the GCP forwarding rule, which may cause some downtime. To enable global access on an existing cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^].
 
 == Get a Cloud API access token
 
@@ -104,30 +106,30 @@ export NETWORK_ID=$(curl -vv -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$NETWORK_POST_BODY" https://api.redpanda.com/v1/networks | jq -r '.operation.metadata.network_id')
 ----
-+
+
 Replace the following placeholder variables for the request body:
-+
---
+
+
 - `<shared-vpc-name>`: The name for the Redpanda network. 
 - `<gcp-region>`: The GCP region where the network will be created.
 - `<byovpc-network-gcp-project-id>`: The ID of the GCP project where your VPC is created.
 - `<byovpc-network-name>`: The name of your VPC.
 - `<byovpc-management-bucket>`: The name of the Google Storage bucket you created for the cluster.
---
+
 ====
 
 Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/\{operation_id}` endpoint.
 
 === Enable global access
 
-. Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled.
+. Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled (`"gcp_enable_global_access": true`).
 
 * For BYOC clusters, run:
 +
 .Show BYOC cluster creation command
 [%collapsible]
 ====
-[,bash]
+[,bash,lines=12]
 ----
 CLUSTER_POST_BODY=`cat << EOF
 {
@@ -151,15 +153,14 @@ export CLUSTER_ID=$(curl -X POST \
   -H 'content-type: application/json' \
   -d "$CLUSTER_POST_BODY" | jq -r '.operation.metadata.cluster_id')
 ----
-+
+
 Replace the following placeholder variables for the request body:
-+
---
+
 - `<cluster-name>`: The name for the Redpanda cluster.
 - `<gcp-region>`: The GCP region where the cluster will be created.
 - `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
 - `<usage-tier>`: Choose a Redpanda Cloud cluster tier. For example, `tier-1-gcp-v2-x86`.
---
+
 ====
 
 * For BYOVPC clusters, you also make a request to the `POST /v1/clusters` endpoint, with a different request body:
@@ -167,7 +168,7 @@ Replace the following placeholder variables for the request body:
 .Show BYOVPC cluster creation command
 [%collapsible]
 ====
-[,bash]
+[,bash,lines=14]
 ----
 CLUSTER_POST_BODY=`cat << EOF
 {
@@ -224,10 +225,9 @@ export CLUSTER_ID=$(curl -vv -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_POST_BODY" https://api.redpanda.com/v1/clusters | jq -r '.operation.metadata.cluster_id')
 ----
-+
+
 Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent the customer-managed resources that you set up previously:
-+
---
+
 - `<cluster-name>`: Provide a name for the new cluster.
 - `<gcp-region>`: Choose a GCP region where the cluster will be created.
 - `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
@@ -243,7 +243,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 - `<byovpc-redpanda-service-acc-email>`: The email for the Redpanda service account.
 - `<byovpc-gke-service-acc-email>`: The email for the GKE service account.
 - `<byovpc-tiered-storage-bucket>`: The name of the Google Storage bucket to use for Tiered Storage.
---
+
 ====
 
 . Run `rpk cloud byoc gcp apply`:

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -1,11 +1,10 @@
 = Enable Global Access 
 :description: Learn how to enable global access for new BYOC and BYOVPC clusters on GCP.
 
-By default, the seed load balancer for a cluster on GCP only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable global access.
+By default, the seed load balancer for a cluster on GCP only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access[global access^].
 
-Global access lets the seed load balancer accept connections from clients outside your cluster's region, then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
+Global access lets the seed load balancer accept connections from clients outside your cluster's region, then route them to the appropriate broker addresses for producing and consuming data. You can enable global access when you create a new BYOC or BYOVPC cluster on GCP.
 
-== Prerequisites
 
 In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to create a resource group, network, and cluster with global access enabled on GCP. 
 

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -254,4 +254,4 @@ rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<gcp-servic
 
 == Test global access
 
-To test if global access is successfully enabled, follow the steps in the GCP documentation to https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#gcloud_17[test global access with a VM client^].
+To test if global access is successfully enabled, see the https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#gcloud_17[GCP documentation^].

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -49,6 +49,9 @@ Make a request to the `POST /v1/networks` endpoint and store the ID of the netwo
 
 * For standard BYOC clusters, run: 
 +
+.Show BYOC network creation example
+[%collapsible]
+====
 [,bash]
 ----
 NETWORK_POST_BODY=`cat << EOF
@@ -69,9 +72,13 @@ export NETWORK_ID=$(curl -vv -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$NETWORK_POST_BODY" https://api.redpanda.com/v1/networks | jq -r '.operation.metadata.network_id')
 ----
+====
 
 * For BYOVPC clusters, you also make a request to the `POST /v1/networks` endpoint, with a different request body:
 +
+.Show BYOVPC network creation example
+[%collapsible]
+====
 [,bash]
 ----
 NETWORK_POST_BODY=`cat << EOF
@@ -107,6 +114,7 @@ Replace the following placeholder variables for the request body:
 - `<byovpc-network-name>`: The name of your VPC.
 - `<byovpc-management-bucket>`: The name of the Google Storage bucket you created for the cluster.
 --
+====
 
 Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/\{operation_id}` endpoint.
 
@@ -116,6 +124,9 @@ Note that this endpoint returns a long-running operation. To check the operation
 
 * For BYOC clusters, run:
 +
+.Show BYOC cluster creation example
+[%collapsible]
+====
 [,bash]
 ----
 CLUSTER_POST_BODY=`cat << EOF
@@ -149,9 +160,13 @@ Replace the following placeholder variables for the request body:
 - `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
 - `<usage-tier>`: Choose a Redpanda Cloud cluster tier. For example, `tier-1-gcp-v2-x86`.
 --
+====
 
 * For BYOVPC clusters, you also make a request to the `POST /v1/clusters` endpoint, with a different request body:
 +
+.Show BYOVPC cluster creation example
+[%collapsible]
+====
 [,bash]
 ----
 CLUSTER_POST_BODY=`cat << EOF
@@ -229,6 +244,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 - `<byovpc-gke-service-acc-email>`: The email for the GKE service account.
 - `<byovpc-tiered-storage-bucket>`: The name of the Google Storage bucket to use for Tiered Storage.
 --
+====
 
 . Run `rpk cloud byoc gcp apply`:
 +

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -7,7 +7,7 @@ You can only enable global access as part of cluster creation, and not for runni
 
 == Prerequisites
 
-* In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to enable the Redpanda endpoint service for your clusters. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
+* In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to create a resource group, network, and cluster with global access enabled on GCP. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
 
 == Get a Cloud API access token
 

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -1,21 +1,21 @@
 = Create a BYOC Cluster Enabled with Global Access 
 :description: Learn how to enable global access for new BYOC and BYOVPC clusters on GCP.
 
-By default, the seed load balancer for your GCP cluster only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable global access.
+By default, the seed load balancer for a cluster on GCP only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable global access.
 
-Global access lets the seed load balancer accept connections from clients outside your cluster's region then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
+Global access lets the seed load balancer accept connections from clients outside your cluster's region, then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
 
 You can only enable global access as part of cluster creation, and not for running clusters.
 
 == Prerequisites
 
-* In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to create a resource group, network, and cluster with global access enabled on GCP. Follow the steps on this page to <<get-a-cloud-api-access-token, get an access token>>.
+In this guide, you use the xref:manage:api/cloud-api-overview.adoc[Redpanda Cloud API] to create a resource group, network, and cluster with global access enabled on GCP. 
 
 == Get a Cloud API access token
 
 include::networking:partial$private-links-api-access-token.adoc[]
 
-== Create a new cluster with global access
+== Create a cluster with global access
 
 === Create a resource group
 
@@ -37,7 +37,7 @@ export RESOURCE_GROUP_ID=$(curl -X POST \
 
 If you're creating a BYOVPC cluster, continue to the next section. Otherwise, if you're creating a standard BYOC cluster, skip ahead to <<create-a-network>>.
 
-=== Configure customer-managed resources for BYOVPC
+=== BYOVPC only: Configure customer-managed resources
 
 . Before you proceed, check the xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#prerequisites[prerequisites and limitations] for new BYOVPC clusters on GCP.
 . Follow the steps to xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc#configure-your-vpc[configure your VPC] with the required permissions and firewall rules.
@@ -49,7 +49,7 @@ Make a request to the `POST /v1/networks` endpoint and store the ID of the netwo
 
 * For standard BYOC clusters, run: 
 +
-.Show BYOC network creation example
+.Show BYOC network creation command
 [%collapsible]
 ====
 [,bash]
@@ -76,7 +76,7 @@ export NETWORK_ID=$(curl -vv -X POST \
 
 * For BYOVPC clusters, you also make a request to the `POST /v1/networks` endpoint, with a different request body:
 +
-.Show BYOVPC network creation example
+.Show BYOVPC network creation command
 [%collapsible]
 ====
 [,bash]
@@ -118,13 +118,13 @@ Replace the following placeholder variables for the request body:
 
 Note that this endpoint returns a long-running operation. To check the operation state, use the `GET /v1/operations/\{operation_id}` endpoint.
 
-=== Create a cluster with global access enabled
+=== Enable global access
 
 . Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled.
 
 * For BYOC clusters, run:
 +
-.Show BYOC cluster creation example
+.Show BYOC cluster creation command
 [%collapsible]
 ====
 [,bash]
@@ -164,7 +164,7 @@ Replace the following placeholder variables for the request body:
 
 * For BYOVPC clusters, you also make a request to the `POST /v1/clusters` endpoint, with a different request body:
 +
-.Show BYOVPC cluster creation example
+.Show BYOVPC cluster creation command
 [%collapsible]
 ====
 [,bash]

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -110,7 +110,7 @@ Note that this endpoint returns a long-running operation. To check the operation
 
 === Create a cluster with global access enabled
 
-Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled.
+. Make a request to the `POST /v1/clusters` endpoint to create a new cluster with global access enabled.
 
 * For BYOC clusters, run:
 +
@@ -212,7 +212,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 +
 --
 - `<cluster-name>`: Provide a name for the new cluster.
-- `<gcp-region>`: Choose a GCP region where the network will be created.
+- `<gcp-region>`: Choose a GCP region where the cluster will be created.
 - `<gcp-zones>`: Provide the list of GCP zones where the brokers will be deployed. Format: `["<zone 1>", "<zone 2>", "<zone N>"]`
 - `<usage-tier>`: Choose a Redpanda Cloud cluster tier. For example, `tier-1-gcp-v2-x86`.
 - `<redpanda-version>`: Choose the Redpanda Cloud version.
@@ -220,7 +220,6 @@ Replace the following placeholders for the request body. Variables with a `byovp
 - `<byovpc-subnet-pods-range-name>`: The name of the IPv4 range designated for K8s pods.
 - `<byovpc-subnet-services-range-name>`: The name of the IPv4 range designated for services.
 - `<byovpc-subnet-master-range>`: The master IPv4 range.
-- `<psc-nat-subnet-name>`: The name of the GCP subnet that was created for Private Service Connect NAT.
 - `<byovpc-agent-service-acc-email>`: The email for the agent service account.
 - `<byovpc-connectors-service-acc-email>`: The email for the connectors service account.
 - `<byovpc-console-service-acc-email>`: The email for the Console service account.
@@ -229,7 +228,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 - `<byovpc-tiered-storage-bucket>`: The name of the Google Storage bucket to use for Tiered Storage.
 --
 
-* Run `rpk cloud byoc gcp apply`:
+. Run `rpk cloud byoc gcp apply`:
 +
 ```bash
 rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<gcp-service-project-id>'

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -152,7 +152,7 @@ Replace the following placeholder variables for the request body:
 +
 [,bash]
 ----
-export CLUSTER_POST_BODY=`cat << EOF
+CLUSTER_POST_BODY=`cat << EOF
 {
   "cluster": {
     "cloud_provider": "CLOUD_PROVIDER_GCP",

--- a/modules/networking/pages/byoc/gcp/enable-global-access.adoc
+++ b/modules/networking/pages/byoc/gcp/enable-global-access.adoc
@@ -1,7 +1,9 @@
 = Create a BYOC Cluster Enabled with Global Access 
 :description: Learn how to enable global access for new BYOC and BYOVPC clusters on GCP.
 
-You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP. Global access lets clients outside your cluster's region or VPC connect to your Redpanda cluster. This is useful for providing access to Redpanda for users and services distributed across different geographic locations.
+By default, the seed load balancer for your GCP cluster only accepts connections from the same region where the cluster is deployed. In Redpanda Cloud, the seed load balancer is the bootstrap server address you configure in your clients. If your Redpanda Cloud clients and BYOC or BYOVPC cluster are not all in the same GCP region, you must enable global access.
+
+Global access lets the seed load balancer accept connections from clients outside your cluster's region then route them to the appropriate broker addresses for producing and consuming data. You can enable https://cloud.google.com/load-balancing/docs/l7-internal/setting-up-l7-internal#global-access[global access^] when you create a new BYOC or BYOVPC cluster on GCP.
 
 You can only enable global access as part of cluster creation, and not for running clusters.
 
@@ -233,3 +235,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 ```bash
 rpk cloud byoc gcp apply --redpanda-id="${CLUSTER_ID}" --project-id='<gcp-service-project-id>'
 ```
+
+== Test global access
+
+To test if global access is successfully enabled, follow the steps in the GCP documentation to https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#gcloud_17[test global access with a VM client^].

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -26,14 +26,7 @@ NETWORK_POST_BODY=`cat << EOF
         "cluster_type": "TYPE_DEDICATED",
         "name": "<shared-vpc-name>",
         "resource_group_id": "$RESOURCE_GROUP_ID",
-        "region": "<region>",
-        "customer_managed_resources": {
-            "gcp": {
-                "network_name": "<network-name>",
-                "network_project_id": "<network-gcp-project-id>",
-                "management_bucket": { "name" : "<management-bucket>" }
-            }
-        }
+        "region": "<region>"
     }
 }
 EOF`

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -21,16 +21,18 @@ export RESOURCE_GROUP_ID=<uuid>
 ----
 NETWORK_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "cluster_type": "TYPE_DEDICATED",
-    "name": "<shared-vpc-name>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "region": "<region>",
-    "customer_managed_resources": {
-        "gcp": {
-            "network_name": "<network-name>",
-            "network_project_id": "<network-gcp-project-id>",
-            "management_bucket": { "name" : "<management-bucket>" }
+    "network": {
+        "cloud_provider": "CLOUD_PROVIDER_GCP",
+        "cluster_type": "TYPE_DEDICATED",
+        "name": "<shared-vpc-name>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "region": "<region>",
+        "customer_managed_resources": {
+            "gcp": {
+                "network_name": "<network-name>",
+                "network_project_id": "<network-gcp-project-id>",
+                "management_bucket": { "name" : "<management-bucket>" }
+            }
         }
     }
 }
@@ -66,19 +68,21 @@ export NETWORK_ID=<metadata.network_id>
 ----
 export CLUSTER_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "type": "TYPE_DEDICATED",
-    "name": "<cluster-name>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "network_id": "$NETWORK_ID",
-    "region": "<region>",
-    "zones": <zones>,
-    "throughput_tier": "<throughput-tier>",
-    "redpanda_version": "<redpanda-version>",
-    "gcp_private_service_connect": {
-        "enabled": true,
-        "consumer_accept_list": <consumer-accept-list>
+    "cluster": {
+        "cloud_provider": "CLOUD_PROVIDER_GCP",
+        "connection_type": "CONNECTION_TYPE_PRIVATE",
+        "type": "TYPE_DEDICATED",
+        "name": "<cluster-name>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "network_id": "$NETWORK_ID",
+        "region": "<region>",
+        "zones": <zones>,
+        "throughput_tier": "<throughput-tier>",
+        "redpanda_version": "<redpanda-version>",
+        "gcp_private_service_connect": {
+            "enabled": true,
+            "consumer_accept_list": <consumer-accept-list>
+        }
     }
 }
 EOF`

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -119,6 +119,8 @@ export CLUSTER_POST_BODY=`cat << EOF
         "zones": <zones>,
         "throughput_tier": "<throughput-tier>",
         "redpanda_version": "<redpanda-version>",
+        # Uncomment out the following line to enable global access
+        # "gcp_enable_global_access": true,
         "gcp_private_service_connect": {
             "enabled": true,
             "consumer_accept_list": <consumer-accept-list>
@@ -149,6 +151,7 @@ curl -vv -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters
 ----
+NOTE: To also enable global access on the seed load balancer for the new cluster, you must set `"gcp_enable_global_access": true` during cluster creation. See xref:networking:pages:byoc:gcp:enable-global-access.adoc[Enable Global Access] for more information.
 +
 Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[customer-managed resources] that should have been created previously:
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -152,12 +152,16 @@ curl -vv -X POST \
 +
 [NOTE] 
 ====
-To also enable global access on the seed load balancer for the new cluster, you must set `"gcp_enable_global_access": true` during cluster creation:
+To also enable global access on the seed load balancer for the Private Service Connect service, you must set `"gcp_private_service_connect.global_access_enabled"` to `true` during cluster creation:
 
 ```
 "cluster": {
     ...
-    "gcp_enable_global_access": true,
+    "gcp_private_service_connect": {
+        "enabled": true,
+        "consumer_accept_list": <consumer-accept-list>
+        "global_access_enabled": true
+    }
     ...
 }
 ```

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -61,16 +61,18 @@ gcloud compute firewall-rules create redpanda-psc \
 ----
 NETWORK_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "cluster_type": "TYPE_BYOC",
-    "name": "<shared-vpc-name>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "region": "<region>",
-    "customer_managed_resources": {
-        "gcp": {
-            "network_name": "<byovpc-network-name>",
-            "network_project_id": "<byovpc-network-gcp-project-id>",
-            "management_bucket": { "name" : "<byovpc-management-bucket>" }
+    "network": {
+        "cloud_provider": "CLOUD_PROVIDER_GCP",
+        "cluster_type": "TYPE_BYOC",
+        "name": "<shared-vpc-name>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "region": "<region>",
+        "customer_managed_resources": {
+            "gcp": {
+                "network_name": "<byovpc-network-name>",
+                "network_project_id": "<byovpc-network-gcp-project-id>",
+                "management_bucket": { "name" : "<byovpc-management-bucket>" }
+            }
         }
     }
 }
@@ -106,35 +108,37 @@ export NETWORK_ID=<metadata.network_id>
 ----
 export CLUSTER_POST_BODY=`cat << EOF
 {
-    "cloud_provider": "CLOUD_PROVIDER_GCP",
-    "connection_type": "CONNECTION_TYPE_PRIVATE",
-    "type": "TYPE_BYOC",
-    "name": "<cluster-name>",
-    "resource_group_id": "$RESOURCE_GROUP_ID",
-    "network_id": "$NETWORK_ID",
-    "region": "<region>",
-    "zones": <zones>,
-    "throughput_tier": "<throughput-tier>",
-    "redpanda_version": "<redpanda-version>",
-    "gcp_private_service_connect": {
-        "enabled": true,
-        "consumer_accept_list": <consumer-accept-list>
-    },
-    "customer_managed_resources": {
-        "gcp": {
-            "subnet": {
-                "name":"<byovpc-subnet-name>",
-                "secondary_ipv4_range_pods": { "name": "<byovpc-subnet-pods-range-name>" },
-                "secondary_ipv4_range_services": { "name": "<byovpc-subnet-services-range-name>" },
-                "k8s_master_ipv4_range": "<byovpc-subnet-master-range>"
-            },
-            "psc_nat_subnet_name": "<psc-nat-subnet-name>",
-            "agent_service_account": { "email": "<byovpc-agent-service-acc-email>" },
-            "connector_service_account": { "email": "<byovpc-connectors-service-acc-email>" },
-            "console_service_account": { "email": "<byovpc-console-service-acc-email>" },
-            "redpanda_cluster_service_account": { "email": "<byovpc-redpanda-service-acc-email>" },
-            "gke_service_account": { "email": "<byovpc-gke-service-acc-email>" },
-            "tiered_storage_bucket": { "name" : "<byovpc-tiered-storage-bucket>" }
+    "cluster": {
+        "cloud_provider": "CLOUD_PROVIDER_GCP",
+        "connection_type": "CONNECTION_TYPE_PRIVATE",
+        "type": "TYPE_BYOC",
+        "name": "<cluster-name>",
+        "resource_group_id": "$RESOURCE_GROUP_ID",
+        "network_id": "$NETWORK_ID",
+        "region": "<region>",
+        "zones": <zones>,
+        "throughput_tier": "<throughput-tier>",
+        "redpanda_version": "<redpanda-version>",
+        "gcp_private_service_connect": {
+            "enabled": true,
+            "consumer_accept_list": <consumer-accept-list>
+        },
+        "customer_managed_resources": {
+            "gcp": {
+                "subnet": {
+                    "name":"<byovpc-subnet-name>",
+                    "secondary_ipv4_range_pods": { "name": "<byovpc-subnet-pods-range-name>" },
+                    "secondary_ipv4_range_services": { "name": "<byovpc-subnet-services-range-name>" },
+                    "k8s_master_ipv4_range": "<byovpc-subnet-master-range>"
+                },
+                "psc_nat_subnet_name": "<psc-nat-subnet-name>",
+                "agent_service_account": { "email": "<byovpc-agent-service-acc-email>" },
+                "connector_service_account": { "email": "<byovpc-connectors-service-acc-email>" },
+                "console_service_account": { "email": "<byovpc-console-service-acc-email>" },
+                "redpanda_cluster_service_account": { "email": "<byovpc-redpanda-service-acc-email>" },
+                "gke_service_account": { "email": "<byovpc-gke-service-acc-email>" },
+                "tiered_storage_bucket": { "name" : "<byovpc-tiered-storage-bucket>" }
+            }
         }
     }
 }

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -150,21 +150,11 @@ curl -vv -X POST \
 -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters
 ----
 +
-[NOTE] 
-====
-To also enable global access on the seed load balancer for the Private Service Connect service, you must set `"gcp_private_service_connect.global_access_enabled"` to `true` during cluster creation:
-
-```
-"cluster": {
-    ...
-    "gcp_private_service_connect": {
-        "enabled": true,
-        "consumer_accept_list": <consumer-accept-list>
-        "global_access_enabled": true
-    }
-    ...
-}
-```
+     "gcp_private_service_connect": {
+         "enabled": true,
+         "consumer_accept_list": <consumer-accept-list>,
+         "global_access_enabled": true
+     }
 
 See xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access] for more information.
 ====

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -119,8 +119,6 @@ export CLUSTER_POST_BODY=`cat << EOF
         "zones": <zones>,
         "throughput_tier": "<throughput-tier>",
         "redpanda_version": "<redpanda-version>",
-        # Uncomment out the following line to enable global access
-        # "gcp_enable_global_access": true,
         "gcp_private_service_connect": {
             "enabled": true,
             "consumer_accept_list": <consumer-accept-list>
@@ -151,7 +149,21 @@ curl -vv -X POST \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters
 ----
-NOTE: To also enable global access on the seed load balancer for the new cluster, you must set `"gcp_enable_global_access": true` during cluster creation. See xref:networking:pages:byoc:gcp:enable-global-access.adoc[Enable Global Access] for more information.
++
+[NOTE] 
+====
+To also enable global access on the seed load balancer for the new cluster, you must set `"gcp_enable_global_access": true` during cluster creation:
+
+```
+"cluster": {
+    ...
+    "gcp_enable_global_access": true,
+    ...
+}
+```
+
+See xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access] for more information.
+====
 +
 Replace the following placeholders for the request body. Variables with a `byovpc_` prefix represent xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[customer-managed resources] that should have been created previously:
 +

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -150,11 +150,19 @@ curl -vv -X POST \
 -d "$CLUSTER_POST_BODY" $PUBLIC_API_ENDPOINT/v1/clusters
 ----
 +
-     "gcp_private_service_connect": {
-         "enabled": true,
-         "consumer_accept_list": <consumer-accept-list>,
-         "global_access_enabled": true
-     }
+[NOTE] 
+====
+To also enable global access on the seed load balancer for the Private Service Connect endpoint, you must set `"gcp_private_service_connect.global_access_enabled": true` during cluster creation:
+
+```
+"cluster": {
+    "gcp_private_service_connect": {
+        "enabled": true,
+        "consumer_accept_list": <consumer-accept-list>,
+        "global_access_enabled": true
+    }
+}
+```
 
 See xref:networking:byoc/gcp/enable-global-access.adoc[Enable Global Access] for more information.
 ====

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -95,11 +95,11 @@ Replace the following placeholder variables for the request body:
 --
 
 
-. Store the network ID (`metadata.network_id`) returned in the response to the Create Network request.
+. Store the network ID (`operation.metadata.network_id`) returned in the response to the Create Network request.
 +
 [,bash]
 ----
-export NETWORK_ID=<metadata.network_id>
+export NETWORK_ID=<operation.metadata.network_id>
 ----
 
 . Make a request to the xref:api:ROOT:cloud-controlplane-api.adoc#post-/v1/clusters[`POST /v1/clusters`] endpoint to create a Redpanda Cloud cluster with Private Service Connect enabled.

--- a/modules/networking/partials/private-links-api-access-token.adoc
+++ b/modules/networking/partials/private-links-api-access-token.adoc
@@ -5,7 +5,7 @@
 export PUBLIC_API_ENDPOINT="https://api.cloud.redpanda.com"
 ----
 
-. In your organization in the Redpanda Cloud UI, go to https://cloud.redpanda.com//organization-iam[**Organization IAM**^]. If you don't have an existing service account, you can create a new one.
+. In the Redpanda Cloud UI, go to the https://cloud.redpanda.com/organization-iam[**Organization IAM**^] page, and select the **Service account** tab. If you don't have an existing service account, you can create a new one.
 +
 Copy and store the client ID and secret.
 +

--- a/modules/networking/partials/psc-ui.adoc
+++ b/modules/networking/partials/psc-ui.adoc
@@ -16,7 +16,7 @@ gcloud compute addresses create <psc-endpoint-ip-name> --subnet=<psc-endpoint-su
 
 . Create the Private Service Connect endpoint forwarding rule:
 +
-NOTE: If you have enabled global access when creating the cluster, you must also include the `--allow-psc-global-access` flag to configure the endpoint to accept client connections from different regions.
+NOTE: If you enabled global access when creating the cluster, you must include the `--allow-psc-global-access` flag to configure the endpoint to accept client connections from different regions.
 +
 [,bash]
 ----    

--- a/modules/networking/partials/psc-ui.adoc
+++ b/modules/networking/partials/psc-ui.adoc
@@ -16,6 +16,8 @@ gcloud compute addresses create <psc-endpoint-ip-name> --subnet=<psc-endpoint-su
 
 . Create the Private Service Connect endpoint forwarding rule:
 +
+NOTE: If you have enabled global access when creating the cluster, you must also include the `--allow-psc-global-access` flag to configure the endpoint to accept client connections from different regions.
++
 [,bash]
 ----    
 gcloud compute forwarding-rules create <psc-endpoint-forwarding-rule-name> --region=<region> --network=<consumer-vpc-name> --address=<psc-endpoint-ip> --target-service-attachment=<rp-psc-service-attachment-url>


### PR DESCRIPTION
## Description

This pull request introduces documentation for enabling global access for BYOC and BYOVPC clusters on GCP, and standardizes API example request bodies across multiple cloud providers by wrapping resources in top-level keys. The changes improve clarity and consistency in API usage, and guide users on how to enable global access for cross-region client connectivity.

**Global Access Enablement Documentation:**

* Added a new guide, `enable-global-access.adoc`, detailing how to enable global access for BYOC and BYOVPC clusters on GCP using the Redpanda Cloud API, including prerequisites, limitations, and step-by-step instructions for both cluster types.
* Updated navigation (`nav.adoc`) and relevant getting started pages to reference the new guide, ensuring users are directed to global access instructions when appropriate. [[1]](diffhunk://#diff-5daf5a85fd51578ad9fc545388bf62176bcea32094ee97b5e30c2eea044e4193R42) [[2]](diffhunk://#diff-8865164e17fac88c9dd04d3e39b552892b06f071311c166510e919dd7d66fb3cL9-R9) [[3]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9R15-R16)

**API Example Standardization:**

* Updated API documentation and code snippets for GCP, AWS, and Azure to wrap `network` and `cluster` objects in a top-level key in JSON request bodies, ensuring consistency with the API's expected format. This affects files such as `controlplane-api.adoc`, `aws-privatelink.adoc`, `azure-private-link.adoc`, `configure-psc-in-api.adoc`, and `gcp-private-service-connect.adoc`. [[1]](diffhunk://#diff-c385e7127a7e89e3b846615418c77efe6c65cc45082a22577e2700bc6eea72f7R93-R95) [[2]](diffhunk://#diff-c385e7127a7e89e3b846615418c77efe6c65cc45082a22577e2700bc6eea72f7R112-R138) [[3]](diffhunk://#diff-c385e7127a7e89e3b846615418c77efe6c65cc45082a22577e2700bc6eea72f7R153) [[4]](diffhunk://#diff-c385e7127a7e89e3b846615418c77efe6c65cc45082a22577e2700bc6eea72f7L163-R182) [[5]](diffhunk://#diff-c385e7127a7e89e3b846615418c77efe6c65cc45082a22577e2700bc6eea72f7L189-R203) [[6]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acR62-R70) [[7]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acR100) [[8]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acR116) [[9]](diffhunk://#diff-44fa14256b425a599042395c62f8d8e0babfbbe79846b452a328bfcd989efd02R83-R91) [[10]](diffhunk://#diff-44fa14256b425a599042395c62f8d8e0babfbbe79846b452a328bfcd989efd02R119) [[11]](diffhunk://#diff-44fa14256b425a599042395c62f8d8e0babfbbe79846b452a328bfcd989efd02R135) [[12]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409R24-R29) [[13]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409R64) [[14]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409R80) [[15]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280R64) [[16]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280R78)

These changes ensure users have clear guidance on enabling global access for their clusters and that all API examples are up-to-date and consistent with current requirements.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

Networking > BYOC > GCP > [Enable Global Access](https://deploy-preview-385--rp-cloud.netlify.app/redpanda-cloud/networking/byoc/gcp/enable-global-access/)
Networking > BYOC > GCP > Private Service Connect > [Create a new BYOVPC cluster with Private Service Connect](https://deploy-preview-385--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/#create-a-new-byovpc-cluster-with-private-service-connect)
Networking > BYOC > GCP > Private Service Connect > [Deploy consumer-side resources](https://deploy-preview-385--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/#deploy-consumer-side-resources)


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)