### PR TITLE
Cloud: Add tip for Iceberg object_storage example with BigQuery

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: ['DOC-1306-iceberg-bigquery-integration', v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]


### PR DESCRIPTION
## Description

PR for single sourcing: https://github.com/redpanda-data/docs/pull/1494

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

[Use Iceberg Catalogs > Integrate filesystem-based catalog](https://deploy-preview-464--rp-cloud.netlify.app/redpanda-cloud/manage/iceberg/use-iceberg-catalogs/#object-storage)
[Integrate with REST Catalogs index page](https://deploy-preview-464--rp-cloud.netlify.app/redpanda-cloud/manage/iceberg/rest-catalog/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)