### PR TITLE
DOC-1577 add warning to not modify throughput_tier

### DIFF
--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -98,7 +98,7 @@ The following functionality is supported in the Cloud API but not in the Redpand
 
 [WARNING]
 ====
-Do not modify `throughput_tier` after it is set. When `allow_deletion` is set to `true`, modifying `throughput_tier` forces replacement of the cluster: Terraform will destroy the existing cluster and create a new one, which can cause data loss. 
+Do not modify `throughput_tier` after it is set. When `allow_deletion` is set to `true`, modifying `throughput_tier` forces replacement of the cluster: Terraform will destroy the existing cluster and create a new one, causing data loss. 
 ====
 
 == Prerequisites

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -98,7 +98,7 @@ The following functionality is supported in the Cloud API but not in the Redpand
 
 [WARNING]
 ====
-Do not modify `throughput_tier` after it is set. Modifying it will tear down the cluster and build a new one.
+Do not modify `throughput_tier` after it is set. When `allow_deletion` is set to `true`, modifying `throughput_tier` forces replacement of the cluster: Terraform will destroy the existing cluster and create a new one, which can cause data loss. 
 ====
 
 == Prerequisites

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -95,6 +95,12 @@ The following functionality is supported in the Cloud API but not in the Redpand
 * Kafka Connect
 * Redpanda Connect
 
+
+[WARNING]
+====
+Do not modify `throughput_tier` after it is set. Modifying it will tear down the cluster and build a new one.
+====
+
 == Prerequisites
 
 . Install at least version 1.0.0 of Terraform using the https://learn.hashicorp.com/tutorials/terraform/install-cli[official guide^].
@@ -255,7 +261,7 @@ resource "redpanda_cluster" "test" {
 
 === Create a Dedicated cluster
 
-A Dedicated cluster is fully managed by Redpanda and ensures consistent performance. This example provisions a cluster on AWS with specific zones and throughput tiers.
+A Dedicated cluster is fully managed by Redpanda and ensures consistent performance. This example provisions a cluster on AWS with specific zones and usage tiers.
 
 [source,hcl]
 ----


### PR DESCRIPTION
## Description
This pull request adds a warning advising users not to modify the `throughput_tier` after it is set, as this action will tear down and rebuild the cluster.

Resolves https://redpandadata.atlassian.net/browse/DOC-1577
Review deadline:

## Page previews
[Redpanda Terraform Provider Limitations](https://deploy-preview-387--rp-cloud.netlify.app/redpanda-cloud/manage/terraform-provider/#limitations)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)