### PR TITLE
DOC-1633 Cloud Auth page update for deleting Okta-OIDC

### DIFF
--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -21,7 +21,7 @@ You must integrate your IdP with Redpanda Cloud to use SSO. On the *Users* page,
 
 By default, the connection is added in a disabled state. Edit the connection to enable it. You can choose to enable auto-enroll in the connection, which provides new users signing in from that IdP access to your Redpanda organization. When you enable auto-enroll, you select to assign a read, write, or admin role to users who log in with that IdP. Set up is different for most IdPs. 
 
-NOTE: Before deleting an SSO connection, an admin must manually delete all users associated with it.
+NOTE: Before you can delete an SSO connection, an admin must manually delete all users associated with that connection.
 
 ==== Integrate with Okta
 


### PR DESCRIPTION
## Description
This pull request changes the warning about deleting SSO connections to note that an admin must manually delete all users associated with an SSO connection before the connection itself can be deleted. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1633
Review deadline:

## Page previews
[Cloud Authentication - SSO](https://deploy-preview-397--rp-cloud.netlify.app/redpanda-cloud/security/cloud-authentication/#single-sign-on)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)