### PR TITLE
DOC-1700 edit Redpanda Connector to Kafka Connect

### DIFF
--- a/modules/develop/pages/managed-connectors/converters-and-serialization.adoc
+++ b/modules/develop/pages/managed-connectors/converters-and-serialization.adoc
@@ -118,6 +118,6 @@ See also: xref:manage:schema-reg/schema-reg-overview.adoc[Redpanda Schema Regist
 
 == Set property keys
 
-Redpanda Connectors use a set of `<property.key>=<value>` to set up its properties. 
+Kafka Connect connectors use a set of `<property.key>=<value>` to set up its properties. 
 
 For example if you want to set the property `topic.creation.enable` to `true`, use `topic.creation.enable=true` in the property settings page.

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -286,7 +286,7 @@ cat << EOT > redpanda-cluster.role
 {
   "name": "redpanda_cluster_role",
   "title": "Redpanda Cluster Role",
-  "description": "Redpanda Cluster Role",
+  "description": "Redpanda Cluster role",
   "includedPermissions": [
     "resourcemanager.projects.get",
     "secretmanager.secrets.get",
@@ -323,7 +323,7 @@ cat << EOT > redpanda-operator.role
 {
   "name": "redpanda_operator_role",
   "title": "Redpanda Operator Role",
-  "description": "Redpanda Operator Role",
+  "description": "Redpanda Operator role",
   "includedPermissions": [
     "resourcemanager.projects.get",
     "secretmanager.secrets.get",
@@ -355,7 +355,7 @@ cat << EOT > redpanda-connect-api.role
 {
   "name": "redpanda_connect_api_role",
   "title": "Redpanda Connect API Role",  
-  "description": "Redpanda Connect API Role", 
+  "description": "Redpanda Connect API role", 
   "includedPermissions": [
     "resourcemanager.projects.get",
     "secretmanager.secrets.get",
@@ -380,7 +380,7 @@ cat << EOT > redpanda-connect.role
 {
   "name": "redpanda_connect_role",
   "title": "Redpanda Connect Role",
-  "description": "Redpanda Connect Role",
+  "description": "Redpanda Connect role",
   "includedPermissions": [
     "resourcemanager.projects.get",
     "secretmanager.versions.access"
@@ -434,20 +434,20 @@ gcloud projects add-iam-policy-binding <service-project-id> \
 ```
 ====
 
-* Kafka Connect connectors service account
+* Kafka Connect service account
 +
 .Show commands
 [%collapsible]
 ====
 ```bash
 gcloud iam service-accounts create redpanda-connectors \
-  --display-name="Redpanda Connectors Service Account"
+  --display-name="Kafka Connect Service Account"
 
 cat << EOT > redpanda-connectors.role
 {
   "name": "redpanda_connectors_role",
-  "title": "Redpanda Connectors Custom Role",
-  "description": "Redpanda Connectors Custom Role",
+  "title": "Kafka Connect Custom Role",
+  "description": "Kafka Connect custom role",
   "includedPermissions": [
     "resourcemanager.projects.get",
     "secretmanager.versions.access"
@@ -628,7 +628,7 @@ gcloud iam service-accounts add-iam-policy-binding <redpanda_connect-gcp-sa-acco
 ```
 ====
 
-* Kafka Connect connectors service account
+* Kafka Connect service account
 +
 .Show command
 [%collapsible]


### PR DESCRIPTION
## Description
This pull request updates references from "Redpanda Connectors" to "Kafka Connect connectors".

* Updated references from "Redpanda Connectors" to "Kafka Connect connectors" in the managed connectors documentation to align with industry terminology.
* Renamed service account and custom role titles and descriptions from "Redpanda Connectors" to "Kafka Connect" in GCP setup instructions for clarity and consistency. [[1]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9L437-R450) [[2]](diffhunk://#diff-73505660c362559206baf921b88084a157f6730dc11b6895f3477170b71047b9L631-R631)

Resolves https://redpandadata.atlassian.net/browse/DOC-1700
Review deadline:

## Page previews


<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)