### PR TITLE
Update antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -57,7 +57,7 @@ asciidoc:
         link-text: 'Learn more'
       - title: 'Cloud API quickstart'
         description: 'Get started with the Redpanda Cloud API.'
-        url: 'https://docs.redpanda.com/api/doc/cloud-controlplane/topic/topic-quickstart'
+        url: '/api/doc/cloud-controlplane/topic/topic-quickstart'
         link-text: 'Learn more'
       - title: 'rpk commands'
         description: 'Redpanda CLI reference for Redpanda Cloud.'


### PR DESCRIPTION
## Description

Because we don't have the API module anymore, I think this is the only way to make this link work. 

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)