### PR TITLE
docs: add redesigned pipeline configuration to What's New

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -10,10 +10,10 @@ This page lists new features added to Redpanda Cloud.
 
 === Group-based access control (GBAC)
 
-GBAC is available for BYOC and Dedicated clusters. In addition to the predefined roles (including Reader, Writer, and Admin) that you cannot modify or delete, you can also create custom roles.
-
 * With xref:security:authorization/gbac/gbac.adoc[GBAC in the control plane], you can manage access to organization-level resources using OIDC groups from your identity provider. Assign OIDC groups to roles so that users inherit access based on their group membership. 
 * With xref:security:authorization/gbac/gbac_dp.adoc[GBAC in the data plane], you can configure cluster-level permissions for provisioned users at scale using OIDC groups. Because group membership is managed by your identity provider, onboarding and offboarding require no changes in Redpanda. 
+
+GBAC is available for BYOC and Dedicated clusters. In addition to the predefined roles (including Reader, Writer, and Admin) that you cannot modify or delete, you can now create custom roles.
 
 === Increased Serverless limits for Redpanda Connect pipelines and MCP servers
 
@@ -21,6 +21,7 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 
 === Redpanda Connect updates
 
+* The Redpanda Connect pipeline creation and editing workflow has been simplified. The new UI replaces the previous multi-page wizard with a visual pipeline diagram, an IDE-like configuration editor, slash commands for inserting variables, and inline links to component documentation. See the xref:develop:connect/connect-quickstart.adoc[Redpanda Connect quickstart] to try it out.
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
 


### PR DESCRIPTION
## Summary
- Adds a What's New entry for April 2026 announcing the redesigned Redpanda Connect pipeline create/edit UI
- The new single-page configuration replaces the previous multi-page wizard with a visual pipeline diagram, IDE-like editor, slash commands, and inline documentation links
- Minor cleanup to GBAC section ordering

## Page previews
[What's New](https://deploy-preview-550--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#redpanda-connect-updates)

## Test plan
- [ ] Verify the new entry renders correctly in the April 2026 section
- [ ] Verify the xref to the Redpanda Connect quickstart resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)