### PR TITLE
fix whats new

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -10,7 +10,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Extended Serverless free trial
 
-The free trial for Redpanda Serverless on AWS now lasts 30 days, up from 14 days. The $100 (USD) credit allowance and 7-day grace period are unchanged. Sign up at https://www.redpanda.com/try-data-streaming[redpanda.com^]. See xref:get-started:cluster-types/serverless.adoc[Serverless clusters].
+The free trial for Redpanda Serverless now lasts 30 days, up from 14 days. The $100 (USD) credit allowance and 7-day grace period are unchanged. Sign up at https://www.redpanda.com/try-data-streaming[redpanda.com^]. See xref:get-started:cluster-types/serverless.adoc[Serverless clusters].
 
 == April 2026
 


### PR DESCRIPTION
## Description
This pull request updates the documentation to reflect a change in the Redpanda Serverless free trial, clarifying that the 30-day trial duration applies to all platforms, not just AWS.

## Page previews
[What's New]([url](https://deploy-preview-576--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/))

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [X] Small fix (typos, links, copyedits, etc)