### PR TITLE
DOC-1812: Add single-sourced Schema Registry Contexts page

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: [Feediver1-patch-7, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [Feediver1-patch-7, v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -468,6 +468,7 @@
 *** xref:manage:schema-reg/schema-reg-ui.adoc[]
 *** xref:manage:schema-reg/schema-reg-api.adoc[]
 *** xref:manage:schema-reg/schema-reg-authorization.adoc[Schema Registry Authorization]
+*** xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry Contexts]
 *** xref:manage:schema-reg/schema-id-validation.adoc[]
 *** xref:manage:schema-reg/record-deserialization.adoc[Deserialization]
 *** xref:manage:schema-reg/programmable-push-filters.adoc[Programmable Push Filters]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -27,7 +27,9 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 
 === Schema Registry Contexts
 
-xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] provide isolated namespaces that separate schemas, subjects, and configuration within a single Schema Registry instance. Each context maintains its own schema ID counter, mode settings, and compatibility settings. Available on BYOC and Dedicated clusters.
+xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] provide isolated namespaces that separate schemas, subjects, and configuration within a single Schema Registry instance. Each context maintains its own schema ID counter, mode settings, and compatibility settings. 
+
+On Serverless clusters, Redpanda uses contexts internally for per-tenant isolation. Contexts are not exposed to end users on Serverless. On BYOC and Dedicated clusters, contexts are available and user-configurable.
 
 == March 2026
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -25,6 +25,10 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
 
+=== Schema Registry Contexts
+
+xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] provide isolated namespaces that separate schemas, subjects, and configuration within a single Schema Registry instance. Each context maintains its own schema ID counter, mode settings, and compatibility settings. Available on BYOC and Dedicated clusters.
+
 == March 2026
 
 === Redpanda Connect updates

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -25,12 +25,6 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
 
-=== Schema Registry Contexts
-
-xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] provide isolated namespaces that separate schemas, subjects, and configuration within a single Schema Registry instance. Each context maintains its own schema ID counter, mode settings, and compatibility settings. 
-
-On Serverless clusters, Redpanda uses contexts internally for per-tenant isolation. Contexts are not exposed to end users on Serverless. On BYOC and Dedicated clusters, contexts are available and user-configurable.
-
 == March 2026
 
 === Redpanda Connect updates
@@ -60,6 +54,12 @@ Use the unified xref:develop:connect/components/inputs/redpanda_migrator.adoc[`r
 xref:develop:topics/cloud-topics.adoc[Cloud Topics] are now available, making it possible to use durable cloud storage (S3, ADLS, GCS) as the primary backing store instead of local disk, eliminating over 90% of cross-AZ replication costs. This makes them ideal for latency-tolerant, high-throughput workloads such as observability streams, analytics pipelines, and AI/ML training data feeds, where cross-AZ networking charges are the dominant cost driver.
 
 You can use Cloud Topics exclusively or in combination with standard topics on a cluster supporting low-latency workloads.
+
+=== Schema Registry Contexts
+
+xref:manage:schema-reg/schema-reg-contexts.adoc[Schema Registry contexts] provide isolated namespaces that separate schemas, subjects, and configuration within a single Schema Registry instance. Each context maintains its own schema ID counter, mode settings, and compatibility settings. 
+
+On Serverless clusters, Redpanda uses contexts internally for per-tenant isolation. Contexts are not exposed to end users on Serverless. On BYOC and Dedicated clusters, contexts are available and user-configurable.
 
 === User-based throughput quotas
 

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -1,4 +1,9 @@
 = Schema Registry Contexts
-:description: Learn about Schema Registry contexts, which provide isolated namespaces for schemas, subjects, and configuration in Redpanda.
+:description: Use Schema Registry contexts to create isolated namespaces for schemas, subjects, and configuration, enabling multi-tenant and multi-team deployments without separate Schema Registry instances.
+:page-topic-type: how-to
+:personas: app_developer, streaming_developer, platform_admin
+:learning-objective-1: Identify when to use Schema Registry contexts for multi-team or multi-cluster deployments.
+:learning-objective-2: Describe how qualified subject syntax maps subjects to contexts.
+:learning-objective-3: Enable and configure Schema Registry contexts using the cluster property and HTTP API.
 
 include::ROOT:manage:schema-reg/schema-reg-contexts.adoc[tag=single-source]

--- a/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
+++ b/modules/manage/pages/schema-reg/schema-reg-contexts.adoc
@@ -1,0 +1,4 @@
+= Schema Registry Contexts
+:description: Learn about Schema Registry contexts, which provide isolated namespaces for schemas, subjects, and configuration in Redpanda.
+
+include::ROOT:manage:schema-reg/schema-reg-contexts.adoc[tag=single-source]


### PR DESCRIPTION
## Summary

- Single-sources the Schema Registry Contexts page from the docs repo (redpanda-data/docs#1658)
- Creates a stub page at `modules/manage/pages/schema-reg/schema-reg-contexts.adoc` with an include directive
- Adds nav entry under Schema Registry
- Adds What's New April 2026 entry

fixes https://redpandadata.atlassian.net/browse/DOC-1812

## Preview pages
[Schema Registry Contexts](https://deploy-preview-551--rp-cloud.netlify.app/redpanda-cloud/manage/schema-reg/schema-reg-contexts/)
[What's New](https://deploy-preview-551--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#schema-registry-contexts)

## Dependencies

- **Depends on**: redpanda-data/docs#1658 (must merge first so the include resolves on `main`)
- I added `// tag::single-source[]` / `// end::single-source[]` tags to the docs PR so the include works

## Before merge

- [ ] **Revert `local-antora-playbook.yml`**: Replace `Feediver1-patch-7` back to `main` in the docs repo branches list (line 18). This override exists only for Netlify preview.
- [ ] Ensure docs PR redpanda-data/docs#1658 is merged first

## Test plan

- [ ] Verify Netlify preview renders the Schema Registry Contexts page with content (not empty)
- [ ] Verify nav entry appears in the Schema Registry section
- [ ] Verify What's New entry renders with working link

🤖 Generated with [Claude Code](https://claude.com/claude-code)