### PR TITLE
DOC-1845 explain multi cc in billing

### DIFF
--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -6,7 +6,7 @@ Redpanda Cloud uses various metrics to measure the consumption of resources.
 
 * All pricing is set in US dollars (USD). 
 * All billing computations are conducted in Coordinated Universal Time (UTC). Billing accrues at hourly intervals. Any usage that is less than an hour is billed for the full hour. 
-* The *Billing* page shows detailed billing activity for each cluster and lets you manage payment methods. Redpanda uses the credit card marked as the default. The most recently added credit card becomes the default payment method, unless you select a different one.
+* The *Billing* page shows detailed billing activity for each cluster and lets you manage payment methods. Redpanda charges the credit card marked as the default. The most recently added credit card becomes the default payment method, unless you select a different one.
 
 NOTE: Pricing information is available on https://www.redpanda.com/price-estimator[redpanda.com^]. For questions about billing, contact billing@redpanda.com.
 


### PR DESCRIPTION
## Description
This pull request updates the description of the **Billing** page to clarify that users can manage payment methods and that the most recently added credit card becomes the default unless another is selected. (`modules/billing/pages/billing.adoc`)

Resolves https://redpandadata.atlassian.net/browse/DOC-1845
Review deadline:

## Page previews
[Billing](https://deploy-preview-465--rp-cloud.netlify.app/redpanda-cloud/billing/billing/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)