### PR TITLE
DOC-1652 change from VPC peering to PSC

### DIFF
--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -135,7 +135,12 @@ rpk cloud byoc aws apply --redpanda-id=$CLUSTER_ID
 
 == Enable PrivateLink endpoint service for existing clusters
 
-CAUTION: As soon as PrivateLink is available on your VPC, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding PrivateLink ports.
+[CAUTION]
+====
+Enabling PrivateLink on your VPC interrupts all communication on existing Redpanda bootstrap server and broker ports due to the change of private DNS resolution.
+
+To avoid disruption, consider using a staged approach to enable PrivateLink. See: xref:networking:byoc/aws/vpc-peering-aws.adoc#switch-from-vpc-peering-to-privatelink[Switch from VPC peering to PrivateLink].
+====
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +
@@ -342,5 +347,5 @@ include::networking:partial$private-links-test-connection.adoc[]
 include::shared:partial$suggested-reading.adoc[]
 
 * link:/api/doc/cloud-controlplane/topic/topic-cloud-api-overview[Cloud API Overview]
-* xref:networking:byoc/aws/vpc-peering-aws.adoc[]
-* xref:networking:dedicated/vpc-peering.adoc[]
+* xref:networking:byoc/aws/vpc-peering-aws.adoc[Add a BYOC VPC Peering Connection]
+* xref:networking:dedicated/vpc-peering.adoc[Add a Dedicated VPC Peering Connection]

--- a/modules/networking/pages/azure-private-link.adoc
+++ b/modules/networking/pages/azure-private-link.adoc
@@ -156,7 +156,7 @@ rpk cloud byoc azure apply --redpanda-id=$CLUSTER_ID --subscription-id=$REDPANDA
 
 === Enable Private Link service for existing clusters
 
-CAUTION: As soon as Private Link is available on your virtual network, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your virtual network are ready to start using the corresponding Private Link ports.
+CAUTION: Enabling Private Link on your VNet interrupts all communication on existing Redpanda bootstrap server and broker ports due to the change of private DNS resolution. Make sure all applications running in your virtual network are ready to start using the corresponding Private Link ports.
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +

--- a/modules/networking/pages/byoc/aws/vpc-peering-aws.adoc
+++ b/modules/networking/pages/byoc/aws/vpc-peering-aws.adoc
@@ -2,6 +2,8 @@
 :description: Use the Redpanda UI and AWS CLI to create a VPC peering connection for a BYOC cluster.
 :page-aliases: deploy:deployment-option/cloud/vpc-peering-aws.adoc
 
+A VPC peering connection is a networking connection between two VPCs. This connection allows the VPCs to communicate with each other as if they were within the same network. A route table routes traffic between the two VPCs using private IPv4 addresses.
+
 To start sending data to the Redpanda cluster, you must configure the VPC network connection by connecting your Redpanda VPC to your existing AWS VPC.
 
 == Prerequisites
@@ -56,3 +58,12 @@ There are two ways to test your connection:
 
 * Return to your cluster overview, and follow the directions in the *How to connect* panel.
 * Use the AWS https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html[Reachability Analyzer^]. Select your VM instance and a Redpanda instance as the source and destination, and test the connection between them.
+
+== Switch from VPC peering to PrivateLink
+
+VPC peering and PrivateLink use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. When you configure the PrivateLink DNS, those hostnames resolve to PrivateLink endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+
+To enable PrivateLink without disrupting VPC peering connections, do a controlled DNS switchover:
+
+. Enable PrivateLink on the existing cluster and configure the PrivateLink connection to Redpanda Cloud, but *do not modify VPC DNS attributes yet*. See: xref:networking:aws-privatelink.adoc#enable-privatelink-endpoint-service-for-existing-clusters[Enable PrivateLink on an existing cluster].
+. During a planned window, modify the VPC DNS attributes to switch the shared hostnames over to PrivateLink.

--- a/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
@@ -48,6 +48,5 @@ VPC peering and Private Service Connect use the same DNS hostnames (connection U
 
 To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
 
-. Enable Private Service Connect on the existing cluster.
-. Deploy consumer-side resources, but do not create private DNS yet. See: xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable PSC on an existing cluster].
+. Enable Private Service Connect on the existing cluster and deploy consumer-side resources, but *do not create private DNS yet*. See: xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable Private Service Connect on an existing cluster].
 . During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
@@ -2,6 +2,8 @@
 :description: Use the Redpanda and GCP UIs to create a VPC peering connection for a BYOC cluster.
 :page-aliases: deploy:deployment-option/cloud/vpc-peering-gcp.adoc
 
+A VPC peering connection is a networking connection between two VPCs. This connection allows the VPCs to communicate with each other as if they were within the same network. A route table routes traffic between the two VPCs using private IPv4 addresses.
+
 To start sending data to the Redpanda cluster, you must configure the VPC network connection by connecting your Redpanda VPC to your existing GCP VPC.
 
 == Prerequisites
@@ -39,3 +41,5 @@ To quickly test this quickly in GCP:
 * Create a virtual machine on your GCP network that has a firewall rule allowing ingress traffic from your IP (for example, `<your-ip>/32`)
 * Activate the Cloud Shell in your project, install `rpk` in the Cloud Shell, and run `rpk cluster info`.
 * If there is output from Redpanda, your connection is successful.
+
+include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
@@ -42,4 +42,12 @@ To quickly test this quickly in GCP:
 * Activate the Cloud Shell in your project, install `rpk` in the Cloud Shell, and run `rpk cluster info`.
 * If there is output from Redpanda, your connection is successful.
 
-include::networking:partial$switch-to-psc.adoc[]
+== Switch from VPC peering to Private Service Connect
+
+VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+
+To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
+
+. Enable Private Service Connect on the existing cluster.
+. Deploy consumer-side resources, but do not create private DNS yet. See: xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable PSC on an existing cluster].
+. During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/byoc/gcp/vpc-peering-gcp.adoc
@@ -44,7 +44,7 @@ To quickly test this quickly in GCP:
 
 == Switch from VPC peering to Private Service Connect
 
-VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. When you configure the Private Service Connect DNS, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
 
 To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
 

--- a/modules/networking/pages/dedicated/aws/vpc-peering.adoc
+++ b/modules/networking/pages/dedicated/aws/vpc-peering.adoc
@@ -22,10 +22,10 @@ To create a peering connection between your VPC and Redpanda's VPC:
 
 . In the Redpanda Cloud UI, go to the *Overview* page for your cluster.
 . In the Details section, click the name of the Redpanda network.
-. On the *Network* page, click *+ Add peering connection*.
-. In *Connection name*, enter a name. For example, the name might refer to the VPC ID of the VPC you created in AWS.
-. In *AWS account number*, enter the account number associated with the VPC you want to connect to.
-. In *AWS VPC ID*, enter the VPC ID by copying it from the AWS VPC Console.
+. On the Networks page, click *VPC peering walkthrough*.
+. For *Connection name*, enter a name. For example, the name might refer to the VPC ID of the VPC you created in AWS.
+. For *AWS account number*, enter the account number associated with the VPC you want to connect to.
+. For *AWS VPC ID*, enter the VPC ID by copying it from the AWS VPC Console.
 . Click *Create peering connection*.
 
 == Accept the peering connection request
@@ -42,6 +42,8 @@ The status should say "Pending acceptance".
 . Open the *Actions* menu and select *Accept Request*.
 . In the confirmation dialog box, verify that the requester owner ID corresponds to the Redpanda account, and select *Yes, Accept*.
 . In the next confirmation dialog box, select *Modify my route tables now*.
++
+Follow the steps in the dialog box to add routes to your route tables in the AWS console. This enables traffic to flow between the two VPCs.
 
 == Switch from VPC peering to PrivateLink
 

--- a/modules/networking/pages/dedicated/aws/vpc-peering.adoc
+++ b/modules/networking/pages/dedicated/aws/vpc-peering.adoc
@@ -42,3 +42,12 @@ The status should say "Pending acceptance".
 . Open the *Actions* menu and select *Accept Request*.
 . In the confirmation dialog box, verify that the requester owner ID corresponds to the Redpanda account, and select *Yes, Accept*.
 . In the next confirmation dialog box, select *Modify my route tables now*.
+
+== Switch from VPC peering to PrivateLink
+
+VPC peering and PrivateLink use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. When you configure the PrivateLink DNS, those hostnames resolve to PrivateLink endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+
+To enable PrivateLink without disrupting VPC peering connections, do a controlled DNS switchover:
+
+. Enable PrivateLink on the existing cluster and configure the PrivateLink connection to Redpanda Cloud, but *do not modify VPC DNS attributes yet*. See: xref:networking:aws-privatelink.adoc#enable-privatelink-endpoint-service-for-existing-clusters[Enable PrivateLink on an existing cluster].
+. During a planned window, modify the VPC DNS attributes to switch the shared hostnames over to PrivateLink. 

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -157,3 +157,5 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
+
+include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -99,7 +99,7 @@ curl -vv -X POST \
 
 [CAUTION]
 ====
-As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
+As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
 
 To avoid disruption, consider using a staged approach. See: xref:networking:dedicated/gcp/vpc-peering-gcp.adoc#switch-from-vpc-peering-to-private-service-connect[Switch from VPC peering to Private Service Connect].
 ====

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -99,7 +99,7 @@ curl -vv -X POST \
 
 [CAUTION]
 ====
-As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
+Enabling Private Service Connect on your VPC interrupts all communication on existing Redpanda bootstrap server and broker ports due to the change of private DNS resolution.
 
 To avoid disruption, consider using a staged approach. See: xref:networking:dedicated/gcp/vpc-peering-gcp.adoc#switch-from-vpc-peering-to-private-service-connect[Switch from VPC peering to Private Service Connect].
 ====

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-api.adoc
@@ -97,7 +97,12 @@ curl -vv -X POST \
 
 == Enable Private Service Connect on an existing cluster
 
-CAUTION: As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports.
+[CAUTION]
+====
+As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
+
+To avoid disruption, consider using a staged approach. See: xref:networking:dedicated/gcp/vpc-peering-gcp.adoc#switch-from-vpc-peering-to-private-service-connect[Switch from VPC peering to Private Service Connect].
+====
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +
@@ -157,5 +162,3 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
-
-include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
@@ -44,3 +44,5 @@ The status should say "Pending acceptance".
 . Open the *Actions* menu and select *Accept Request*.
 . In the confirmation dialog box, verify that the requester owner ID corresponds to the Redpanda account, and select *Yes, Accept*.
 . In the next confirmation dialog box, select *Modify my route tables now*.
+
+include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
@@ -45,4 +45,12 @@ The status should say "Pending acceptance".
 . In the confirmation dialog box, verify that the requester owner ID corresponds to the Redpanda account, and select *Yes, Accept*.
 . In the next confirmation dialog box, select *Modify my route tables now*.
 
-include::networking:partial$switch-to-psc.adoc[]
+== Switch from VPC peering to Private Service Connect
+
+VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+
+To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
+
+. Enable Private Service Connect on the existing cluster.
+. Deploy consumer-side resources, but do not create private DNS yet. See: xref:networking:dedicated/gcp/configure-psc-in-api.adoc#enable-private-service-connect-on-an-existing-cluster[Enable PSC on an existing cluster].
+. During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
@@ -47,7 +47,7 @@ The status should say "Pending acceptance".
 
 == Switch from VPC peering to Private Service Connect
 
-VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
+VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. When you configure the Private Service Connect DNS, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
 
 To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
 

--- a/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
@@ -51,6 +51,5 @@ VPC peering and Private Service Connect use the same DNS hostnames (connection U
 
 To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
 
-. Enable Private Service Connect on the existing cluster.
-. Deploy consumer-side resources, but do not create private DNS yet. See: xref:networking:dedicated/gcp/configure-psc-in-api.adoc#enable-private-service-connect-on-an-existing-cluster[Enable PSC on an existing cluster].
+. Enable Private Service Connect on the existing cluster and deploy consumer-side resources, but *do not create private DNS yet*. See: xref:networking:dedicated/gcp/configure-psc-in-api.adoc#enable-private-service-connect-on-an-existing-cluster[Enable Private Service Connect on an existing cluster].
 . During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
+++ b/modules/networking/pages/dedicated/gcp/vpc-peering-gcp.adoc
@@ -17,33 +17,25 @@ TIP: Consider adding `rp` at the beginning of the VPC name to indicate that this
 
 == Create a peering connection
 
-To create a peering connection between your VPC and Redpanda's VPC:
+A peering becomes active after both Redpanda and GCP create a peering that targets the other project/network.
 
 . In the Redpanda Cloud UI, go to the *Overview* page for your cluster.
 . In the Details section, click the name of the Redpanda network.
-. On the *Network* page, click *+ Add peering connection*.
-. In *Connection name*, enter a name for the connection.
+. On the Networks page for your cluster, click *VPC peering walkthrough*.
+. For *Connection name*, enter a name for the connection.
 +
 For example, the name might refer to the VPC ID of the VPC you created in GCP.
 
-. In *GCP account number*, enter the account number associated with the VPC you want to connect to.
-. In *GCP VPC ID*, enter the VPC ID.
+. For *GCP project ID*, enter the ID of the project that contains the VPC network you want to connect to.
+. For *VPC network name*, enter the name of the VPC network.
 . Click *Create peering connection*.
 
-== Accept the peering connection request
+== Create the reciprocal peering connection
 
-Redpanda sends a peering request to the GCP. You must accept the request from the Redpanda VPC to set up the peering connection.
-
-. Log in to GCP.
-. Select the region where the VPC was created.
-. From the navigation menu, select *Peering Connections*.
-. Under *Requester VPC*, select the VPC you created for use with Redpanda.
-+
-The status should say "Pending acceptance".
-
-. Open the *Actions* menu and select *Accept Request*.
-. In the confirmation dialog box, verify that the requester owner ID corresponds to the Redpanda account, and select *Yes, Accept*.
-. In the next confirmation dialog box, select *Modify my route tables now*.
+. In the Google Cloud console, go to VPC network peering - Create peering connection.
+. For *Name*, enter a name for the connection (for example, `rp-peering`).
+. Select your VPC network, project, and VPC network name.
+. Click *Create*.
 
 == Switch from VPC peering to Private Service Connect
 

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -193,7 +193,7 @@ Replace the following placeholders for the request body. Variables with a `byovp
 
 [CAUTION]
 ====
-As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
+Enabling Private Service Connect on your VPC interrupts all communication on existing Redpanda bootstrap server and broker ports due to the change of private DNS resolution.
 
 To avoid disruption, consider using a staged approach to enable Private Service Connect. See: xref:networking:byoc/gcp/vpc-peering-gcp.adoc#switch-from-vpc-peering-to-private-service-connect[Switch from VPC peering to Private Service Connect].
 ====

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -298,3 +298,4 @@ curl -v -X PATCH \
 -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
 
+include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/pages/gcp-private-service-connect.adoc
+++ b/modules/networking/pages/gcp-private-service-connect.adoc
@@ -191,7 +191,12 @@ Replace the following placeholders for the request body. Variables with a `byovp
 
 == Enable Private Service Connect on an existing BYOC or BYOVPC cluster
 
-CAUTION: As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports.
+[CAUTION]
+====
+As soon as Private Service Connect is available on your VPC, all communication on existing Redpanda bootstrap server and  broker ports is interrupted due to the change on the private DNS resolution. Make sure all applications running in your VPC are ready to start using the corresponding Private Service Connect ports. 
+
+To avoid disruption, consider using a staged approach to enable Private Service Connect. See: xref:networking:byoc/gcp/vpc-peering-gcp.adoc#switch-from-vpc-peering-to-private-service-connect[Switch from VPC peering to Private Service Connect].
+====
 
 . In the Redpanda Cloud UI, go to the cluster overview and copy the cluster ID from the **Details** section.
 +
@@ -297,5 +302,3 @@ curl -v -X PATCH \
 -H "Authorization: Bearer $AUTH_TOKEN" \
 -d "$CLUSTER_PATCH_BODY" $PUBLIC_API_ENDPOINT/v1/clusters/$CLUSTER_ID
 ----
-
-include::networking:partial$switch-to-psc.adoc[]

--- a/modules/networking/partials/switch-to-psc.adoc
+++ b/modules/networking/partials/switch-to-psc.adoc
@@ -1,9 +1,0 @@
-== Switch from VPC peering to Private Service Connect
-
-VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
-
-To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
-
-. Enable Private Service Connect on the existing cluster.
-. Deploy consumer-side resources, but do not create private DNS yet. See xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable PSC on an existing cluster].
-. During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/partials/switch-to-psc.adoc
+++ b/modules/networking/partials/switch-to-psc.adoc
@@ -1,0 +1,11 @@
+== Switch from VPC peering to Private Service Connect
+
+VPC peering and Private Service Connect use the same seed endpoints (connection URLs) to connect to the Redpanda cluster. When Private Service Connect is enabled, these endpoints get resolved through DNS, potentially breaking existing VPC peering connections.  
+
+To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
+
+. Follow the steps to enable Private Service Connect on an existing cluster.
+. Follow the next steps to deploy consumer-side resources *but stop before the DNS configuration in steps 6 and 7*. 
+. When you're ready to fully transition clients to Private Service Connect, follow the DNS configuration in steps 6 and 7.
+
+See xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable Private Service Connect on an existing cluster].

--- a/modules/networking/partials/switch-to-psc.adoc
+++ b/modules/networking/partials/switch-to-psc.adoc
@@ -1,11 +1,9 @@
 == Switch from VPC peering to Private Service Connect
 
-VPC peering and Private Service Connect use the same seed endpoints (connection URLs) to connect to the Redpanda cluster. When Private Service Connect is enabled, these endpoints get resolved through DNS, potentially breaking existing VPC peering connections.  
+VPC peering and Private Service Connect use the same DNS hostnames (connection URLs) to connect to the Redpanda cluster. After you complete the Private Service Connect DNS configuration, those hostnames resolve to Private Service Connect endpoints, which can interrupt existing VPC peering-based connections if clients aren't ready.
 
 To enable Private Service Connect without disrupting VPC peering connections, do a controlled DNS switchover:
 
-. Follow the steps to enable Private Service Connect on an existing cluster.
-. Follow the next steps to deploy consumer-side resources *but stop before the DNS configuration in steps 6 and 7*. 
-. When you're ready to fully transition clients to Private Service Connect, follow the DNS configuration in steps 6 and 7.
-
-See xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable Private Service Connect on an existing cluster].
+. Enable Private Service Connect on the existing cluster.
+. Deploy consumer-side resources, but do not create private DNS yet. See xref:networking:gcp-private-service-connect.adoc#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster[Enable PSC on an existing cluster].
+. During a planned window, create the private DNS zone and records in your VPC to switch the shared hostnames over to Private Service Connect.

--- a/modules/networking/partials/vnet-peering.adoc
+++ b/modules/networking/partials/vnet-peering.adoc
@@ -27,7 +27,7 @@ To create a peering connection between your Azure VNet and Redpanda VPC:
 
 . In the Redpanda Cloud UI, go to the *Overview* page for your cluster.
 . In the Details section, click the name of the *Redpanda network*.
-. On the *Network* page for your cluster, click *+ Add peering connection*.
+. On the Networks page for your cluster, click *VPC peering walkthrough*.
 . For *Connection name*, enter a name. For example, the name could refer to your Azure VNet ID.
 . For *Azure account number*, enter the account number associated with the VNet you want to connect to.
 . For *Azure VNet ID*, enter the VNet ID.


### PR DESCRIPTION
## Description
This pull request updates the networking doc to add how to switch from VPC peering to PrivateLink or Private Service Connect. 

- Added new "Switch from VPC peering to PrivateLink" and "Switch from VPC peering to Private Service Connect" sections in AWS and GCP BYOC and Dedicated guides, describing a staged DNS switchover process to avoid client disruption. [[1]](diffhunk://#diff-b6be944b1a3e47d87b4d599ff8f5ee996e45a74685085d494c0452aea4ff0ba2R61-R69) [[2]](diffhunk://#diff-b8107479b8960f8bacce20835cd01ca4da484da90afa57c99cd1d72d54ad3325R44-R52) [[3]](diffhunk://#diff-dac3575a8d3782538a0aa5cda85e6ed63def8fa15a079115aeb1577f4036b59eR45-R55) [[4]](diffhunk://#diff-3cb0cb07f72cd75c6fb5f7c9bacf8193c166168a33beaec4d56e8cc1fe4159d0L20-R47)
- Updated warnings for enabling PrivateLink and Private Service Connect to recommend staged approaches and reference relevant new sections for safe migration. [[1]](diffhunk://#diff-66ea720430f41f22a8c57e10687a5532decb00a5108ec6b715e1e0fc9b4978acL138-R143) [[2]](diffhunk://#diff-44fa14256b425a599042395c62f8d8e0babfbbe79846b452a328bfcd989efd02L159-R159) [[3]](diffhunk://#diff-8ce1d72200c43317bd875941ec5b21f2e58c64ed8ed5b19f9532d3b189816409L100-R105) [[4]](diffhunk://#diff-f3fed6dbc7157a74820c0be4c8752d6a386697a878f850663c396f2c329f0280L194-R199)

- Refined instructions for creating peering connections in AWS, GCP, and Azure, including more accurate UI labels and steps, and clarified reciprocal peering requirements for GCP. [[1]](diffhunk://#diff-dac3575a8d3782538a0aa5cda85e6ed63def8fa15a079115aeb1577f4036b59eL25-R28) [[2]](diffhunk://#diff-3cb0cb07f72cd75c6fb5f7c9bacf8193c166168a33beaec4d56e8cc1fe4159d0L20-R47) [[3]](diffhunk://#diff-a8c1a19f67fb9506b59184569c0668de74ec255b570f8f1dab47eda6c9302c72L30-R30)

Resolves https://redpandadata.atlassian.net/browse/DOC-1652, https://redpandadata.atlassian.net/browse/DOC-1481, https://redpandadata.atlassian.net/browse/DOC-26
Review deadline:

## Page previews
DOC-652 (switch from VPC peering to PSC/PrivateLink)
- [VPC Peering on GPC BYOC](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/byoc/gcp/vpc-peering-gcp/#switch-from-vpc-peering-to-private-service-connect)
- [Configure PSC BYOC](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/gcp-private-service-connect/#enable-private-service-connect-on-an-existing-byoc-or-byovpc-cluster)
- [VPC Peering on GPC Dedicated](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/gcp/vpc-peering-gcp/#switch-from-vpc-peering-to-private-service-connect)
- [Configure PSC Dedicated](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/gcp/configure-psc-in-api/#enable-private-service-connect-on-an-existing-cluster)
- [VPC Peering on AWS BYOC](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/byoc/aws/vpc-peering-aws/#switch-from-vpc-peering-to-privatelink)
- [VPC Peering on AWS Dedicated](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/aws/vpc-peering/#switch-from-vpc-peering-to-privatelink)
- [Configure PrivateLink](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/aws-privatelink/#enable-privatelink-endpoint-service-for-existing-clusters)

DOC-1481 (make specific to GCP)
[Create the reciprocal peering connection](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/gcp/vpc-peering-gcp/#create-the-reciprocal-peering-connection)

DOC-26 (finish step 7)
[Accept peering connection, step 7](https://deploy-preview-408--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/aws/vpc-peering/#accept-the-peering-connection-request)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)