### PR TITLE
DOC-1716 Azure BYOC cluster creation is missing registering 1 provider

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -35,7 +35,7 @@ In the https://login.microsoftonline.com/[Azure Portal^], confirm that the dedic
 
 * **Role**: The Azure user must have the _Owner_ role in the subscription.
 
-* **Resources**: The subscription must be registered for the following resource providers. See the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types[Microsoft documentation^]. 
+* **Resources**: The subscription must be registered for the following resource providers (AKS + common dependencies). See the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types[Microsoft documentation^]. 
 +
 --
 ** Microsoft.Compute
@@ -43,6 +43,7 @@ In the https://login.microsoftonline.com/[Azure Portal^], confirm that the dedic
 ** Microsoft.Storage
 ** Microsoft.KeyVault
 ** Microsoft.Network
+** Microsoft.ContainerService
 --
 +
 To check if a resource provider is registered, run the following command using the Azure CLI or in the Azure Cloud Shell. For example, to check for Microsoft.Compute, run:
@@ -50,19 +51,29 @@ To check if a resource provider is registered, run the following command using t
 ``` 
 az provider show -n Microsoft.Compute
 ```
-+ 
-If it is not registered, run: 
 +
+If it is not registered, run:
 ```
-az provider register --namespace 'Microsoft.Compute'
+az provider register --namespace Microsoft.Compute
 ```
++
+To check the registration status, run:
+```
+az provider show -n Microsoft.Compute --query registrationState -o tsv
+```
+
 
 * **Feature**: The subscription must be registered for Microsoft.Compute/EncryptionAtHost. See the https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-enable-host-based-encryption-cli#prerequisites[Microsoft documentation^].
 +
 To register it, run:
-+
 ```
-az feature register --namespace Microsoft.Compute --name EncryptionAtHost  
+az feature register --namespace Microsoft.Compute --name EncryptionAtHost
+
+# (optional) Wait and verify it shows as Registered
+az feature show --namespace Microsoft.Compute --name EncryptionAtHost --query properties.state -o tsv
+
+# Refresh the provider after enabling a feature
+az provider register --namespace Microsoft.Compute
 ```
 
 * **Monitoring**: The subscription must have Azure Network Watcher enabled in the NetworkWatcherRG resource group and the region where you will use Redpanda. Network Watcher lets you monitor and diagnose conditions at a network level. See the https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-create?tabs=portaly[Microsoft documentation^]. 


### PR DESCRIPTION
## Description
This pull request updates the documentation for creating BYOC clusters on Azure, clarifying the required resource providers and improving instructions for registering and verifying provider status. 

* Clarified that the subscription must be registered for AKS and common dependencies, and explicitly added `Microsoft.ContainerService` to the required resource providers list.
* Improved instructions for checking, registering, and verifying the status of resource providers and features using Azure CLI commands, including examples for both registration and status queries.

Resolves https://redpandadata.atlassian.net/browse/DOC-1716
Review deadline:

## Page previews
Create a BYOC Cluster on Azure

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)