### PR TITLE
docs(ai-agents): rewrite Transcripts pages for ADP GA

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -61,7 +61,7 @@
 **** xref:ai-agents:agents/a2a-concepts.adoc[A2A Protocol]
 ** xref:ai-agents:observability/index.adoc[Transcripts]
 *** xref:ai-agents:observability/concepts.adoc[Concepts]
-*** xref:ai-agents:observability/transcripts.adoc[View Transcripts]
+*** xref:ai-agents:observability/transcripts.adoc[Read a transcript]
 *** xref:ai-agents:observability/ingest-custom-traces.adoc[Ingest Traces from Custom Agents]
 ** xref:ai-agents:ai-gateway/index.adoc[AI Gateway]
 *** xref:ai-agents:ai-gateway/what-is-ai-gateway.adoc[Overview]

--- a/modules/ai-agents/pages/observability/concepts.adoc
+++ b/modules/ai-agents/pages/observability/concepts.adoc
@@ -225,6 +225,8 @@ AI SDK layer (following https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-a
 - `gen_ai.agent.name`: Sub-agent name for multi-agent systems
 - `gen_ai.provider.name`, `gen_ai.request.model`: LLM provider and model
 - `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`: Token consumption
+- `gen_ai.usage.input_tokens_cost_usd`, `gen_ai.usage.output_tokens_cost_usd`: USD cost per call, derived from token counts and a per-model pricing table
+// TODO: Confirm exact USD-cost attribute names + pricing-table coverage with team-ai before GA.
 - `gen_ai.tool.name`, `gen_ai.tool.call.arguments`: Tool execution details
 - `gen_ai.input.messages`, `gen_ai.output.messages`: Full LLM conversation context
 
@@ -320,9 +322,10 @@ Redpanda manages both the `redpanda.otel_traces` topic and its schema automatica
 
 The `redpanda.otel_traces` topic has a predefined retention policy. Configuration changes to this topic are not supported. If you modify settings, Redpanda reverts them to the default values.
 
-The topic persists in your cluster even after all agents and MCP servers are deleted, allowing you to retain historical trace data for analysis.
+The topic persists even after all agents and MCP servers are deleted, allowing you to retain historical trace data for analysis.
 
-Transcripts may contain sensitive information from your tool inputs and outputs. Consider implementing appropriate glossterm:ACL[access control lists (ACLs)] for the `redpanda.otel_traces` topic, and review the data in transcripts before sharing or exporting to external systems.
+Transcripts may contain sensitive information from your tool inputs and outputs. Review the data in transcripts before sharing or exporting to external systems.
+// TODO: Re-add guidance on ACL scoping for `redpanda.otel_traces` once the standalone-ADP permission model lands. Today's wording assumed users manage topic ACLs on their own Redpanda Cloud cluster, which won't apply when ADP is a separate product surface.
 
 == Transcripts compared to audit logs
 
@@ -336,6 +339,13 @@ Transcripts provide:
 * Ability to reconstruct execution paths and identify bottlenecks
 
 Transcripts are optimized for execution-level observability and governance. For user-level accountability tracking ("who initiated what"), use the session and task topics for agents, which provide records of agent conversations and task execution.
+
+[[history-reconstruction]]
+== Reconstructed transcript history
+
+Trace data on `redpanda.otel_traces` is subject to a retention policy. When a transcript covers a long-running conversation whose earliest spans have already been evicted, Redpanda reconstructs the missing turns from the LLM message context carried on later spans (`gen_ai.input.messages`) and marks those turns as _reconstructed_. Reconstructed turns preserve the high-level intent and role ordering of the conversation, but do not preserve byte-level fidelity: token counts, per-turn latency, and tool-call arguments are unavailable for the reconstructed range. Use the `is_reconstructed` marker in the UI to tell which turns came from live spans and which came from reconstruction.
+
+// TODO: Verify model names on this page against the GA build (gpt-5.2, claude-sonnet-4-5, gpt-5-nano, gemini-3-flash-preview) — replace any that ship with a different GA identifier.
 
 == Next steps
 

--- a/modules/ai-agents/pages/observability/concepts.adoc
+++ b/modules/ai-agents/pages/observability/concepts.adoc
@@ -343,7 +343,7 @@ Transcripts are optimized for execution-level observability and governance. For 
 [[history-reconstruction]]
 == Reconstructed transcript history
 
-Trace data on `redpanda.otel_traces` is subject to a retention policy. When a transcript covers a long-running conversation whose earliest spans have already been evicted, Redpanda reconstructs the missing turns from the LLM message context carried on later spans (`gen_ai.input.messages`) and marks those turns as _reconstructed_. Reconstructed turns preserve the high-level intent and role ordering of the conversation, but do not preserve byte-level fidelity: token counts, per-turn latency, and tool-call arguments are unavailable for the reconstructed range. Use the `is_reconstructed` marker in the UI to tell which turns came from live spans and which came from reconstruction.
+Trace data on `redpanda.otel_traces` is subject to a retention policy. When a transcript covers a long-running conversation whose earliest spans have already been evicted, Redpanda reconstructs the missing turns from the LLM message context carried on later spans (`gen_ai.input.messages`) and sets the boolean field `is_reconstructed` to `true` on each affected turn. The UI surfaces this as a **Reconstructed** badge on those turns — `is_reconstructed` is the backing data field; "Reconstructed" is the visible label. Reconstructed turns preserve the high-level intent and role ordering of the conversation, but do not preserve byte-level fidelity: token counts, per-turn latency, and tool-call arguments are unavailable for the reconstructed range.
 
 // TODO: Verify model names on this page against the GA build (gpt-5.2, claude-sonnet-4-5, gpt-5-nano, gemini-3-flash-preview) — replace any that ship with a different GA identifier.
 

--- a/modules/ai-agents/pages/observability/ingest-custom-traces.adoc
+++ b/modules/ai-agents/pages/observability/ingest-custom-traces.adoc
@@ -7,6 +7,8 @@
 
 include::ai-agents:partial$adp-la.adoc[]
 
+// TODO (standalone-ADP rewrite): This page was written when ADP lived inside a Redpanda Cloud cluster, so the setup flow deploys a Redpanda Connect pipeline on the user's own cluster and references cluster-id-shaped URLs (`<pipeline-id>.pipelines.<cluster-id>.clusters.rdpa.co`). Post-2026-04-21, ADP ships as its own product surface and users won't necessarily have a Redpanda Cloud cluster. The whole ingestion flow (prereqs, pipeline deployment, endpoint URL format, auth) needs a rewrite once the standalone-ADP ingestion path is defined. Tracking under ADP Docs Plan Workflow #11 (BYOA telemetry). Until then, the content below is accurate for the federated-in-cloud-ui preview but will mislead standalone-ADP users.
+
 You can extend Redpanda's transcript observability to custom agents built with frameworks like LangChain or instrumented with OpenTelemetry SDKs. By ingesting traces from external applications into the `redpanda.otel_traces` topic, you gain unified visibility across all agent executions, from Redpanda's declarative agents, Remote MCP servers, to your own custom implementations.
 
 After reading this page, you will be able to:
@@ -17,8 +19,8 @@ After reading this page, you will be able to:
 
 == Prerequisites
 
-* A BYOC cluster
-* Ability to manage secrets in Redpanda Cloud
+* A Redpanda Connect pipeline host (today: a BYOC Redpanda Cloud cluster with Connect enabled). Ability to manage secrets on that host.
+// TODO: Replace with the standalone-ADP ingestion target once defined (may no longer require a Redpanda Cloud cluster).
 * The latest version of xref:manage:rpk/rpk-install.adoc[`rpk`] installed
 * Custom agent or application instrumented with OpenTelemetry SDK
 * Basic understanding of the https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/[OpenTelemetry span format^] and https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry Protocol (OTLP)^]
@@ -29,7 +31,8 @@ If you're using LangChain with OpenTelemetry tracing, you can send traces to Red
 
 . Configure LangChain's OpenTelemetry integration by following the https://docs.langchain.com/langsmith/trace-with-opentelemetry[LangChain documentation^]. 
 
-. Deploy a Redpanda Connect pipeline using the `otlp_http` input to receive OTLP traces over HTTP. Create the pipeline in the **Connect** page of your cluster, or see the <<configure-the-ingestion-pipeline,Configure the ingestion pipeline>> section below for a sample configuration.
+. Deploy a Redpanda Connect pipeline using the `otlp_http` input to receive OTLP traces over HTTP. Today, create the pipeline in the **Connect** page of your Redpanda Cloud cluster. See the <<configure-the-ingestion-pipeline,Configure the ingestion pipeline>> section below for a sample configuration.
+// TODO: Update the deployment entry point once the standalone-ADP ingestion flow is defined.
 
 . Configure your OTEL exporter to send traces to your Redpanda Connect pipeline using environment variables:
 +
@@ -51,7 +54,7 @@ By default, traces are sent to both LangSmith and your Redpanda Connect pipeline
 export LANGSMITH_OTEL_ONLY="true"
 ----
 
-Your LangChain application will send traces to the `redpanda.otel_traces` topic, making them visible in the Transcripts view in your cluster  alongside Remote MCP server and declarative agent traces.
+Your LangChain application will send traces to the `redpanda.otel_traces` topic, making them visible in the Transcripts view alongside Remote MCP server and declarative agent traces.
 
 For non-LangChain applications or custom instrumentation, continue with the sections below.
 
@@ -168,17 +171,20 @@ NOTE: Clients must include the authentication token in gRPC metadata as `authori
 
 The OTLP input automatically handles format conversion, so no processors are needed for basic trace ingestion. Each span becomes a separate message in the `redpanda.otel_traces` topic.
 
-=== Deploy the pipeline in Redpanda Cloud
+=== Deploy the ingestion pipeline
+
+// TODO (standalone-ADP): Steps below assume a Redpanda Cloud cluster with Connect enabled. The standalone ADP product surface may expose a different deployment entry point. Revisit the whole subsection under Workflow #11.
 
 . In the *Connect* page of your Redpanda Cloud cluster, click *Create Pipeline*.
 . For the input, select the *otlp_http* (or *otlp_grpc*) component.
 . Skip to *Add a topic* and select `redpanda.otel_traces` from the list of existing topics. Leave the default advanced settings.
 . In the *Add permissions* step, create a service account with write access to the `redpanda.otel_traces` topic.
-. In the *Create pipeline* step, enter a name for your pipeline and paste the configuration. Redpanda Cloud automatically handles authentication for incoming requests.
+. In the *Create pipeline* step, enter a name for your pipeline and paste the configuration. Authentication for incoming requests is handled automatically.
 
 == Send traces from your custom agent
 
-Configure your custom agent to send OpenTelemetry traces to the pipeline endpoint. After deploying the pipeline, you can find its URL in the Redpanda Cloud UI on the pipeline details page.
+Configure your custom agent to send OpenTelemetry traces to the pipeline endpoint. After deploying the pipeline, you can find its URL on the pipeline details page in the host UI.
+// TODO (standalone-ADP): Confirm where users find the pipeline URL once the ingestion path moves out of the Redpanda Cloud UI.
 
 [cols="1,3", options="header"]
 |===
@@ -193,7 +199,8 @@ Configure your custom agent to send OpenTelemetry traces to the pipeline endpoin
 
 === Authenticate to the pipeline
 
-The OTLP pipeline uses the same authentication mechanism as the Redpanda Cloud API. Obtain an access token using your service account credentials as described in xref:redpanda-cloud:security:cloud-authentication.adoc#authenticate-to-the-cloud-api[Authenticate to the Cloud API].
+The OTLP pipeline uses the same authentication mechanism as the Redpanda Cloud API (today, while ingestion runs on a Redpanda Cloud cluster). Obtain an access token using your service account credentials as described in xref:redpanda-cloud:security:cloud-authentication.adoc#authenticate-to-the-cloud-api[Authenticate to the Cloud API].
+// TODO (standalone-ADP): Update the auth model when the standalone ADP ingestion path is defined.
 
 Include the token in your requests:
 
@@ -558,13 +565,13 @@ Check that traces are being published to the `redpanda.otel_traces` topic:
 rpk topic consume redpanda.otel_traces --offset end -n 10
 ----
 
-You can also view the `redpanda.otel_traces` topic in the *Topics* page of Redpanda Cloud UI.
+You can also view the `redpanda.otel_traces` topic in the *Topics* page of the host UI (today, the Redpanda Cloud UI).
 
 Look for spans with your custom `instrumentationScope.name` to identify traces from your agent.
 
 === View traces in Transcripts 
 
-After your custom agent sends traces through the pipeline, they appear in your cluster's *Agentic AI > Transcripts* view alongside traces from Remote MCP servers, declarative agents, and AI Gateway.
+After your custom agent sends traces through the pipeline, they appear in the *Transcripts* view of the ADP UI alongside traces from Remote MCP servers, declarative agents, and AI Gateway.
 
 ==== Identify custom agent transcripts
 

--- a/modules/ai-agents/pages/observability/transcripts.adoc
+++ b/modules/ai-agents/pages/observability/transcripts.adoc
@@ -1,16 +1,16 @@
-= View Transcripts
-:description: Filter and navigate the Transcripts interface to investigate end-to-end agent execution records stored on Redpanda's immutable log.
+= Read a Transcript
+:description: Open a transcript in the ADP UI, read the conversation turn by turn, and investigate errors, costs, and performance.
 :page-topic-type: how-to
 :personas: agent_developer, platform_admin
-:learning-objective-1: Filter transcripts to find specific execution traces
-:learning-objective-2: Use the timeline interactively to navigate to specific time periods
-:learning-objective-3: Navigate between detail views to inspect span information at different levels
+:learning-objective-1: Filter and open a transcript for a specific agent or MCP server execution
+:learning-objective-2: Read a transcript as a turn-by-turn conversation, including tool calls and token usage
+:learning-objective-3: Investigate errors, slow turns, and cost anomalies from the transcript detail view
 
 include::ai-agents:partial$adp-la.adoc[]
 
-Use the Transcripts view to filter, inspect, and debug agent execution records. Filter by operation type, time range, or service to isolate specific executions, then drill into span hierarchies to trace request flow and identify where failures or performance bottlenecks occur.
+Use the Transcripts view to read a complete record of an agent or MCP server execution, turn by turn. Each transcript captures the conversation between the user, the agent, any LLM calls, and any tools it invoked, along with token usage, USD cost, latency, and any errors.
 
-For conceptual background on spans and trace structure, see xref:ai-agents:observability/concepts.adoc[].
+For conceptual background on the underlying OpenTelemetry data model, see xref:ai-agents:observability/concepts.adoc[].
 
 After reading this page, you will be able to:
 
@@ -20,110 +20,179 @@ After reading this page, you will be able to:
 
 == Prerequisites
 
-* xref:ai-agents:agents/create-agent.adoc[Running agent] or xref:ai-agents:mcp/remote/quickstart.adoc[MCP server] with at least one execution
-* Access to the Transcripts view (requires appropriate permissions to read the `redpanda.otel_traces` glossterm:topic[])
+* A running xref:ai-agents:agents/create-agent.adoc[agent] or xref:ai-agents:mcp/remote/quickstart.adoc[MCP server] with at least one execution
+* Access to the ADP UI
+// TODO: Replace with the exact standalone-ADP sign-in URL and IAM/role requirement once the standalone product surface ships. Today: flag `enableTranscriptsInConsole` must be on for the user's cluster.
+* Read access to the `redpanda.otel_traces` glossterm:topic[]
+// TODO: Confirm whether this ACL is user-managed or auto-granted on the standalone ADP UI.
 
-== Navigate the Transcripts interface
+== Open the Transcripts view
 
-=== Filter transcripts
+. Sign in to the ADP UI.
+// TODO: Replace with the standalone ADP URL + sign-in flow once available.
+. Open *Transcripts* from the primary navigation.
 
-Use filters to narrow down transcripts and quickly locate specific executions. When you use any of the filters, the transcript table updates to show only matching results.
+The transcripts list shows every recent execution across the agents and MCP servers you can read.
 
-The Transcripts view provides several quick-filter buttons:
+== Read the transcripts list
 
-* *Service*: Isolate operations from a particular component in your agentic data plane (agents, MCP servers, or AI Gateway)
-* *LLM Calls*: Inspect large language model (LLM) invocations, including chat completions and embeddings
-* *Tool Calls*: View tool executions by agents
-* *Agent Spans*: Inspect agent invocation and reasoning
-* *Errors Only*: Filter for failed operations or errors
-* *Slow (>5s)*: Isolate operations that exceeded five seconds in duration, useful for performance investigation
+Each row in the list represents one execution (one trace). Columns include:
 
-You can combine multiple filters to narrow results further. For example, use *Tool Calls* and *Errors Only* together to investigate failed tool executions.
+* *Start time* — when the execution began (sortable).
+* *Agent* / *Service* — the agent or MCP server name from the span's `service.name` resource attribute.
+* *Status* — `RUNNING`, `COMPLETED`, or `ERROR`.
+* *Turn count* — number of turns in the conversation.
+* *Total tokens* — sum of input + output tokens across the conversation.
+* *USD cost* — total cost for the execution, derived from per-model pricing. See <<troubleshooting>> if this column shows `0`.
+* *Duration* — wall-clock time between the first and last span.
 
-Toggle *Full traces* on to see the complete execution context, in grayed-out text, for the filtered transcripts in the table.
+A transcript marked _reconstructed_ is one in which some turns were rebuilt from LLM message context after the original spans were evicted from `redpanda.otel_traces`. See xref:ai-agents:observability/concepts.adoc#history-reconstruction[Reconstructed transcript history] for what that means.
 
-==== Filter by attribute
+// TODO: Confirm final column list on the GA Console UI. Today's labels likely shift. Verify against adp-production before merge.
 
-Click the *Attribute* button to query exact matches on specific span metadata such as the following:
+=== Filter the list
 
-* Agent names
-* LLM model names, for example, `gemini-3-flash-preview`
-* Tool names
-* Span and trace IDs
+Use filters to narrow the list to the executions you care about.
 
-You can add multiple attribute filters to refine results.
+// TODO: Re-verify every filter chip against the GA UI on adp-production. The list below reflects the beta Console MFE and may have moved.
+
+* *Service* — isolate operations from a single agent, MCP server, or AI Gateway.
+* *LLM Calls* — executions that invoked a language model.
+* *Tool Calls* — executions that invoked one or more tools.
+* *Errors Only* — executions with `TranscriptStatus.ERROR` or a per-turn error.
+* *Slow (>5s)* — executions exceeding five seconds end-to-end.
+* *Attribute* — exact-match filter on a specific span attribute. Supported keys include agent names, LLM model names, tool names, span/trace IDs, and `gen_ai.conversation.id`.
+
+Combine filters to narrow further (for example, *Tool Calls* + *Errors Only* to find failed tool executions).
+
+Toggle *Full traces* on to include the complete execution context (grayed-out) alongside the filtered rows.
 
 === Use the interactive timeline
 
-Use the timeline visualization to quickly identify when errors began or patterns changed, and navigate directly to transcripts from specific time windows when investigating issues that occurred at known times.
-
-Click on any bar in the timeline to zoom into transcripts from that specific time period. The transcript table automatically scrolls to show operations from the time bucket in view.
+The timeline shows execution volume over time, with color indicators for successful vs. failed executions. Click a bar to zoom into that time window; the table scrolls to match.
 
 [NOTE]
 ====
-When viewing time ranges with many transcripts (hundreds or thousands), the table displays a subset of the data to maintain performance and usability. The timeline bar indicates the actual time range of data currently loaded into view, which may be narrower than your selected time range. 
-
-Refer to the timeline header to check the exact range and count of visible transcripts, for example, "Showing 100 of 299 transcripts from 13:17 to 15:16".
+When the selected range holds many transcripts, the list shows a subset to keep the UI responsive. The header reports the actual loaded range, for example "Showing 100 of 299 transcripts from 13:17 to 15:16".
 ====
 
-== Inspect span details
+// TODO: Confirm the sampling threshold and header wording against the GA UI.
 
-The transcript table shows:
+== Open a transcript
 
-* **Time**: When the glossterm:span[] started (sortable)
-* **Span**: Span type and name with hierarchical tree structure
-* **Duration**: Total time or relative duration shown as visual bars
+Click any row to open the transcript detail view. The view has two parts: a summary header and the conversation.
 
-To view nested operations, expand any parent span. To learn more about span hierarchies and cross-service traces, see xref:ai-agents:observability/concepts.adoc[].
+=== Summary header
 
-Click any span to view details in the panel:
+The summary header reports:
 
-* **Summary tab**: High-level overview with token usage, operation counts, and conversation history.
-* **Attributes tab**: Structured metadata for debugging (see xref:ai-agents:observability/concepts.adoc#key-attributes-by-layer[standard attributes by layer]).
-* **Raw data tab**: Complete glossterm:OpenTelemetry[] span in JSON format. You can also view raw transcript data in the `redpanda.otel_traces` topic.
+* *Duration* — end-to-end wall-clock time.
+* *Status* — `RUNNING`, `COMPLETED`, or `ERROR`.
+* *Turn count* — number of turns (SYSTEM, USER, ASSISTANT, TOOL).
+* *Tokens* — input, output, and total.
+* *USD cost* — total cost, with a breakdown by turn on hover.
+* *LLM calls* — number of assistant turns that invoked a model.
+* *Tool calls* — number of tool invocations across the conversation.
+* *Conversation ID* — the `gen_ai.conversation.id` shared by related invocations. Follow it to find earlier or later executions in the same user session.
+* *Service* — the agent or MCP server that produced the transcript.
 
-[NOTE]
-====
-Rows labeled "awaiting root — waiting for parent span" indicate incomplete glossterm:trace[,traces]. This occurs when child spans arrive before parent spans due to network latency or service failures. Consistent "awaiting root" entries suggest instrumentation issues.
-====
+// TODO: Verify the exact field set and labels on the GA UI. The list above reflects the proto (`TranscriptSummary`, `TranscriptUsage`) plus the beta UI; the Console MFE may add or rename fields.
+
+=== Read the conversation
+
+Turns are listed in order by role:
+
+* *SYSTEM* — the system prompt and any priming instructions.
+* *USER* — a user message that started or continued the conversation.
+* *ASSISTANT* — a response from the LLM. Shows the model, input/output token counts, USD cost for that turn, and latency. If the assistant turn called a tool, its tool calls are nested underneath.
+* *TOOL* — a tool invocation. Shows the tool name, the arguments passed, the result, and the latency of the call.
+
+Any turn may carry the `is_reconstructed` marker. Reconstructed turns preserve role order and the high-level content of the conversation but do not carry per-turn token counts, latency, or tool-call arguments. See xref:ai-agents:observability/concepts.adoc#history-reconstruction[Reconstructed transcript history] for the mechanics.
+
+=== Errors
+
+An errored transcript shows `TranscriptStatus.ERROR` in the summary header. The specific failure appears on the turn that raised it, with:
+
+* *Code* — `TranscriptError.code` (for example, a provider error code or `INVALID_ARGUMENT`).
+* *Message* — a short description from the LLM provider, the tool, or the agent runtime.
+
+If the failure happened during a tool call, the error is attached to the TOOL turn; if it was an LLM call, it's on the ASSISTANT turn; if neither, it's on the trace root.
 
 == Common investigation tasks
 
-The following patterns demonstrate how to use the Transcripts view for understanding and troubleshooting your agentic systems.
-
 === Debug errors
 
-. Use *Errors Only* to filter for failed operations, or review the timeline to identify and zoom in to when errors began occurring.
-. Expand error spans to examine the failure context.
-. Check preceding tool call arguments and LLM responses for root cause.
+. Filter the list by *Errors Only*, or use the timeline to find a window where error volume spiked.
+. Open the failing transcript and scroll to the turn carrying the error code.
+. Read the immediately preceding turns (tool arguments, assistant output) for root cause.
 
 === Investigate performance issues
 
-. Use the *Slow (>5s)* filter to identify operations with high latency.
-. Expand slow spans to identify bottlenecks in the execution tree.
-. Compare duration bars across similar operations to spot anomalies.
+. Apply the *Slow (>5s)* filter.
+. Open a slow transcript and scan the per-turn latency column to find the bottleneck turn.
+. For tool-bound bottlenecks, expand the tool call to see arguments and result size — a large result often correlates with slow tool execution.
 
 === Analyze tool usage
 
-. Apply the *Tool Calls* filter and optionally use the *Attribute* filter to focus on a specific tool.
-. Review tool execution frequency in the timeline.
-. Click individual tool call spans to inspect arguments and responses.
-.. Check the Description field to understand tool invocation context.
-.. Use the Arguments field to verify correct parameter passing.
+. Filter the list by *Tool Calls*.
+. Optionally narrow to a specific tool with the *Attribute* filter on `gen_ai.tool.name`.
+. Open individual transcripts to read the tool calls: arguments in, results out, latency.
 
-=== Monitor LLM interactions
+=== Monitor LLM interactions and cost
 
-. Click *LLM Calls* to focus on model invocations and optionally filter by model name and provider using the *Attribute* filter.
-. Review token usage patterns across different time periods.
-. Examine conversation history to understand model behavior.
-. Spot unexpected model calls or token consumption spikes.
+. Filter by *LLM Calls*.
+. Optionally narrow to a specific model with the *Attribute* filter on `gen_ai.request.model`.
+. Compare token usage and USD cost across assistant turns to spot runaway prompts or unexpected model calls.
 
 === Trace multi-service operations
 
-. Locate the parent agent or gateway span in the transcript table.
-. Use the *Attribute* filter to follow the trace ID through agent and MCP server boundaries.
-. Expand the transcript tree to reveal child spans across services.
-. Review durations to understand where latency occurs in distributed calls.
+. Find the agent-level transcript for the request you want to trace.
+. Copy the *Conversation ID* from the summary header.
+. Filter the list by that `gen_ai.conversation.id` to see every transcript in the same conversation (for example, a root agent plus its sub-agent invocations, or an agent plus its MCP tool calls on a remote service).
+
+== Limitations
+
+* Large time windows sample the list to keep the UI responsive. The exact transcript you need may not be in the current page; narrow the time range or add filters.
+* Reconstructed turns do not carry token counts, latency, or tool-call arguments for the reconstructed range. For byte-level fidelity, lower the ingestion lag or extend `redpanda.otel_traces` retention (see xref:ai-agents:observability/concepts.adoc#opentelemetry-traces-topic[How Redpanda stores trace data]).
+* USD cost is only populated for models covered by the pricing table.
+// TODO: List which providers/models are priced at GA and what users see for un-priced ones (`0`, `null`, or an explicit "unknown" marker).
+// TODO: If the GA Console UI ships transcript export, document the entry point and output format here; otherwise omit.
+
+[[troubleshooting]]
+== Troubleshooting
+
+=== Transcript stuck in RUNNING
+
+A transcript stays in `RUNNING` until the root span closes. Common causes:
+
+* The agent or MCP server is still executing (this is normal — wait, or open a newer transcript).
+* The root span never flushed because the process was killed mid-execution. Expect this to resolve once the OTLP ingestion lag clears; if it doesn't after several minutes, the trace is likely orphaned.
+
+=== USD cost shows 0
+
+Cost is derived from the `gen_ai.usage.*` attributes on each LLM-call span and a per-model pricing table.
+// TODO: Document which providers/models are priced at GA.
+If cost is `0` for a transcript that clearly used tokens, check:
+
+* The model is in the pricing table.
+* The `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` attributes are present on the ASSISTANT-turn spans.
+* The cost-reporting pipeline is enabled on your ADP environment.
+
+=== All turns marked reconstructed
+
+Reconstruction happens when the original spans have been evicted from `redpanda.otel_traces`. Causes:
+
+* Retention on `redpanda.otel_traces` is aggressive relative to how long the conversation has been running.
+* OTLP ingestion fell behind and the span was dropped before it reached the topic.
+
+For long-running conversations, accept some reconstruction; for short conversations whose turns are all reconstructed, investigate ingestion and retention.
+
+=== Transcript missing entirely
+
+* Confirm the agent or MCP server actually ran — check its logs and the corresponding session or task topic.
+* Confirm your user has read access to `redpanda.otel_traces`.
+// TODO: Replace with the standalone-ADP permission model once available.
+* Confirm the feature flag enabling Transcripts is on for your environment.
 
 == Next steps
 

--- a/modules/ai-agents/pages/observability/transcripts.adoc
+++ b/modules/ai-agents/pages/observability/transcripts.adoc
@@ -170,13 +170,14 @@ A transcript stays in `RUNNING` until the root span closes. Common causes:
 
 === USD cost shows 0
 
-Cost is derived from the `gen_ai.usage.*` attributes on each LLM-call span and a per-model pricing table.
+`TranscriptUsage.usd_cost` is populated by the cost-reporting pipeline from the `gen_ai.usage.*` attributes on each LLM-call span combined with a per-model pricing table. For the full list of cost-bearing attributes (including the explicit USD-cost fields), see xref:ai-agents:observability/concepts.adoc#key-attributes-by-layer[Key attributes by layer].
 // TODO: Document which providers/models are priced at GA.
+
 If cost is `0` for a transcript that clearly used tokens, check:
 
 * The model is in the pricing table.
-* The `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` attributes are present on the ASSISTANT-turn spans.
 * The cost-reporting pipeline is enabled on your ADP environment.
+* The LLM-call spans carry the `gen_ai.usage.*` attributes the pipeline reads — either the token-count inputs (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) or the explicit USD-cost fields listed on the concepts page.
 
 === All turns marked reconstructed
 

--- a/modules/ai-agents/partials/transcripts-ui-guide.adoc
+++ b/modules/ai-agents/partials/transcripts-ui-guide.adoc
@@ -77,13 +77,20 @@ endif::[]
 When you select a transcript, the summary panel shows:
 
 * Duration: Total execution time for this request
-* Total Spans: Number of operations in the trace
+* Status: `RUNNING`, `COMPLETED`, or `ERROR`
+* Turn count: Number of conversation turns (SYSTEM, USER, ASSISTANT, TOOL)
 ifeval::["{context}" == "agent"]
-* Token Usage: Input tokens, output tokens, and total (critical for cost tracking)
+* Token Usage: Input tokens, output tokens, and total
+* USD cost: Total cost for the execution, derived from per-model pricing
 * LLM Calls: How many times the agent called the language model
+* Tool Calls: How many tools the agent invoked
 * Service: The agent identifier
-* Conversation ID: Links to session data topics
+* Conversation ID: The `gen_ai.conversation.id` shared by related invocations in the same user session
 endif::[]
 ifeval::["{context}" == "mcp"]
 * Service: The MCP server identifier
 endif::[]
+
+If any turns were rebuilt from LLM message context after their original spans were evicted, the panel shows a _reconstructed_ marker on those turns. For the mechanics, see xref:ai-agents:observability/concepts.adoc#history-reconstruction[Reconstructed transcript history].
+
+// TODO: Re-verify this field list against the GA Console UI on adp-production. Beta labels may shift; update wording before GA.


### PR DESCRIPTION
**Tracks:** [DOC-2115 — Read and understand a transcript](https://redpandadata.atlassian.net/browse/DOC-2115) (ADP Docs Plan Workflow #7)

## Summary

- Rewrites `observability/transcripts.adoc` around the `TranscriptService` turn / tool-call model (was span hierarchy) — adds USD cost, reconstructed-turn handling, and ADP-UI-generic prereqs.
- Updates `observability/concepts.adoc` with USD-cost attributes and a reconstructed-transcript-history section; drops cluster-centric topic-ACL wording.
- Expands the shared `transcripts-ui-guide.adoc` Summary panel (USD cost, turn count, tool calls, status, reconstructed marker) — propagates into `monitor-agents.adoc` and `monitor-mcp-servers.adoc` via the include.
- Renames nav entry `View Transcripts` → `Read a transcript` to match ADP Docs Plan Workflow #7.
- Light standalone-ADP wording pass on `ingest-custom-traces.adoc` with a page-top `// TODO:` flagging the full rewrite as pending under Workflow #11 (BYOA telemetry).

Every area that depends on the (TBD) standalone-ADP surface carries a `// TODO:` marker — sign-in URL, IAM model, USD-cost coverage, filter-chip labels, export. These will be resolved after a live walkthrough against `adp-production`.

Plan (Confluence): https://redpandadata.atlassian.net/wiki/spaces/DOC/pages/1867153415/Transcripts+docs+rewrite+ADP+GA+2026-06-15+plan
Parent workstream: https://redpandadata.atlassian.net/wiki/spaces/DOC/pages/1845461009 (Workflow #7)

## Preview pages

- [Read a Transcript](https://deploy-preview-560--rp-cloud.netlify.app/redpanda-cloud/ai-agents/observability/transcripts/) (updated)
- [Transcripts and AI Observability](https://deploy-preview-560--rp-cloud.netlify.app/redpanda-cloud/ai-agents/observability/concepts/) (updated)
- [Ingest OpenTelemetry Traces from Custom Agents](https://deploy-preview-560--rp-cloud.netlify.app/redpanda-cloud/ai-agents/observability/ingest-custom-traces/) (updated)

## Test plan

- [ ] `npm run build && npm run serve` — locally verified; nav renders "Read a transcript", no new unresolved xrefs, no regressions in `monitor-agents.adoc` / `monitor-mcp-servers.adoc` (both include the updated partial).
- [ ] Netlify preview — walk the Observability / Transcripts section end-to-end.
- [ ] Live walkthrough on `adp-production` (flag `enableTranscriptsInConsole` on) — verify every filter chip, detail-panel field, and column matches the draft. Resolve the `// TODO:` markers in-branch.
- [ ] Proto cross-check against `TranscriptService` / `TranscriptSummary` / `TranscriptTurn` comments.
- [ ] `docs-team-standards:review` editorial pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)