### PR TITLE
DOC-1724 fix typo

### DIFF
--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -84,7 +84,7 @@ NOTE: Redpanda Serverless is opinionated about Kafka configurations. For example
 
 * Redpanda Serverless supports the Kafka API. Serverless clusters work with all Kafka clients. See xref:develop:kafka-clients.adoc[].
 * Serverless clusters support all major Apache Kafka messages for managing topics, producing/consuming data (including transactions), managing groups, managing offsets, and managing ACLs. (User management is available in the Redpanda Cloud UI or with `rpk security acl`.) 
-* xref:develop:connect/about.adoc[Redpanda Connect] is integrated with Serverless as a beta feature for testing and feedback. Choose from a range of connectors, processors, and other components to quickly build and deploy streaming data pipelines or AI applications.
+* Use xref:develop:connect/about.adoc[Redpanda Connect] to quickly build and deploy streaming data pipelines or AI applications. 
 
 === Unsupported features
 


### PR DESCRIPTION
## Description
The update removes the mention of Redpanda Connect being a beta feature in Serverless.

Resolves https://redpandadata.atlassian.net/browse/DOC-1724
Review deadline:

## Page previews
[Serverless](https://deploy-preview-429--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/serverless/#supported-features)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)