### PR TITLE
DOC-1646 RBAC in DP not supported for Serverless

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -172,6 +172,7 @@ Consider BYOC or Dedicated if you need more control over the deployment or if yo
 * Private networking
 * Multiple availability zones (AZs). A multi-AZ cluster provides higher resiliency in the event of a failure in one of the zones. 
 * Ability to export Redpanda metrics to a third-party monitoring system
+* Role-based access control (RBAC) in the data plane
 * Kafka Connect
 * Higher limits and quotas. See xref:reference:tiers/byoc-tiers.adoc[BYOC usage tiers] and xref:reference:tiers/dedicated-tiers.adoc[Dedicated usage tiers] compared to xref:get-started:cluster-types/serverless.adoc#serverless-usage-limits[Serverless limits].
 

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -92,10 +92,10 @@ Not all features included in BYOC clusters are available in Serverless. For exam
 
 * HTTP Proxy API
 * Ability to export metrics to a third-party monitoring system
-* Kafka Connect 
 * Private networking (VPC peering or AWS PrivateLink)
 * Multiple availability zones (AZs)
 * RBAC in the data plane and mTLS authentication for Kafka API clients
+* Kafka Connect 
 
 == Next steps
 

--- a/modules/security/pages/authorization/rbac/rbac_dp.adoc
+++ b/modules/security/pages/authorization/rbac/rbac_dp.adoc
@@ -3,4 +3,6 @@
 
 Use role-based access control (RBAC) in the glossterm:data plane[] to configure cluster-level permissions for provisioned users at scale. RBAC works in conjunction with all supported authentication methods.
 
+RBAC in the data plane is available for BYOC and Dedicated clusters. 
+
 include::ROOT:manage:partial$rbac-dp.adoc[tag=single-source]


### PR DESCRIPTION
## Description
This pull request clarifies the availability of role-based access control (RBAC) in the data plane for Serverless. 

* Added explicit mention that RBAC in the data plane is available for BYOC and Dedicated clusters in `modules/security/pages/authorization/rbac/rbac_dp.adoc`.
* Updated the feature list for BYOC and Dedicated clusters in `modules/get-started/pages/cloud-overview.adoc` to include RBAC in the data plane.
* Clarified and reordered features for Serverless clusters in `modules/get-started/pages/cluster-types/serverless.adoc`, ensuring RBAC and mTLS authentication are listed, and adjusted the placement of Kafka Connect for consistency.

Resolves https://redpandadata.atlassian.net/browse/DOC-1646
Review deadline:

## Page previews
[Cloud Overview](https://deploy-preview-403--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#serverless-vs-byocdedicated)
[RBAC in the Data Plane](https://deploy-preview-403--rp-cloud.netlify.app/redpanda-cloud/security/authorization/rbac/rbac_dp/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)