### PR TITLE
DOC-1538 BYOC customer tags after cluster creation

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -50,6 +50,72 @@ As part of agent deployment:
 
 include::get-started:partial$no-access.adoc[]
 
+== Manage custom tags/labels
+
+You can manage custom AWS resource tags/labels on an existing BYOC cluster with the xref:manage:api/cloud-byoc-controlplane-api.adoc[Cloud Control Plane API].
+
+Make sure you have:
+
+* The cluster ID. You can find the cluster ID in the Redpanda Cloud UI. Look in the **Details** section of the cluster overview.
+* A valid bearer token for the Cloud API. For details, see link:/api/doc/cloud-controlplane/authentication[Authenticate to the API]. 
+
+include::shared:partial$feature-flag.adoc[]
+
+. To refresh agent permissions so the Redpanda agent can update tags, run:
++
+[,bash]
+----
+rpk cloud byoc aws apply --redpanda-id=$cluster_id
+----
++
+This is because the following IAM actions are required for tag updates:
++
+* `ec2:DescribeTags`
+* `ec2:DescribeVolumes`
+* `ec2:DescribeNetworkInterfaces`
+* `ec2:CreateTags`
+* `ec2:DeleteTags`
+* `iam:TagPolicy`
+* `iam:UntagPolicy`
+* `iam:TagInstanceProfile`
+* `iam:UntagInstanceProfile`
++
+TIP: Re-applying BYOC is idempotent and (re)grants any newly required privileges to the agent instance profile.
++
+You can manage custom AWS resource tags/labels on an existing BYOC cluster with the link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[Cloud API].
++
+The `PATCH` call sets the labels and tags specified under `"cloud_provider_tags"`. It replaces the existing labels and tags with the specified labels and tags. To remove a single entry, omit it from the map you send.
++
+[,bash]
+----
+cluster_patch_body=$(cat <<'JSON'
+{
+  "cloud_provider_tags": {
+    "custom-label-1": "true",
+    "custom-label-2": "123"
+  }
+}
+JSON
+)
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -d "$cluster_patch_body" \
+----
++
+To remove all tags on an existing BYOC cluster, run:
++
+[,bash]
+----
+cluster_patch_body='{"cloud_provider_tags": {}}'
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}"\
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -d "$cluster_patch_body" \
+----
+
 == Next steps
 
 xref:networking:byoc/aws/index.adoc[Configure private networking]

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -155,6 +155,63 @@ Optionally, click *Advanced settings* to specify up to five key-value custom tag
 +
 As part of agent deployment, Redpanda assigns the permissions required to run the agent. For details about these permissions, see xref:security:authorization/cloud-iam-policies-azure.adoc[Azure IAM policies].
 
+== Manage custom tags/labels
+
+You can manage custom Azure resource tags/labels on an existing BYOC cluster with the xref:manage:api/cloud-byoc-controlplane-api.adoc[Cloud Control Plane API].
+
+Make sure you have:
+
+* The cluster ID. You can find the cluster ID in the Redpanda Cloud UI. Look in the **Details** section of the cluster overview.
+* A valid bearer token for the Cloud API. For details, see link:/api/doc/cloud-controlplane/authentication[Authenticate to the API]. 
+
+include::shared:partial$feature-flag.adoc[]
+
+. To refresh agent permissions in the target subscription, run:
++
+[,bash]
+----
+rpk cloud byoc azure apply --redpanda-id=$cluster_id --subscription-id=$subscription_id
+----
+
+. To set or replace tags on an existing BYOC cluster, invoke the Cloud API.
++
+The `PATCH` call sets the labels and tags specified under `"cloud_provider_tags"`. It replaces the existing labels and tags with the specified labels and tags. To remove a single entry, omit it from the map you send.
++
+[,bash]
+----
+cluster_patch_body=$(cat <<'JSON'
+{
+  "cloud_provider_tags": {
+    "custom-label-1": "true",
+    "custom-label-2": "123"
+  }
+}
+JSON
+)
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -d "$cluster_patch_body" \
+----
++
+To remove all tags on an existing BYOC cluster, run:
++
+[,bash]
+----
+cluster_patch_body='{"cloud_provider_tags": {}}'
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -d "$cluster_patch_body" \
+----
+
+=== Limitations 
+
+* Nodepool Application Security Groups (ASG): Custom tags are applied only during cluster creation and are not updated after.
+* Private Link–related network interfaces (Kubernetes API server, Tiered Storage, and Private Link service): Custom tags are applied only at cluster creation and are not updated after.
+
 == Next steps
 
 * xref:networking:azure-private-link.adoc[Configure Azure Private Link]

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -20,8 +20,10 @@ Enter a cluster name, then select the resource group, provider (GCP), xref:refer
 * If you plan to create a private network in your own VPC, select the region where your VPC is located.
 * Three availability zones provide two backups in case one availability zone goes down.
 ====
-+ 
-Optionally, click *Advanced settings* to specify up to five key-value custom labels. After the cluster is created, the labels are applied to all GCP resources associated with this cluster. For more information, see the https://cloud.google.com/compute/docs/labeling-resources[GCP documentation^].
++
+Optionally, click *Advanced settings* to specify up to five key-value custom labels. GCP labels enable you to make firewall rules and routes applicable to specific clusters. If the key of a label starts with `gcp.network-tag.`, the label is a network tag. After the cluster is created, the labels are applied to all GCP resources associated with this cluster. For more information, see the https://cloud.google.com/compute/docs/labeling-resources[GCP documentation^].
+
+After cluster creation, you can manage custom GCP labels/tags on an existing BYOC cluster with the xref:manage:api/cloud-byoc-controlplane-api.adoc[Cloud Control Plane API].
 
 . Click *Next*.
 . On the Network page, enter the connection type: either *Public* or *Private*. For BYOC clusters, *Private* is best-practice.
@@ -33,6 +35,65 @@ Optionally, click *Advanced settings* to specify up to five key-value custom lab
 Note that `rpk` configures the permissions required by the agent to provision and actively maintain the cluster. For details about these permissions, see xref:security:authorization/cloud-iam-policies-gcp.adoc[GCP IAM permissions].
 
 include::get-started:partial$no-access.adoc[]
+
+== Manage custom tags/labels
+
+In addition to adding custom GCP labels and GCP network tags at create time, you can manage custom GCP labels and tags on an existing BYOC cluster with the xref:manage:api/cloud-byoc-controlplane-api.adoc[Cloud Control Plane API].
+
+Make sure you have:
+
+* The cluster ID. You can find the cluster ID in the Redpanda Cloud UI. Look in the **Details** section of the cluster overview.
+* A valid bearer token for the Cloud API. For details, see link:/api/doc/cloud-controlplane/authentication[Authenticate to the API]. 
+
+include::shared:partial$feature-flag.adoc[]
+
+. To refresh agent permissions so the Redpanda agent can update tags, run:
++
+[,bash]
+----
+rpk cloud byoc gcp apply --redpanda-id=$redpanda_id --project_id=$project_id 
+----
++
+This is because the following IAM actions are required for tag updates:
++
+* `compute.disks.get`
+* `compute.disks.list`
+* `compute.disks.setLabels`
+* `compute.instances.setLabels`
+
+. To set or replace tags on an existing BYOC cluster, invoke the Cloud API.
++
+The `PATCH` call sets the labels and tags specified under `"cloud_provider_tags"`. It replaces the existing labels and tags with the specified labels and tags. To remove a single entry, omit it from the map you send.
++
+[,bash]
+----
+cluster_patch_body=cat << EOF
+{
+  "cloud_provider_tags": {
+    "custom-label-1": "true",
+    "custom-label-2": "true",
+    "gcp.network-tag.custom-network-tag-1": "true",
+    "gcp.network-tag.custom-network-tag-2": "true"
+}
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}" \
+   -H "Content-Type: application/json" \
+   -H "Authorization: Bearer $AUTH_TOKEN" \
+----
++
+Redpanda Cloud allows up to 16 custom labels and network tags in GCP. 
++
+To remove all tags on an existing BYOC cluster, run:
++
+[,bash]
+----
+cluster_patch_body='{"cloud_provider_tags": {}}'
+
+curl -X PATCH "https://api.redpanda.com/v1/clusters/{cluster.id}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $AUTH_TOKEN" \
+  -d "$cluster_patch_body" \
+----
 
 == Next steps
 


### PR DESCRIPTION
## Description
This pull request adds documentation for managing custom cloud provider tags and labels on existing BYOC clusters across AWS, Azure, and GCP. It adds instructions for using the Cloud Control Plane API to update, replace, or remove tags/labels after cluster creation, and clarifies required IAM permissions and update limitations for each provider.

**Tag/Label Management Documentation:**

* **AWS**:
  - Added a new section describing how to manage custom AWS resource tags/labels on existing BYOC clusters via the Cloud Control Plane API, including required IAM actions and usage of the `rpk cloud byoc aws apply` command to refresh agent permissions.

* **Azure**:
  - Added instructions for updating custom Azure resource tags/labels on existing BYOC clusters using the Cloud Control Plane API, including agent permission refresh steps and limitations regarding nodepool ASGs and Private Link network interfaces.

* **GCP**:
  - Enhanced the documentation to clarify the difference between GCP labels and network tags, and added instructions for managing custom labels/tags (including network tags) on existing BYOC clusters via the Cloud Control Plane API, with details on required IAM permissions and tag limits. [[1]](diffhunk://#diff-8865164e17fac88c9dd04d3e39b552892b06f071311c166510e919dd7d66fb3cL24-R26) [[2]](diffhunk://#diff-8865164e17fac88c9dd04d3e39b552892b06f071311c166510e919dd7d66fb3cR39-R97)

Resolves https://redpandadata.atlassian.net/browse/DOC-1538
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [X] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)