### PR TITLE
Update cloud-authentication.adoc Okta discovery URL

### DIFF
--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -37,11 +37,11 @@ To integrate with Okta, follow the https://help.okta.com/en-us/Content/Topics/Ap
 https://auth.prd.cloud.redpanda.com/login/callback
 ```
 
-Okta provides the following fields required for SSO configuration on the Redpanda *Users* page: `clientId`, `clientSecret`, and `discoveryUrl`. The discovery URL for Okta generally looks like the following (where `an_id` could be “default”):
+Okta provides the following fields required for SSO configuration on the Redpanda *Users* page: `clientId`, `clientSecret`, and `discoveryUrl`. The discovery URL for Okta generally looks like the following:
 
 [pass]
 ```
-https://<orgname>.okta.com/oauth2/<an_id>/.well-known/openid-configuration
+https://<orgname>.okta.com/.well-known/openid-configuration
 ``` 
 
 ==== Integrate with Microsoft Entra ID

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -37,7 +37,7 @@ To integrate with Okta, follow the https://help.okta.com/en-us/Content/Topics/Ap
 https://auth.prd.cloud.redpanda.com/login/callback
 ```
 
-Okta provides the following fields required for SSO configuration on the Redpanda *Users* page: `clientId`, `clientSecret`, and `discoveryUrl`. The discovery URL for Okta generally looks like the following:
+Okta provides the following fields required for SSO configuration on the Redpanda *Users* page: `clientId`, `clientSecret`, and `discoveryUrl`. The discovery URL for Okta depends on the https://help.okta.com/oie/en-us/content/topics/security/api-build-oauth-servers.htm[Authorization server] details:
 
 [pass]
 ```


### PR DESCRIPTION
Changed Okta discovery URL to authorization server details that supports groups inclusion in scope.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)