### PR TITLE
Add spaces before line continuation characters

### DIFF
--- a/modules/ai-agents/pages/mcp/remote/quickstart.adoc
+++ b/modules/ai-agents/pages/mcp/remote/quickstart.adoc
@@ -116,7 +116,7 @@ For BYOC and Dedicated clusters, use:
 [,bash]
 ----
 rpk cloud mcp proxy \
---cluster-id <cluster-id>\
+--cluster-id <cluster-id> \
 --mcp-server-id <server-id> \
 --install --client claude-code
 ----
@@ -126,7 +126,7 @@ For Serverless clusters, use:
 [,bash]
 ----
 rpk cloud mcp proxy \
---serverless-cluster-id <cluster-id>\
+--serverless-cluster-id <cluster-id> \
 --mcp-server-id <server-id> \
 --install --client claude-code
 ----


### PR DESCRIPTION
## Description

Without the space, the command fails with `Error: unknown command "d4n85qr2dvss73alh530" for "rpk cloud mcp proxy"`.

Reported in Slack.

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [x] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)