### PR TITLE
DOC-1575 RPCN vs Wasm decision matrix

### DIFF
--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -7,7 +7,7 @@ NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpa
 
 [TIP]
 ====
-Data transforms do not access external networks or disks, and are best for lightweight data prep (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:
+Data transforms do not access external networks or disks, and are best for lightweight data preparation (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:
 
 * External integration (HTTP services, databases, cloud storage) for enrichment or fan-out to third-party systems
 * Batching or windowed processing for grouping/aggregation

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -5,7 +5,7 @@ NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpa
 
 [TIP]
 ====
-Data transforms don't access external networks or disks, and are best for lightweight data prep (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:
+Data transforms do not access external networks or disks, and are best for lightweight data prep (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:
 
 * External integration (HTTP services, databases, cloud storage) for enrichment or fan-out to third-party systems
 * Batching or windowed processing for grouping/aggregation

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -3,6 +3,8 @@
 
 NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
 
+:tip-caption: When to use Redpanda Connect instead
+
 [TIP]
 ====
 Data transforms do not access external networks or disks, and are best for lightweight data prep (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:

--- a/modules/develop/pages/data-transforms/build.adoc
+++ b/modules/develop/pages/data-transforms/build.adoc
@@ -3,4 +3,16 @@
 
 NOTE: Data transforms are supported on BYOC and Dedicated clusters running Redpanda version 24.3 and later.
 
+[TIP]
+====
+Data transforms don't access external networks or disks, and are best for lightweight data prep (filtering, scrubbing, schema/format conversion). Use xref:develop:connect/about.adoc[Redpanda Connect] when you need any of the following:
+
+* External integration (HTTP services, databases, cloud storage) for enrichment or fan-out to third-party systems
+* Batching or windowed processing for grouping/aggregation
+* Prebuilt processors and connectors to reduce custom code
+
+====
+
+:tip-caption: Tip
+
 include::ROOT:develop:data-transforms/build.adoc[tag=single-source]

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -290,9 +290,48 @@ Dedicated::
 
 == Redpanda Connect and Kafka Connect
 
-xref:develop:connect/about.adoc[Redpanda Connect] is integrated into Redpanda Cloud and available as a fully-managed service. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications from the Cloud UI or using the link:/api/doc/cloud-dataplane/group/endpoint-redpanda-connect-pipeline[Data Plane API]. Comprehensive metrics, monitoring, and per pipeline scaling are also available. To start using Redpanda Connect, xref:develop:connect/connect-quickstart.adoc[try this quickstart].
+xref:develop:connect/about.adoc[Redpanda Connect] lets you compose pipelines from a rich library of inputs, processors, and outputs with strong metrics, logging, and per-pipeline scaling. To try it, see the xref:develop:connect/connect-quickstart.adoc[quickstart].
 
-xref:develop:managed-connectors/index.adoc[Kafka Connect] is disabled by default on all new clusters. To unlock this feature for your BYOC or Dedicated clusters, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. Note that when Kafka Connect is enabled, there is a node running for Kafka Connect, even if connectors are not used.
+xref:develop:managed-connectors/index.adoc[Kafka Connect] is disabled by default on all new clusters. To unlock this feature for your BYOC or Dedicated cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^]. When enabled, a Kafka Connect node runs even if no connectors are configured.
+
+=== Redpanda Connect vs data transforms
+
+xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) provide lightweight, per-record changes between Redpanda topics with minimal latency. Transforms run inside the broker, map one input topic to one or more output topics, and are intentionally sandboxed (no external network or disk access). They're ideal for validation, redaction, format/schema conversion, and simple routing.
+
+[cols="1,2,2",options="header",stripes=none]
+|===
+|  | Data transforms | Redpanda Connect
+
+| Best for
+| Simple, stateless, per-record normalization inside Redpanda
+| Enrichment/lookup with external services; multi-stage flows
+
+| External I/O
+| Not permitted (sandboxed)
+| Native (HTTP/DB/object storage)
+
+| Topology
+| 1→1 or 1→N (no cross-topic fan-in)
+| Fan-in and fan-out; multi-step pipelines
+
+| Ordering
+| Preserves per-partition order
+| Can preserve; batching/parallelism may relax unless tuned
+
+| Scale & isolation
+| Shares broker CPU/memory → keep lightweight
+| Scales independently; isolates heavy work from brokers
+
+| Failure handling
+| You code routing/error behavior
+| Built-in retries/backoff and DLQ patterns
+|===
+
+[TIP]
+====
+* Use data transforms for simple, in-broker, per-record changes with minimal latency.
+* Use Redpanda Connect if your pipeline must talk to external systems (HTTP services, databases, cloud storage), or when you need advanced flow control, such as batching and windowed processing. 
+====
 
 == Redpanda Cloud vs Self-Managed feature compatibility
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -311,7 +311,7 @@ xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) pr
 | Native (HTTP/DB/object storage)
 
 | Topology
-| 1→1 or 1→N (no cross-topic fan-in)
+| 1:1 or 1:N (no cross-topic fan-in)
 | Fan-in and fan-out; multi-step pipelines
 
 | Ordering

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -316,7 +316,7 @@ xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) pr
 
 | Ordering
 | Preserves per-partition order
-| Can preserve; batching/parallelism may relax unless tuned
+| Per-partition order can be preserved; configure parallelism and batching accordingly
 
 | Scale & isolation
 | Shares broker CPU/memory → keep lightweight

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -319,7 +319,7 @@ xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) pr
 | Per-partition order can be preserved; configure parallelism and batching accordingly
 
 | Scale & isolation
-| Shares broker CPU/memory → keep lightweight
+| Shares broker CPU/memory. Best for lightweight operations
 | Scales independently; isolates heavy work from brokers
 
 | Failure handling

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -308,7 +308,7 @@ xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) pr
 
 | External I/O
 | Not permitted (sandboxed)
-| Native (HTTP/DB/object storage)
+| Native (HTTP/database/object storage)
 
 | Topology
 | 1:1 or 1:N (no cross-topic fan-in)
@@ -319,7 +319,7 @@ xref:develop:data-transforms/how-transforms-work.adoc[Data transforms] (Wasm) pr
 | Per-partition order can be preserved; configure parallelism and batching accordingly
 
 | Scale & isolation
-| Shares broker CPU/memory. Best for lightweight operations
+| Shares broker CPU/memory; best for lightweight operations
 | Scales independently; isolates heavy work from brokers
 
 | Failure handling


### PR DESCRIPTION
## Description
This pull request clarifies the differences between Redpanda Connect and data transforms, helping users choose the right tool for their data pipeline needs. It adds a new comparison table and explanatory tips to highlight use cases, capabilities, and limitations of each feature.

* Added a detailed comparison table and explanation of Redpanda Connect vs data transforms in `modules/get-started/pages/cloud-overview.adoc`
* Added a new tip to `modules/develop/pages/data-transforms/build.adoc` explaining that data transforms are best for lightweight, in-broker data prep, while Redpanda Connect should be used for external integrations, batching, and prebuilt processors.

Resolves https://redpandadata.atlassian.net/browse/DOC-1575
Review deadline:

## Page previews
[Cloud Overview](https://deploy-preview-402--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#redpanda-connect-and-kafka-connect)
[Develop Data Transforms](https://deploy-preview-402--rp-cloud.netlify.app/redpanda-cloud/develop/data-transforms/build/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)