### PR TITLE
preview: Remove token structure examples from Cloud GBAC docs

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: [fix/remove-token-examples-from-cloud-gbac, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]


### PR DESCRIPTION
## Summary
- Companion preview PR for redpanda-data/docs#1669
- Points the playbook at the `fix/remove-token-examples-from-cloud-gbac` branch in the docs repo to generate a Cloud deploy preview

⚠️ **Revert playbook change before merge** — or close this PR after review.

## Preview pages
- [GBAC in the Data Plane](https://deploy-preview-553--rp-cloud.netlify.app/redpanda-cloud/security/authorization/gbac/gbac_dp/) (token structure examples removed)
- [GBAC in the Control Plane](https://deploy-preview-553--rp-cloud.netlify.app/redpanda-cloud/security/authorization/gbac/gbac/) (token structure examples removed)

## Self-managed preview (from docs#1669 — unchanged)
- [GBAC (self-managed)](https://deploy-preview-1669--redpanda-docs-preview.netlify.app/current/manage/security/authorization/gbac/) (token structure examples still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)