### PR TITLE
DOC-1269 Clarify SSO with Entra ID

### DIFF
--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -27,6 +27,7 @@ CAUTION: Deleting an SSO connection also deletes all users attached to it.
 
 To integrate with Okta, follow the https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm[Okta documentation^] to create an application within Okta for Redpanda. The Redpanda callback location (that is, the redirect location where Okta sends the user) is the following:
 
+
 ```
 https://auth.prd.cloud.redpanda.com/login/callback
 ```
@@ -40,24 +41,21 @@ https://<orgname>.okta.com/oauth2/<an_id>/.well-known/openid-configuration
 
 ==== Integrate with Microsoft Entra ID
 
-To integrate with Entra ID, follow the https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft documentation^] to create an OIDC enterprise (Web) application:
+To integrate with Microsoft Entra ID, create a Web application registration that uses the OIDC Authorization Code flow with PKCE:
 
-. In the https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id[Entra App Gallery^], on the Create your own application page: 
-.. Select *Register an application to integrate with Microsoft Entra ID*.
-.. For the name of your app, enter `Redpanda Cloud`. 
-.. Click *Create*.
-. On the Register an application page: 
-.. For Supported account types, select *Accounts in this organizational directory only (Redpanda only - Single tenant)*.
-.. For Redirect URI, select *Web* platform with the Callback URL from Redpanda Cloud. To find the Callback URL in Redpanda Cloud, navigate to the *Users*: *Single sign-on* page, and click *Add connection*. Copy the *Callback URL*, and paste it into the Azure *Redirect URI* field. 
+. In the https://entra.microsoft.com/[Microsoft Entra admin center^], go to *App registrations* and click *New registration*.
+.. Name: `Redpanda Cloud`.
+.. Supported account types: *Accounts in this organizational directory only (Single tenant)*.
+.. Redirect URI: select *Web*, and paste the Callback URL from Redpanda Cloud. To find the Callback URL, go to *Users* > *Single sign-on* in Redpanda Cloud and click *Add connection*. Copy the *Callback URL*.
 +
 IMPORTANT: The platform type must be *Web*. Because Redpanda Cloud uses the OIDC Authorization Code flow with PKCE and a server-side callback, the app must be configured as Web (not SPA or mobile).
 .. Click *Register*.
-. On the Azure Enterprise applications page, you can now search for the Redpanda Cloud app to assign users access to Redpanda Cloud.
-. On the Azure app for Redpanda Cloud, click *Endpoints*, and copy the *OpenID Connect metadata document URL* endpoint.
+. After registration, a corresponding Enterprise application (service principal) appears under *Enterprise applications*. If your organization restricts access, assign users/groups to this Enterprise application to allow access to Redpanda Cloud.
+. On the application registration for Redpanda Cloud, click *Endpoints* and copy the *OpenID Connect metadata document* URL.
 . In Redpanda Cloud, on the *Users*: *Single sign-on* page, paste that endpoint address into the *Discovery URI* field. Then, complete the SSO configuration:
 .. For *Client ID*, copy and paste the *Application (client) ID* from the Azure app for Redpanda Cloud.
 .. For *Client secret*, copy and paste the secret you get from adding a client secret on the Certificates & secrets page for the Azure app for Redpanda Cloud.
-.. For *Realm*, enter your Entra ID tenant domain name.
+.. For *Realm*, enter your Microsoft Entra ID tenant domain name.
 .. Click *Save*.
 .. On the Redpanda Cloud Users: Single sign-on page, edit your new Entra ID connection to enable single sign-on. 
 +

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -64,7 +64,7 @@ Users with an email address with that realm (domain) can now access your Redpand
 [NOTE]
 ====
 
-* No additional claims required: Do not add optional claims or group claims to ID/Access tokens. Redpanda Cloud only relies on standard OIDC claims provided by your IdP.
+* No additional claims required: Redpanda Cloud only relies on standard OIDC claims provided by your IdP. Do not configure optional claims or group claims in ID/Access tokens.
 * No API permissions required: You do not need Microsoft Graph or any other API permissions. Microsoft Graph `User.Read` may be listed (some tenants add it during app creation), but Redpanda Cloud performs OIDC sign-in only and does not call Microsoft Graph.
 * First-login consent only: On first sign-in, users are prompted to consent to the standard OIDC scopes `openid`, `profile`, and `email`. After the first consent, users should not be prompted again unless consent is revoked or the app configuration changes.
 ====

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -1,12 +1,13 @@
 = Authentication
 :description: Learn about Redpanda Cloud authentication.
 :page-aliases: deploy:deployment-option/cloud/security/cloud-authentication.adoc
+:page-toclevels: 3
 
-Redpanda Cloud ensures the highest level of authentication for both users and services.
+Redpanda Cloud provides secure authentication for both users accessing the platform and services connecting to your clusters.
 
 == User authentication
 
-Redpanda provides user authentication to your Redpanda organization through email or single sign-on. 
+Redpanda provides user authentication to your Redpanda organization through email/password or single sign-on. 
 
 === Email
 
@@ -39,7 +40,7 @@ https://<orgname>.okta.com/oauth2/<an_id>/.well-known/openid-configuration
 
 ==== Integrate with Microsoft Entra ID
 
-To integrate with Azure Entra ID, follow the https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft documentation^] to create an OIDC enterprise (web) application:
+To integrate with Azure Entra ID, follow the https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft documentation^] to create an OIDC enterprise (Web) application:
 
 . In the https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id[Entra App Gallery^], on the Create your own application page: 
 .. Select *Register an application to integrate with Microsoft Entra ID*.
@@ -47,20 +48,37 @@ To integrate with Azure Entra ID, follow the https://learn.microsoft.com/en-us/e
 .. Click *Create*.
 . On the Register an application page: 
 .. For Supported account types, select *Accounts in this organizational directory only (Redpanda only - Single tenant)*.
-.. For Redirect URI, select *Web* platform with the Callback URL found in Redpanda Cloud. In Redpanda Cloud, navigate to *Users*: *Single sign-on*, and click *Add connection*. Copy the *Callback URL*, and paste it into the Azure *Redirect URI* field. 
+.. For Redirect URI, select *Web* platform with the Callback URL from Redpanda Cloud. To find the Callback URL in Redpanda Cloud, navigate to the *Users*: *Single sign-on* page, and click *Add connection*. Copy the *Callback URL*, and paste it into the Azure *Redirect URI* field. 
++
+IMPORTANT: The platform type must be *Web*. Because Redpanda Cloud uses the OIDC Authorization Code flow with PKCE and a server-side callback, the app must be configured as Web (not SPA or mobile).
 .. Click *Register*.
-. On the Azure Enterprise applications page, you can now search for the Redpanda Cloud app to assign users access to Redpanda Cloud.  
+. On the Azure Enterprise applications page, you can now search for the Redpanda Cloud app to assign users access to Redpanda Cloud.
 . On the Azure app for Redpanda Cloud, click *Endpoints*, and copy the *OpenID Connect metadata document URL* endpoint.
-. In Redpanda Cloud, on *Users*: *Single sign-on*, paste that endpoint address into the *Discovery URI* field. Then, complete the SSO configuration:
+. In Redpanda Cloud, on the *Users*: *Single sign-on* page, paste that endpoint address into the *Discovery URI* field. Then, complete the SSO configuration:
 .. For *Client ID*, copy and paste the *Application (client) ID* from the Azure app for Redpanda Cloud.
 .. For *Client secret*, copy and paste the secret you get from adding a client secret on the Certificates & secrets page for the Azure app for Redpanda Cloud.
 .. For *Realm*, enter your Azure Entra ID tenant domain name.
 .. Click *Save*.
-.. On the Redpanda Cloud SSO page, edit your new Entra ID connection to enable SSO. 
+.. On the Redpanda Cloud Users: Single sign-on page, edit your new Entra ID connection to enable single sign-on. 
 +
 Users with an email address with that realm (domain) can now access your Redpanda Cloud account. 
 +
-NOTE: You can continue to configure your Azure Enterprise app page for Redpanda Cloud, but there is no need to configure JWT-based claims or API permissions.
+[NOTE]
+====
+
+* No additional claims required: Do not add optional claims or group claims to ID/Access tokens. Redpanda Cloud only relies on standard OIDC claims provided by your IdP.
+* No API permissions required: You do not need Microsoft Graph or any other API permissions. Microsoft Graph `User.Read` may be listed (some tenants add it during app creation), but Redpanda Cloud performs OIDC sign-in only and does not call Microsoft Graph.
+* First-login consent only: On first sign-in, users are prompted to consent to the standard OIDC scopes `openid`, `profile`, and `email`. After the first consent, users should not be prompted again unless consent is revoked or the app configuration changes.
+====
+
+===== Tips for Integrating Entra ID
+
+If users are repeatedly prompted for consent or cannot sign in:
+
+* Ensure the app is configured as Web with the exact Redirect URI from Redpanda Cloud.
+* Remove any extra API permissions (for example, `Microsoft Graph: User.Read`).
+* Avoid adding non-standard claims or scopes.
+
 
 == Service authentication
 
@@ -212,7 +230,7 @@ NOTE: If you enable mTLS authentication, you cannot disable it later.
 
 ==== Create a new cluster with mTLS enabled
 
-. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already. You'll need the resource group ID and network ID to create a cluster in the next step.
+. Follow the steps to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already. You'll need the resource group ID and network ID to create a cluster in the next step.
 
 . Make a link:/api/doc/cloud-controlplane/operation/operation-clusterservice_createcluster[`POST /v1/clusters`] request to create a new cluster with mTLS enabled.
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -64,7 +64,7 @@ Users with an email address with that realm (domain) can now access your Redpand
 [NOTE]
 ====
 
-* No additional claims required: Redpanda Cloud only relies on standard OIDC claims provided by your IdP. Do not configure optional claims or group claims in ID/Access tokens.
+* No additional claims required: Redpanda Cloud only relies on standard OIDC claims provided by your IdP. You do not need to configure optional claims or group claims in ID/Access tokens.
 * No API permissions required: You do not need Microsoft Graph or any other API permissions. Microsoft Graph `User.Read` may be listed (some tenants add it during app creation), but Redpanda Cloud performs OIDC sign-in only and does not call Microsoft Graph.
 * First-login consent only: On first sign-in, users are prompted to consent to the standard OIDC scopes `openid`, `profile`, and `email`. After the first consent, users should not be prompted again unless consent is revoked or the app configuration changes.
 ====

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -266,7 +266,7 @@ EOF`
 curl -v -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+-d "$CLUSTER_CREATE_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>
 ----
 
 Make sure to replace the following variables:
@@ -350,7 +350,7 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>
 ----
 
 Make sure to replace the following variables:
@@ -611,7 +611,7 @@ EOF`
 curl -v -X PATCH \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $AUTH_TOKEN" \
--d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>`
+-d "$CLUSTER_PATCH_BODY" https://api.redpanda.com/v1/clusters/<cluster-id>
 ----
 ====
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -40,7 +40,7 @@ https://<orgname>.okta.com/oauth2/<an_id>/.well-known/openid-configuration
 
 ==== Integrate with Microsoft Entra ID
 
-To integrate with Azure Entra ID, follow the https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft documentation^] to create an OIDC enterprise (Web) application:
+To integrate with Entra ID, follow the https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc[Microsoft documentation^] to create an OIDC enterprise (Web) application:
 
 . In the https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id[Entra App Gallery^], on the Create your own application page: 
 .. Select *Register an application to integrate with Microsoft Entra ID*.
@@ -57,7 +57,7 @@ IMPORTANT: The platform type must be *Web*. Because Redpanda Cloud uses the OIDC
 . In Redpanda Cloud, on the *Users*: *Single sign-on* page, paste that endpoint address into the *Discovery URI* field. Then, complete the SSO configuration:
 .. For *Client ID*, copy and paste the *Application (client) ID* from the Azure app for Redpanda Cloud.
 .. For *Client secret*, copy and paste the secret you get from adding a client secret on the Certificates & secrets page for the Azure app for Redpanda Cloud.
-.. For *Realm*, enter your Azure Entra ID tenant domain name.
+.. For *Realm*, enter your Entra ID tenant domain name.
 .. Click *Save*.
 .. On the Redpanda Cloud Users: Single sign-on page, edit your new Entra ID connection to enable single sign-on. 
 +
@@ -393,7 +393,7 @@ You can choose to enable mTLS and SASL simultaneously for the Kafka API, and mTL
 
 ==== Create a new cluster with both mTLS and SASL enabled
 
-. Follow the steps to to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
+. Follow the steps to create a resource group and network for xref:manage:api/cloud-byoc-controlplane-api.adoc#create-a-resource-group[BYOC] or xref:manage:api/cloud-dedicated-controlplane-api.adoc#create-a-resource-group[Dedicated], if you haven't already done so. You'll need the resource group ID and network ID to create a cluster in the next step.
 
 . Make a link:/api/doc/cloud-controlplane/operation/operation-clusterservice_createcluster[`POST /v1/clusters`] request to create a new cluster with both mTLS and SASL or Basic authentication enabled.
 +


### PR DESCRIPTION
## Description
This pull request updates the Redpanda Cloud authentication documentation for clarity and accuracy around integrating with Microsoft Entra ID. Updated and expanded the Microsoft Entra ID integration instructions to emphasize the need for the app to be configured as *Web* (not SPA or mobile), due to the OIDC Authorization Code flow with PKCE and server-side callback. Added note detailing claims, API permissions, and consent behavior, plus troubleshooting tips for common issues.

Resolves https://redpandadata.atlassian.net/browse/DOC-1269
Review deadline:

## Page previews
[SSO - Integrate with Microsoft Entra ID](https://deploy-preview-392--rp-cloud.netlify.app/redpanda-cloud/security/cloud-authentication/#integrate-with-microsoft-entra-id)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)