### PR TITLE
Add What's New entry for Terraform Schema Registry

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -248,6 +248,7 @@
 **** xref:develop:connect/components/processors/group_by_value.adoc[]
 **** xref:develop:connect/components/processors/http.adoc[]
 **** xref:develop:connect/components/processors/insert_part.adoc[]
+**** xref:develop:connect/components/processors/jira.adoc[]
 **** xref:develop:connect/components/processors/jmespath.adoc[]
 **** xref:develop:connect/components/processors/jq.adoc[]
 **** xref:develop:connect/components/processors/json_schema.adoc[]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -12,6 +12,10 @@ This page lists new features added to Redpanda Cloud.
 
 xref:get-started:cluster-types/byoc/remote-read-replicas.adoc[Remote read replicas] are now generally available (GA) for BYOC clusters on AWS and GCP. This feature allows you to create read-only topics that mirror a topic on a different cluster, providing greater flexibility and scalability for your data streaming needs.
 
+=== Schema Registry and ACLs in Terraform provider
+
+The xref:manage:terraform-provider.adoc[Redpanda Terraform provider] now supports managing schemas and Schema Registry ACLs. You can use the provider to register schemas in formats such as Avro, Protobuf, or JSON Schema, and control access to Schema Registry subjects and operations through ACLs.
+
 == October 2025
 
 === Remote MCP: beta


### PR DESCRIPTION
## Description

This pull request adds the `jira` processor to the navigation and the announcement of Schema Registry and ACL support in the Terraform provider.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)