### PR TITLE
Add JSON array scanner

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -317,6 +317,7 @@
 **** xref:develop:connect/components/scanners/chunker.adoc[]
 **** xref:develop:connect/components/scanners/csv.adoc[]
 **** xref:develop:connect/components/scanners/decompress.adoc[]
+**** xref:develop:connect/components/scanners/json_array.adoc[]
 **** xref:develop:connect/components/scanners/json_documents.adoc[]
 **** xref:develop:connect/components/scanners/lines.adoc[]
 **** xref:develop:connect/components/scanners/re_match.adoc[]

--- a/modules/develop/pages/connect/components/scanners/json_array.adoc
+++ b/modules/develop/pages/connect/components/scanners/json_array.adoc
@@ -1,0 +1,3 @@
+= json_array
+:page-aliases: components:scanners/json_array.adoc
+include::redpanda-connect:components:scanners/json_array.adoc[tag=single-source]


### PR DESCRIPTION
## Description

This PR single-sources the content for the new `json_array` scanner into Redpanda Cloud. The original content was introduced in https://github.com/redpanda-data/rp-connect-docs/pull/304

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)