### PR TITLE
DOC-1680 update list of beta features

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -387,7 +387,7 @@ The following features are currently in beta in Redpanda Cloud:
 * BYOVNet for Azure
 * Secrets Management for BYOVPC on GCP and AWS
 * Remote Read Replicas for AWS and GCP 
-* AI agents
+* Redpanda Cloud MCP Server
 * Several Redpanda Connect components 
 
 == Next steps


### PR DESCRIPTION
## Description
This pull request updates the list of beta features in the Redpanda Cloud documentation, replacing "AI agents" with "Redpanda Cloud MCP Server" in the beta features list.

Resolves https://redpandadata.atlassian.net/browse/DOC-1680
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)