### PR TITLE
DOC-1788 clarify ephemeral clusters for RRR

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -386,7 +386,6 @@ The following features are currently in beta in Redpanda Cloud:
 * BYOVPC for AWS  
 * BYOVNet for Azure
 * Secrets Management for BYOVPC on GCP and AWS
-* Remote Read Replicas for AWS and GCP 
 * xref:ai-agents:index.adoc[AI agents with MCP servers]
 * Several Redpanda Connect components 
 

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -1,11 +1,10 @@
 = Create Remote Read Replicas
 :description: Learn how to create a remote read replica topic with BYOC, which is a read-only topic that mirrors a topic on a different cluster.
 :page-aliases: deploy:deployment-option/cloud/remote-read-replicas.adoc, manage:remote-read-replicas.adoc
-:page-beta: true
 
-A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the source cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster.
+A remote read replica topic is a read-only topic that mirrors a topic on a different cluster. You can create a separate remote cluster just for consumers of this topic and populate its topics from object storage. A read-only topic on a remote cluster can serve any consumer, without increasing the load on the source cluster. Because these read-only topics access data directly from object storage, there's no impact to the performance of the cluster. Remote read replica topics do not store any data. When a cluster running a remote read replica is terminated, the topic data only exists on the origin cluster.
 
-Redpanda Cloud supports remote read replicas in BYOC clusters on AWS or GCP. These clusters can be ephemeral; that is, created temporarily to handle specific or transient workloads, but they don't have to be. The ability to make clusters ephemeral provides flexibility and cost efficiency: you can scale resources up or down as needed and pay only for what you use.
+Redpanda Cloud supports remote read replica topics in BYOC clusters on AWS or GCP. These clusters can be ephemeral; that is, created temporarily to handle specific or transient workloads, but they don't have to be. The ability to make them ephemeral provides flexibility and cost efficiency: you can scale resources up or down as needed and pay only for what you use. 
 
 == Prerequisites
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -6,6 +6,12 @@
 
 This page lists new features added to Redpanda Cloud.
 
+== November 2025
+
+=== Remote read replicas: GA
+
+xref:get-started:cluster-types/byoc/remote-read-replicas.adoc[Remote read replicas] are now generally available (GA) for BYOC clusters on AWS and GCP. This feature allows you to create read-only topics that mirror a topic on a different cluster, providing greater flexibility and scalability for your data streaming needs.
+
 == October 2025
 
 === Remote MCP: beta


### PR DESCRIPTION
## Description
This pull request updates the doc for creating remote read replica topics in BYOC clusters. It clarifies that BYOC clusters can be ephemeral (temporary) but do not have to be, emphasizing flexibility and cost efficiency in resource management.

Additionally, it removes the beta badge and updates What's New and Cloud Overview to show RRR as GA now. 

Resolves https://redpandadata.atlassian.net/browse/DOC-1788
Review deadline:

## Page previews
[Create Remote Read Replicas](https://deploy-preview-451--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/remote-read-replicas/)
[What's New](https://deploy-preview-451--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/)
[removed from list of features in beta](https://deploy-preview-451--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/#features-in-beta)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)