### PR TITLE
docs: add arc output connector for cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -23,7 +23,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: auto-docs/update-rpcn-connector-docs
+    branches: main
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -23,7 +23,7 @@ content:
     branches: main
     start_paths: [docs,'*/docs']
   - url: https://github.com/redpanda-data/rp-connect-docs
-    branches: main
+    branches: auto-docs/update-rpcn-connector-docs
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -171,6 +171,7 @@
 
 *** xref:develop:connect/components/outputs/about.adoc[]
 **** xref:develop:connect/components/outputs/amqp_0_9.adoc[]
+**** xref:develop:connect/components/outputs/arc.adoc[]
 **** xref:develop:connect/components/outputs/aws_dynamodb.adoc[]
 **** xref:develop:connect/components/outputs/aws_kinesis.adoc[]
 **** xref:develop:connect/components/outputs/aws_kinesis_firehose.adoc[]

--- a/modules/develop/pages/connect/components/outputs/arc.adoc
+++ b/modules/develop/pages/connect/components/outputs/arc.adoc
@@ -1,0 +1,3 @@
+= arc
+:page-aliases: components:outputs/arc.adoc
+include::redpanda-connect:components:outputs/arc.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -22,6 +22,8 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 === Redpanda Connect updates
 
 * The Redpanda Connect pipeline creation and editing workflow has been simplified. The new UI replaces the previous multi-page wizard with a visual pipeline diagram, an IDE-like configuration editor, slash commands for inserting variables, and inline links to component documentation. See the xref:develop:connect/connect-quickstart.adoc[Redpanda Connect quickstart] to try it out.
+* Outputs:
+** xref:develop:connect/components/outputs/arc.adoc[arc]: Send data to an Arc columnar analytical database using its high-performance MessagePack ingestion endpoint.
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
 


### PR DESCRIPTION
## Summary

Add cloud-docs support for the new `arc` output connector.

This PR:
- Adds the `arc` connector page using include syntax from rp-connect-docs
- Updates the What's New page with an entry for the arc connector

## Preview pages

- [arc](https://deploy-preview-557--rp-cloud.netlify.app/redpanda-cloud/develop/connect/components/outputs/arc/) (new)
- [What's New in Redpanda Cloud](https://deploy-preview-557--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/) (updated)

## Related PRs

- rp-connect-docs PR: https://github.com/redpanda-data/rp-connect-docs/pull/414

## Details

The `arc` output connector sends data to an Arc columnar analytical database using its high-performance MessagePack ingestion endpoint. It is cloud-supported and available in Redpanda Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)