### PR TITLE
replace external links with concepts

### DIFF
--- a/modules/networking/pages/cloud-security-network.adoc
+++ b/modules/networking/pages/cloud-security-network.adoc
@@ -218,7 +218,7 @@ AWS::
 --
 * *Time synchronization*
 +
-Redpanda Cloud uses the https://aws.amazon.com/about-aws/whats-new/2017/11/introducing-the-amazon-time-sync-service/[Amazon Time Sync Service^], a fleet of redundant satellite-connected and atomic reference clocks in AWS regions.
+Redpanda Cloud uses the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html[Amazon Time Sync Service^], a fleet of redundant satellite-connected and atomic reference clocks in AWS regions.
 
 * *Domain name system (DNS)*
 +


### PR DESCRIPTION
## Description
This pull request changed the link for the Amazon Time Sync Service in the `cloud-security-network.adoc` file to point to the official AWS documentation instead of the AWS news page.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)