### PR TITLE
DOC-1528 Document Schema Registry and ACLs

### DIFF
--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -20,12 +20,12 @@ With the Redpanda Terraform provider, you can manage:
 
 * **Simplicity**: Manage all your Redpanda Cloud resources in one place.
 * **Automation**: Create and modify resources without manual intervention.
-* **Version Control**: Track and roll back changes using version control systems such as GitHub.
+* **Version Control**: Track and roll back changes using version control systems, such as GitHub.
 * **Scalability**: Scale your infrastructure as your needs grow with minimal effort.
 
 == Understand Terraform configurations
 
-Terraform configurations are written in link:https://developer.hashicorp.com/terraform/language[HCL (HashiCorp Configuration Language)], which is declarative. Here are the main building blocks of a Terraform configuration:
+Terraform configurations are written in link:https://developer.hashicorp.com/terraform/language[HCL (HashiCorp Configuration Language)^], which is declarative. Here are the main building blocks of a Terraform configuration:
 
 === Providers
 


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1528 and https://redpandadata.atlassian.net/browse/DOC-944

This pull request updates the Terraform provider documentation to add support for managing Redpanda Schema Registry resources, including schemas and Schema Registry ACLs. The documentation now explains how to use new Terraform resources to register schemas and configure fine-grained access control, and provides example configurations for both. It also adds links to the official documentation for these new resources.

**Schema Registry resource management:**

* Added documentation describing how to use the new `redpanda_schema` resource to register and manage schemas in the Redpanda Schema Registry, including example Terraform configuration and explanation of key fields.
* Added documentation for the `redpanda_schema_registry_acl` resource, showing how to configure access control policies for Schema Registry subjects or registry-wide operations, with example configuration and field explanations.
* Included an example demonstrating how to combine schema registration and ACL configuration in a single Terraform file for automated setup.

**Documentation navigation:**

* Updated the resource list to include Schema Registry schemas and Schema Registry ACLs as manageable resources via Terraform.
* Added links to the official Schema and Schema Registry ACL resource documentation in the references section for easier navigation.

## Page previews

https://deploy-preview-448--rp-cloud.netlify.app/redpanda-cloud/manage/terraform-provider/

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)