### PR TITLE
fix typo

### DIFF
--- a/modules/networking/pages/byoc/aws/index.adoc
+++ b/modules/networking/pages/byoc/aws/index.adoc
@@ -1,3 +1,3 @@
 = AWS
-:description: Learn how to configure private networking for BYOC clusters on GCP. 
+:description: Learn how to configure private networking for BYOC clusters on AWS. 
 :page-layout: index


### PR DESCRIPTION
This pull request updates the documentation to correctly describe the AWS BYOC networking configuration page.

* Documentation correction: Changed the description in `modules/networking/pages/byoc/aws/index.adoc` to refer to AWS instead of GCP.

## Page previews
[Networking - BYOC index page](https://deploy-preview-468--rp-cloud.netlify.app/redpanda-cloud/networking/byoc/)

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [X] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)