### PR TITLE
Enclose secret in single quotes

### DIFF
--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -45,7 +45,7 @@ To set a cluster property with a secret, you must use the following notation:
 
 [source,bash]
 ----
-rpk cluster config set iceberg_rest_catalog_client_secret ${secrets.<secret-name>}
+rpk cluster config set iceberg_rest_catalog_client_secret '${secrets.<secret-name>}'
 ----
 
 NOTE: Some properties require a rolling restart, and it can take several minutes for the update to complete. The `rpk cluster config set` command returns the operation ID.  


### PR DESCRIPTION
## Description

This PR modifies a code example that uses a secret in rpk cluster config set. Single quotes are added around the secret to ensure that the shell doesn't try to interpret the secret as a variable, and the secret value gets passed into the cluster config correctly.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)