### PR TITLE
DOC-2077: rename "Cluster settings" to "Dataplane settings"

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -171,6 +171,7 @@
 
 *** xref:develop:connect/components/outputs/about.adoc[]
 **** xref:develop:connect/components/outputs/amqp_0_9.adoc[]
+**** xref:develop:connect/components/outputs/arc.adoc[]
 **** xref:develop:connect/components/outputs/aws_dynamodb.adoc[]
 **** xref:develop:connect/components/outputs/aws_kinesis.adoc[]
 **** xref:develop:connect/components/outputs/aws_kinesis_firehose.adoc[]

--- a/modules/develop/pages/connect/components/outputs/arc.adoc
+++ b/modules/develop/pages/connect/components/outputs/arc.adoc
@@ -1,0 +1,3 @@
+= arc
+:page-aliases: components:outputs/arc.adoc
+include::redpanda-connect:components:outputs/arc.adoc[tag=single-source]

--- a/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc
@@ -42,7 +42,7 @@ Optionally, click *Advanced settings* to specify up to five key-value custom tag
 ** For a xref:networking:cidr-ranges.adoc[CIDR range], choose one that does not overlap with your existing VPCs or your Redpanda network.
 ** Clusters with private networking include a setting for API Gateway network access. Public access exposes endpoints for Redpanda Console, the Data Plane API, and the MCP Server API, but they remain protected by your authentication and authorization controls. Private access restricts endpoint access to your VPC only.
 +
-NOTE: After the cluster is created, you can change the API Gateway access on the cluster settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
+NOTE: After the cluster is created, you can change the API Gateway access on the Dataplane settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
 . Click *Next*.
 . On the Deploy page, follow the steps to log in to Redpanda Cloud and deploy the agent.
 +

--- a/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc
@@ -168,7 +168,7 @@ Optionally, click *Advanced settings* to specify up to five key-value custom tag
 +
 Private access incurs an additional cost, since it involves deploying two network load balancers, instead of one. 
 +
-NOTE: After the cluster is created, you can change the API Gateway access on the cluster settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
+NOTE: After the cluster is created, you can change the API Gateway access on the Dataplane settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
 . Click *Next*.
 . On the Deploy page, follow the steps to log in to Redpanda Cloud and deploy the agent.
 +

--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -44,7 +44,7 @@ Optionally, click *Advanced settings* to specify up to five key-value custom GCP
 ** For a xref:networking:cidr-ranges.adoc[CIDR range], choose one that does not overlap with your existing VPCs or your Redpanda network.
 ** Clusters with private networking include a setting for API Gateway network access. Public access exposes endpoints for Redpanda Console, the Data Plane API, but they remain protected by your authentication and authorization controls. Private access restricts endpoint access to your VPC only.
 +
-NOTE: After the cluster is created, you can change the API Gateway access on the cluster settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
+NOTE: After the cluster is created, you can change the API Gateway access on the Dataplane settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
 . Click *Next*.
 . On the Deploy page, follow the steps to log in to Redpanda Cloud and deploy the agent.
 +

--- a/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc
@@ -738,7 +738,7 @@ You can delete the cluster in the Cloud UI.
 
 . Log in to https://cloud.redpanda.com[Redpanda Cloud^].
 . Select your cluster.
-. Go to the **Cluster settings** page and click **Delete**, then confirm your deletion. 
+. Go to the **Dataplane settings** page and click **Delete**, then confirm your deletion. 
 
 == Manage custom resource labels and network tags
 

--- a/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
@@ -26,7 +26,7 @@ Private networks require either a VPC peering connection or a private connectivi
 +
 On Azure, private access incurs an additional cost, since it involves deploying two network load balancers, instead of one.
 +
-NOTE: After the cluster is created, you can change the API Gateway access on the cluster settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
+NOTE: After the cluster is created, you can change the API Gateway access on the Dataplane settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
 
 . Click *Create*.
 +
@@ -137,7 +137,7 @@ The message that you produced to the topic is displayed along with some other de
 
 If you don't want to continue experimenting with your cluster, you can delete it.
 
-Go to **Cluster settings** and click **Delete cluster**.
+Go to **Dataplane settings** and click **Delete cluster**.
 
 == Next steps
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -205,7 +205,7 @@ BYOC and Dedicated clusters with private networking now allow control of API Gat
 * Public access exposes Redpanda Console, Data Plane API, and MCP Server API endpoints over the internet, although they remain protected by your authentication and authorization controls.
 * Private access restricts endpoint access to your private network (VPC or VNet) only.
 
-After the cluster is created, you can change the API Gateway access on the cluster settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
+After the cluster is created, you can change the API Gateway access on the Dataplane settings page. If you change from public to private access, users without VPN access to the Redpanda VPC will lose access to these services.
 
 === Redpanda Connect updates
 
@@ -601,7 +601,7 @@ mTLS authentication is now available for Kafka API clients. You can xref:securit
 
 === Manage private connectivity in the UI
 
-You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or Dedicated cluster on the *Cluster settings* page in Redpanda Cloud. See the steps for xref:networking:configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
+You can now manage GCP Private Service Connect and AWS PrivateLink connections to your BYOC or Dedicated cluster on the *Dataplane settings* page in Redpanda Cloud. See the steps for xref:networking:configure-privatelink-in-cloud-ui.adoc[PrivateLink] and xref:networking:configure-private-service-connect-in-cloud-ui.adoc[Private Service Connect].
 
 === Single message transforms
 
@@ -671,4 +671,4 @@ In the Redpanda Console UI, you can xref:manage:schema-reg/schema-reg-ui.adoc[pe
 
 === Maintenance windows
 
-With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Cluster settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 
+With maintenance windows, you have greater flexibility to plan upgrades to your cluster. By default, Redpanda Cloud upgrades take place on Tuesdays. Optionally, on the **Dataplane settings** page, you can select a window of specific off-hours for your business for Redpanda to apply updates. All times are in Coordinated Universal Time (UTC). Updates may start at any time during that window. 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -143,11 +143,11 @@ Shadowing is supported on BYOC and Dedicated clusters running Redpanda version 2
 
 You can now view and export metrics from Serverless clusters to third-party monitoring systems like Prometheus and Grafana. See xref:manage:monitor-cloud.adoc[Monitor Redpanda Cloud] for details on configuring monitoring for your Serverless cluster and xref:reference:public-metrics-reference.adoc[Metrics Reference] for a list of metrics available in Serverless.
 
-=== User impersonation
+=== Account impersonation
 
-BYOC and Dedicated clusters now support unified authentication and authorization between the Redpanda Cloud UI and Redpanda with xref:security:cloud-authentication.adoc#user-impersonation[user impersonation]. This means you can authenticate to fine-grained access within Redpanda using the same credentials you use to authenticate to Redpanda Cloud. 
+BYOC and Dedicated clusters now support unified authentication and authorization between the Redpanda Cloud UI and Redpanda with xref:security:cloud-authentication.adoc#account-impersonation[account impersonation]. This means you can authenticate to fine-grained access within Redpanda using the same credentials you use to authenticate to Redpanda Cloud. 
 
-With user impersonation, the topics users see in the UI are identical to what they can access with the Cloud API or `rpk`, ensuring consistent permissions across all interfaces and clear auditing of data plane user actions.
+With account impersonation (originally called user impersonation), the topics users see in the UI are identical to what they can access with the Cloud API or `rpk`, ensuring consistent permissions across all interfaces and clear auditing of data plane user actions.
 
 === Redpanda Connect updates
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -22,6 +22,8 @@ Serverless clusters now support up to 100 Redpanda Connect pipelines and 100 MCP
 === Redpanda Connect updates
 
 * The Redpanda Connect pipeline creation and editing workflow has been simplified. The new UI replaces the previous multi-page wizard with a visual pipeline diagram, an IDE-like configuration editor, slash commands for inserting variables, and inline links to component documentation. See the xref:develop:connect/connect-quickstart.adoc[Redpanda Connect quickstart] to try it out.
+* Outputs:
+** xref:develop:connect/components/outputs/arc.adoc[arc]: Send data to an Arc columnar analytical database using its high-performance MessagePack ingestion endpoint.
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
 

--- a/modules/get-started/partials/quick-start-cloud.adoc
+++ b/modules/get-started/partials/quick-start-cloud.adoc
@@ -147,7 +147,7 @@ The message that you produced to the topic is displayed along with some other de
 
 If you don't want to continue experimenting with your cluster, you can delete it.
 
-Go to **Cluster settings** and click **Delete cluster**.
+Go to **Dataplane settings** and click **Delete cluster**.
 
 == Next steps
 

--- a/modules/manage/pages/maintenance.adoc
+++ b/modules/manage/pages/maintenance.adoc
@@ -9,7 +9,7 @@ Redpanda runs maintenance operations on clusters in a rolling fashion, accompani
 
 == Maintenance windows
 
-Redpanda Cloud may run maintenance operations on any day, at any time. You can override this default and schedule a specific maintenance window on your cluster's *Cluster settings* page. 
+Redpanda Cloud may run maintenance operations on any day, at any time. You can override this default and schedule a specific maintenance window on your cluster's *Dataplane settings* page. 
 
 If you select a *Scheduled* maintenance window, then Redpanda Cloud runs operations on the day and time specified. Maintenance windows typically take six hours. All operations begin during your maintenance window, but some operations may complete after the window closes. All times are in Coordinated Universal Time (UTC).
 

--- a/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc
@@ -31,7 +31,7 @@ Consider using Private Service Connect if you have multiple VPC networks and cou
 
 == Enable Private Service Connect for existing clusters
 
-. In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
+. In the Redpanda Cloud UI, open your https://cloud.redpanda.com/clusters[cluster^], and click **Dataplane settings**.
 . Under Private Service Connect, click **Enable**. 
 ifdef::env-byoc[]
 . For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a PSC NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You also need to create VPC network firewall rules to allow Private Service Connect traffic. You can use the `gcloud` CLI:
@@ -71,10 +71,10 @@ Provide your values for the following placeholders:
 See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^]. 
 endif::[]
 . For the accepted consumers list, you need the GCP project IDs from which incoming connections will be accepted.
-. It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Cluster settings** changes from **In progress** to **Enabled**.
+. It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Dataplane settings** changes from **In progress** to **Enabled**.
 
 include::networking:partial$psc-ui.adoc[]
 
 == Disable Private Service Connect
 
-In **Cluster settings**, click **Disable**. Existing connections are closed after it is disabled. To connect using Private Service Connect again, you must re-enable it.
+In **Dataplane settings**, click **Disable**. Existing connections are closed after it is disabled. To connect using Private Service Connect again, you must re-enable it.

--- a/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
+++ b/modules/networking/pages/configure-privatelink-in-cloud-ui.adoc
@@ -29,12 +29,12 @@ include::networking:partial$dns_resolution.adoc[]
 
 == Enable endpoint service for existing clusters
 
-. In the Redpanda Cloud Console, select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Cluster settings* page.
+. In the Redpanda Cloud Console, select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Dataplane settings* page.
 . For AWS PrivateLink, click *Enable*.
 . On the Enable PrivateLink page, for Allowed principal ARNs, click *Add*, and enter the Amazon Resource Names (ARNs) for each AWS principal allowed to access the endpoint service. For example, for all principals in a specific account, use `arn:aws:iam::<account-id>:root`. See the AWS documentation on https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permission[configuring an endpoint service^] for details.
 . Click *Add* after entering each ARN, and when finished, click *Enable*.
 . (Optional) To enable cross-region PrivateLink, add supported regions. See <<cross-region-privatelink>>.
-. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status on the Cluster settings page changes from *In progress* to *Enabled*.
+. It may take several minutes for your cluster to update. When the update is complete, the AWS PrivateLink status on the Dataplane settings page changes from *In progress* to *Enabled*.
 
 NOTE: For help with issues when enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
 
@@ -57,7 +57,7 @@ NOTE: Use `<cluster_domain>` as the domain you target with your DNS conditional 
 
 === Get name of PrivateLink endpoint service
 
-You need the service name to <<create-vpc-endpoint,create a VPC endpoint>>. You can find the service name on the *Cluster settings* page after PrivateLink is enabled, or in the *How to Connect* section of the cluster overview.
+You need the service name to <<create-vpc-endpoint,create a VPC endpoint>>. You can find the service name on the *Dataplane settings* page after PrivateLink is enabled, or in the *How to Connect* section of the cluster overview.
 
 [,bash]
 ----
@@ -94,20 +94,20 @@ For more information about AWS cross-region PrivateLink support, see the https:/
 
 NOTE: The *Supported regions* option only appears in the UI for multi-AZ clusters.
 
-. In the Redpanda Cloud Console, select your https://cloud.redpanda.com/clusters[cluster^], and go to the cluster settings page.
+. In the Redpanda Cloud Console, select your https://cloud.redpanda.com/clusters[cluster^], and go to the Dataplane settings page.
 . In the AWS PrivateLink section, click *Edit* (or *Enable* if PrivateLink is not yet enabled).
 . In the *Supported regions* section, click *Add* to add a region from which PrivateLink endpoints can connect to your cluster.
 . Select an AWS region from the dropdown. The cluster's home region is automatically included and not shown in the list.
 . Repeat to add additional regions as needed.
 . Click *Save* (or *Enable*) to apply the changes.
 
-After saving, the *Supported regions* row on the cluster settings page displays your configured regions.
+After saving, the *Supported regions* row on the Dataplane settings page displays your configured regions.
 
 Clients in VPCs located in the supported regions can now create PrivateLink endpoints that connect to your Redpanda cluster.
 
 == Disable endpoint service
 
-On the Cluster settings page for the cluster, click *Disable* for PrivateLink. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
+On the Dataplane settings page for the cluster, click *Disable* for PrivateLink. Existing connections are closed after the AWS PrivateLink service is disabled. To connect using PrivateLink again, you must re-enable the service.
 
 include::shared:partial$suggested-reading.adoc[]
 

--- a/modules/networking/pages/dedicated/gcp/configure-psc-in-ui.adoc
+++ b/modules/networking/pages/dedicated/gcp/configure-psc-in-ui.adoc
@@ -30,7 +30,7 @@ Consider using Private Service Connect if you have multiple VPC networks and cou
 
 == Enable Private Service Connect for existing clusters
 
-. In the Redpanda Cloud Console, open your https://cloud.redpanda.com/clusters[cluster^], and click **Cluster settings**.
+. In the Redpanda Cloud Console, open your https://cloud.redpanda.com/clusters[cluster^], and click **Dataplane settings**.
 . Under Private Service Connect, click **Enable**. 
 ifdef::env-byoc[]
 . For xref:get-started:cluster-types/byoc/gcp/vpc-byo-gcp.adoc[BYOVPC clusters], you need a NAT subnet with `purpose` set to `PRIVATE_SERVICE_CONNECT`. You also need to create VPC network firewall rules to allow Private Service Connect traffic. You can use the `gcloud` CLI:
@@ -70,10 +70,10 @@ Provide your values for the following placeholders:
 See the GCP documentation for https://cloud.google.com/vpc/docs/configure-private-service-connect-producer#add-subnet-psc[creating a subnet for Private Service Connect^]. 
 endif::[]
 . For the accepted consumers list, you need the GCP project IDs from which incoming connections will be accepted.
-. It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Cluster settings** changes from **In progress** to **Enabled**.
+. It may take several minutes for your cluster to update. When the update is complete, the Private Service Connect status in **Dataplane settings** changes from **In progress** to **Enabled**.
 
 include::networking:partial$psc-ui.adoc[]
 
 == Disable Private Service Connect
 
-In **Cluster settings**, click **Disable**. Existing connections are closed after GCP Private Service Connect is disabled. To connect using Private Service Connect again, you must re-enable the service.
+In **Dataplane settings**, click **Disable**. Existing connections are closed after GCP Private Service Connect is disabled. To connect using Private Service Connect again, you must re-enable the service.

--- a/modules/networking/pages/serverless/aws/privatelink-ui.adoc
+++ b/modules/networking/pages/serverless/aws/privatelink-ui.adoc
@@ -45,7 +45,7 @@ Do not configure forwarding rules to target the VPC's Amazon-provided DNS resolv
 
 If you do not already have a PrivateLink resource for your cluster's resource group and region, create one at the organization level on the Networking page. For Serverless clusters, click **Create PrivateLink**.
 
-. Select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Cluster settings* page.
+. Select your https://cloud.redpanda.com/clusters[cluster^], and go to the *Dataplane settings* page.
 . Under Networking, select **Private Access** and then select an existing PrivateLink.
 
 NOTE: For help with issues enabling PrivateLink, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda support^].
@@ -198,7 +198,7 @@ include::networking:partial$private-links-test-connection-serverless.adoc[]
 
 == Disable endpoint service
 
-On the Cluster Settings page, deselect **Private Access**. Existing connections are closed after the AWS PrivateLink service is disabled.
+On the Dataplane settings page, deselect **Private Access**. Existing connections are closed after the AWS PrivateLink service is disabled.
 
 NOTE: Disabling private access in Redpanda Cloud does not delete the PrivateLink endpoint in your AWS account or the PrivateLink resource in Redpanda Cloud. Both remain provisioned and continue to incur charges until you explicitly delete them.
 

--- a/modules/networking/partials/psc-ui.adoc
+++ b/modules/networking/partials/psc-ui.adoc
@@ -3,7 +3,7 @@
 
 For each consumer VPC network, you must complete the following steps to successfully connect to the service attachment and use the Kafka API and other Redpanda services, such as HTTP Proxy.
 
-. In **Cluster settings**, copy the **DNS zone** and **Service attachment URL** under **Private Service Connect**. Use this URL to create the Private Service Connect endpoint in GCP.
+. In **Dataplane settings**, copy the **DNS zone** and **Service attachment URL** under **Private Service Connect**. Use this URL to create the Private Service Connect endpoint in GCP.
 
 . Get the name of the consumer VPC network and the subnet `<psc-endpoint-subnet>`, where the Private Service Connect endpoint forwarding rule will be created.
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -113,23 +113,23 @@ Administrators can require MFA for all users in an organization.
 * *TOTP code not accepted:* Ensure the code hasn't expired and that your phone's time is set automatically; time drift can cause invalid codes.
 * *Remembered device prompts again:* The 30-day trust is device- and browser-specific. Clearing cookies, switching browsers, or using a new device requires re-verification.
 
-=== User impersonation
+=== Account impersonation
 
 include::shared:partial$feature-flag.adoc[]
 
-BYOC and Dedicated clusters support unified authentication and authorization between the Redpanda Cloud UI and Redpanda with user impersonation. With user impersonation enabled, the topics and resources users see in the UI match exactly what they can access with the Cloud API or `rpk`. You can use the same credentials to authenticate to both Redpanda Cloud and the underlying Redpanda cluster, with consistent permissions across all interfaces. This ensures accurate audit logs and unified identity enforcement across all client applications, including the Cloud UI. 
+BYOC and Dedicated clusters support unified authentication and authorization between the Redpanda Cloud UI and Redpanda with account impersonation. With account impersonation enabled, the topics and resources users see in the UI match exactly what they can access with the Cloud API or `rpk`. You can use the same credentials to authenticate to both Redpanda Cloud and the underlying Redpanda cluster, with consistent permissions across all interfaces. This ensures accurate audit logs and unified identity enforcement across all client applications, including the Cloud UI. 
 
-* *Without user impersonation*: Redpanda Cloud uses a static service account to access your cluster. All UI requests appear to come from this generic admin user.
-* *With user impersonation*: Redpanda Cloud uses your individual user credentials and evaluates permissions using glossterm:ACL[,access control lists (ACLs)] and glossterm:RBAC[,role-based access control (RBAC)] in the data plane. Each user sees only the resources they have permission to access.  
+* *Without account impersonation*: Redpanda Cloud uses a static service account to access your cluster. All UI requests appear to come from this generic admin user.
+* *With account impersonation*: Redpanda Cloud uses your individual user credentials and evaluates permissions using glossterm:ACL[,access control lists (ACLs)] and glossterm:RBAC[,role-based access control (RBAC)] in the data plane. Each user sees only the resources they have permission to access.  
 
-To enable user impersonation:
+To enable account impersonation:
 
-. Go to the *Dataplane settings* page and select the option to enable user impersonation.
+. Go to the *Dataplane settings* page and select the option to enable account impersonation.
 . Configure permissions for your users on the cluster *Security* page using ACLs or RBAC roles.
 
 [IMPORTANT]
 ====
-After enabling user impersonation:
+After enabling account impersonation:
 
 * *Admin users* continue to have full access as before
 * *Reader and Writer users* will lose access to the cluster until you explicitly grant them permissions through ACLs or RBAC roles on the *Security* page

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -124,7 +124,7 @@ BYOC and Dedicated clusters support unified authentication and authorization bet
 
 To enable user impersonation:
 
-. Go to the *Cluster settings* page and select the option to enable user impersonation.
+. Go to the *Dataplane settings* page and select the option to enable user impersonation.
 . Configure permissions for your users on the cluster *Security* page using ACLs or RBAC roles.
 
 [IMPORTANT]


### PR DESCRIPTION
## Summary

Redpanda Cloud Console renamed the per-cluster **Cluster settings** page to **Dataplane settings**. Verified in the Cloud UI across Serverless, BYOC, and Dedicated. This PR updates 27 references across 14 files so step-by-step procedures match the current UI.

Closes [DOC-2077](https://redpandadata.atlassian.net/browse/DOC-2077).

## Files changed

- `modules/get-started/pages/cluster-types/byoc/aws/create-byoc-cluster-aws.adoc`
- `modules/get-started/pages/cluster-types/byoc/azure/create-byoc-cluster-azure.adoc`
- `modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc`
- `modules/get-started/pages/cluster-types/byoc/gcp/vpc-byo-gcp.adoc`
- `modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc`
- `modules/get-started/pages/whats-new-cloud.adoc` (3 release-note references; all describe functionality users can still do today, so renamed rather than preserved)
- `modules/get-started/partials/quick-start-cloud.adoc`
- `modules/manage/pages/maintenance.adoc`
- `modules/networking/pages/configure-private-service-connect-in-cloud-ui.adoc`
- `modules/networking/pages/configure-privatelink-in-cloud-ui.adoc`
- `modules/networking/pages/dedicated/gcp/configure-psc-in-ui.adoc`
- `modules/networking/pages/serverless/aws/privatelink-ui.adoc`
- `modules/networking/partials/psc-ui.adoc`
- `modules/security/pages/cloud-authentication.adoc`

Formatting markers (`**bold**`, `*italic*`, plain text) preserved per occurrence.

## Out of scope

`modules/get-started/partials/quick-start-cloud.adoc` line 18 (`. For cluster settings, enter **redpandaquickstart** for the cluster name.`) describes a step in the cluster-creation wizard, not the post-creation **Dataplane settings** page. Left unchanged — wizard step may not have been renamed.

## Follow-up

Separate PR in [docs-team-standards](https://github.com/redpanda-data/docs-team-standards): add `Dataplane settings` entry to `resources/writing-style/terminology.md` so the `review` skill flags future regressions.

## Review feedback addressed

- @alextreichler noted in https://github.com/redpanda-data/cloud-docs/pull/558#pullrequestreview-4149758482 that "user impersonation" is now called "Account Impersonation" in the Cloud Console. Renamed in `modules/security/pages/cloud-authentication.adoc` and `modules/get-started/pages/whats-new-cloud.adoc` (commit `b2ce79e`). Both pages are already in the Preview pages list below.

## Preview pages

- [Create a BYOC Cluster on AWS](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/aws/create-byoc-cluster-aws/) (updated)
- [Create a BYOC Cluster on Azure](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/azure/create-byoc-cluster-azure/) (updated)
- [Create a BYOC Cluster on GCP](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/gcp/create-byoc-cluster-gcp/) (updated)
- [Create a BYOVPC Cluster on GCP](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/byoc/gcp/vpc-byo-gcp/) (updated)
- [Create a Dedicated Cluster](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/create-dedicated-cloud-cluster/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/) (updated)
- [Upgrades and Maintenance](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/manage/maintenance/) (updated)
- [Configure GCP Private Service Connect in the Cloud UI](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/networking/configure-private-service-connect-in-cloud-ui/) (updated)
- [Configure AWS PrivateLink in the Cloud Console](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/networking/configure-privatelink-in-cloud-ui/) (updated)
- [Configure GCP Private Service Connect in the Cloud Console (Dedicated)](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/networking/dedicated/gcp/configure-psc-in-ui/) (updated)
- [Configure AWS PrivateLink in the Cloud Console (Serverless)](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/networking/serverless/aws/privatelink-ui/) (updated)
- [Cloud authentication](https://deploy-preview-558--rp-cloud.netlify.app/redpanda-cloud/security/cloud-authentication/) (updated)

## Test plan

- [x] `npm run build` succeeds locally (exit 0)
- [x] `git grep -i "cluster settings" -- 'modules/**/*.adoc'` returns only the intentional wizard-step line
- [x] `git grep -i "dataplane settings" -- 'modules/**/*.adoc'` returns 27 matches across 14 files
- [ ] Netlify preview renders affected pages correctly (spot-check PrivateLink, What's New, Maintenance, Cloud Authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2077]: https://redpandadata.atlassian.net/browse/DOC-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

