### PR TITLE
DOC-1682 Monitoring not supported on Serverless

### DIFF
--- a/modules/manage/pages/monitor-cloud.adoc
+++ b/modules/manage/pages/monitor-cloud.adoc
@@ -2,14 +2,15 @@
 :description: Learn how to configure monitoring on your BYOC or Dedicated cluster to maintain system health and optimize performance.
 :page-aliases: manage:monitoring.adoc, deploy:deployment-option/cloud/monitor-cloud.adoc
 
-You can configure monitoring on your Redpanda BYOC or Dedicated cluster to maintain system health and optimize performance. You can monitor Redpanda with https://prometheus.io/[Prometheus^] or with any other monitoring and alerting tool, such as Datadog, New Relic, Elastic Cloud, Google Cloud, or Azure.
+You can configure monitoring on your cluster to maintain system health and optimize performance. You can monitor Redpanda with https://prometheus.io/[Prometheus^] or with any other monitoring and alerting tool, such as Datadog, New Relic, Elastic Cloud, Google Cloud, or Azure.
 
-Redpanda Cloud exports Redpanda metrics for all brokers and connectors from a single OpenMetrics endpoint. This endpoint can be found on the *Overview* page for your cluster, under *How to connect* and *Prometheus*.
+Redpanda Cloud exports Redpanda metrics for all brokers and connectors from a single OpenMetrics endpoint. This endpoint can be found on the *Overview* page for your BYOC or Dedicated cluster, under *How to connect* and *Prometheus*.
 
 
 [NOTE]
 ====
 
+- BYOC and Dedicated clusters can export Redpanda metrics to a third-party monitoring system. Serverless clusters _cannot_ export Redpanda metrics.
 - To maximize performance, Redpanda exports some metrics only when the underlying feature is in use. For example, a metric for consumer groups, xref:reference:public-metrics-reference.adoc#redpanda_kafka_consumer_group_committed_offset[`redpanda_kafka_consumer_group_committed_offset`], is only exported when groups are registered.
 - Operating system-level and node-level metrics (such as CPU, memory, disk, and network usage) are not available through this endpoint. For infrastructure monitoring, use your cloud provider's native monitoring tools (such as Azure Monitor, AWS CloudWatch, or Google Cloud Monitoring).
 ====


### PR DESCRIPTION
## Description
This pull request clarifies which cluster types have monitoring capabilities on the Monitor RP Cloud page. 

* Specified that the OpenMetrics endpoint is available for BYOC or Dedicated clusters
* Added a note clarifying that only BYOC and Dedicated clusters can export Redpanda metrics to third-party monitoring systems, while Serverless clusters cannot.

Resolves [https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>](https://redpandadata.atlassian.net/browse/DOC-1682)
Review deadline:

## Page previews
Monitor Redpanda Cloud

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [X] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)