### PR TITLE
DOC-1907: Add Paginate Messages stub

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [DOC-1907-paginate-messages-events, v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: [DOC-1907-paginate-messages-events, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -405,6 +405,7 @@
 ** xref:develop:consume-data/index.adoc[Consume Data]
 *** xref:develop:consume-data/consumer-offsets.adoc[Consumer Offsets]
 *** xref:develop:consume-data/follower-fetching.adoc[Follower Fetching]
+*** xref:develop:consume-data/paginate-messages-events.adoc[Paginate Messages and Events]
 ** xref:develop:http-proxy.adoc[]
 ** xref:develop:data-transforms/index.adoc[]
 *** xref:develop:data-transforms/how-transforms-work.adoc[Overview]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -405,7 +405,7 @@
 ** xref:develop:consume-data/index.adoc[Consume Data]
 *** xref:develop:consume-data/consumer-offsets.adoc[Consumer Offsets]
 *** xref:develop:consume-data/follower-fetching.adoc[Follower Fetching]
-*** xref:develop:consume-data/paginate-messages-events.adoc[Paginate Messages and Events]
+*** xref:develop:consume-data/paginate-messages-events.adoc[]
 ** xref:develop:http-proxy.adoc[]
 ** xref:develop:data-transforms/index.adoc[]
 *** xref:develop:data-transforms/how-transforms-work.adoc[Overview]

--- a/modules/develop/pages/consume-data/paginate-messages-events.adoc
+++ b/modules/develop/pages/consume-data/paginate-messages-events.adoc
@@ -1,0 +1,4 @@
+= Paginate Messages and Pipeline Events in Redpanda Console
+:description: Retrieve more than 500 messages or pipeline events in Redpanda Console by paging through larger result sets.
+
+include::ROOT:console:ui/paginate-messages-events.adoc[tag=single-source]

--- a/modules/develop/pages/consume-data/paginate-messages-events.adoc
+++ b/modules/develop/pages/consume-data/paginate-messages-events.adoc
@@ -1,4 +1,4 @@
-= Paginate Messages and Pipeline Events in Redpanda Console
-:description: Retrieve more than 500 messages or pipeline events in Redpanda Console by paging through larger result sets.
+= Paginate Messages in Redpanda Console
+:description: Retrieve more than the default batch of messages in Redpanda Console by paging through larger result sets.
 
 include::ROOT:console:ui/paginate-messages-events.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -27,6 +27,10 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 
 == March 2026
 
+=== Redpanda Console: unlimited pagination for messages and pipeline events
+
+Redpanda Console now supports paginating past the previous 500-event cap when you browse topic messages or debug Redpanda Connect pipeline events. This unblocks inspecting large topics and debugging pipelines that emit many events under debug-level logging. See xref:develop:consume-data/paginate-messages-events.adoc[].
+
 === Redpanda Connect updates
 
 * Inputs:

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -27,9 +27,9 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 
 == March 2026
 
-=== Redpanda Console: unlimited pagination for messages and pipeline events
+=== Redpanda Console: unlimited pagination for messages
 
-Redpanda Console now supports paginating past the previous 500-event cap when you browse topic messages or debug Redpanda Connect pipeline events. This unblocks inspecting large topics and debugging pipelines that emit many events under debug-level logging. See xref:develop:consume-data/paginate-messages-events.adoc[].
+Redpanda Console now supports paginating past the previous 500-record cap when you browse topic messages, so you can inspect large topics without being limited to the initial result set. See xref:develop:consume-data/paginate-messages-events.adoc[].
 
 === Redpanda Connect updates
 


### PR DESCRIPTION
## Summary

- Single-sources the Paginate Messages page from the docs repo (redpanda-data/docs#1673)
- Creates stub page at `modules/develop/pages/consume-data/paginate-messages-events.adoc`
- Adds nav entry under Develop > Consume Data
- Adds What's New March 2026 entry for the Redpanda Console unlimited-pagination feature

fixes https://redpandadata.atlassian.net/browse/DOC-1907

## Preview pages

- [Paginate Messages in Redpanda Console](https://deploy-preview-556--rp-cloud.netlify.app/redpanda-cloud/develop/consume-data/paginate-messages-events/) (new)
- [What's New in Redpanda Cloud](https://deploy-preview-556--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/#redpanda-console-unlimited-pagination-for-messages) (updated)

## Dependencies

- **Depends on**: redpanda-data/docs#1673 (must merge first so the include resolves on `main`)

## Before merge

- [ ] **Revert cloud-docs playbook**: In `local-antora-playbook.yml`, replace `DOC-1907-paginate-messages-events` back to `main` in the docs repo branches list
- [ ] **Revert docs playbook**: In redpanda-data/docs#1673, revert the `cloud-docs` branch reference back to `'main'` in the docs repo's `local-antora-playbook.yml`
- [ ] Ensure docs PR redpanda-data/docs#1673 is merged first

## Test plan

- [ ] Verify Netlify preview renders the Paginate Messages page with full content (not empty / unresolved include)
- [ ] Verify nav entry appears under Develop > Consume Data
- [ ] Verify What's New March 2026 entry renders with a working xref link