### PR TITLE
Fix missing link text

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -115,7 +115,7 @@ The deprecation timeline is:
 - End-of-support date: November 28, 2025
 - Retirement date: May 28, 2026
 
-See link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[] for more information.
+See the link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud API Deprecation Policy] for more information.
 
 === Read-only cluster configuration properties
 
@@ -220,7 +220,7 @@ Usage limits for Serverless Pro clusters increased to: ingress = 100 MBps, egres
 
 === Cloud API reference
 
-The Cloud API reference is now provided as separate references for the link:/api/doc/cloud-controlplane/[Control Plane API] and link:/api/doc/cloud-dataplane/[Data Plane APIs]. The Control Plane API and Data Plane APIs follow separate OpenAPI specifications, so the reference is updated to better reflect the structure of the Cloud APIs and to improve usability of the documentation. See also: link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[].
+The Cloud API reference is now provided as separate references for the link:/api/doc/cloud-controlplane/[Control Plane API] and link:/api/doc/cloud-dataplane/[Data Plane APIs]. The Control Plane API and Data Plane APIs follow separate OpenAPI specifications, so the reference is updated to better reflect the structure of the Cloud APIs and to improve usability of the documentation. See also: link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[Cloud API Overview].
 
 == January 2025
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -105,7 +105,7 @@ There could be updated documentation, release notes, and communication from your
 | At Redpanda's discretion.
 |===
 
-See also: link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[]
+See also: link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud API Deprecation Policy].
 
 
 === Deprecated features
@@ -123,7 +123,7 @@ The deprecation timeline is:
 - End-of-support date: November 28, 2025
 - Retirement date: May 28, 2026
 
-See link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[] for more information.
+See link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud API Deprecation Policy] for more information.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. Serverless Standard is deprecated.  
 
 All existing Serverless Standard clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -123,7 +123,7 @@ The deprecation timeline is:
 - End-of-support date: November 28, 2025
 - Retirement date: May 28, 2026
 
-See link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud API Deprecation Policy] for more information.
+See the link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud API Deprecation Policy] for more information.
 | March 2025 | Serverless Standard | For a better customer experience, the Serverless Standard and Serverless Pro products merged into a single offering. Serverless Standard is deprecated.  
 
 All existing Serverless Standard clusters will be migrated to the new xref:get-started:cluster-types/serverless.adoc[Serverless] platform (with higher usage limits, 99.9% SLA, and additional regions) on August 31, 2025.

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -372,6 +372,6 @@ include::networking:partial$private-links-test-connection.adoc[]
 
 include::shared:partial$suggested-reading.adoc[]
 
-* link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[]
+* link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[Cloud API Overview]
 * xref:networking:byoc/aws/vpc-peering-aws.adoc[]
 * xref:networking:dedicated/vpc-peering.adoc[]

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -714,5 +714,5 @@ The command should succeed, and you should be able to create a topic named `test
 
 include::shared:partial$suggested-reading.adoc[]
 
-- link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[]
-- link:/api/doc/cloud-controlplane/authentication[]
+- link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[Cloud API Overview]
+- link:/api/doc/cloud-controlplane/authentication[Cloud API Authentication]


### PR DESCRIPTION
## Description

Add missing descriptive link text to some `xref:` links that were migrated to Bump pages (we use `link:` syntax for Bump pages because they are not in an Antora/AsciiDoc project).

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)