### PR TITLE
DOC-1707: Update cloud-encryption.adoc Deprecated cipher suites

### DIFF
--- a/modules/security/pages/cloud-encryption.adoc
+++ b/modules/security/pages/cloud-encryption.adoc
@@ -33,6 +33,8 @@ the public certificate transparency log.
 The following protocols and cipher suites are supported and accepted by Redpanda
 services such as Schema Registry, HTTP Proxy, and Kafka API.
 
+NOTE: Cipher suites marked ** are deprecated.
+
 ```bash
 Supported Server Cipher(s):
 Preferred TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
@@ -40,16 +42,16 @@ Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
 Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
 Accepted  TLSv1.3  128 bits  TLS_AES_128_CCM_SHA256        Curve 25519 DHE 253
 Preferred TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
-Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256
+Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256 **
 Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
-Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384
+Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384 **
 Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
-Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.2  128 bits  AES128-SHA
-Accepted  TLSv1.2  128 bits  AES128-CCM
-Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA          Curve 25519 DHE 253
-Accepted  TLSv1.2  256 bits  AES256-SHA
-Accepted  TLSv1.2  256 bits  AES256-CCM
+Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA **       Curve 25519 DHE 253
+Accepted  TLSv1.2  128 bits  AES128-SHA **
+Accepted  TLSv1.2  128 bits  AES128-CCM **
+Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA **       Curve 25519 DHE 253
+Accepted  TLSv1.2  256 bits  AES256-SHA **
+Accepted  TLSv1.2  256 bits  AES256-CCM **
 
 Server Key Exchange Group(s):
 TLSv1.3  128 bits  secp256r1 (NIST P-256)


### PR DESCRIPTION
## Description

Resolves https://redpandadata.atlassian.net/browse/DOC-1707
Review deadline:

## Page previews
[Preview](https://deploy-preview-454--rp-cloud.netlify.app/redpanda-cloud/security/cloud-encryption/#data-in-transit-encryption)


## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)