### PR TITLE
Clarify Grafana usage on Cloud monitoring page

### DIFF
--- a/modules/manage/pages/monitor-cloud.adoc
+++ b/modules/manage/pages/monitor-cloud.adoc
@@ -14,15 +14,16 @@ Redpanda Cloud exports Redpanda metrics for all brokers and connectors from a si
 - Operating system-level and node-level metrics (such as CPU, memory, disk, and network usage) are not available through this endpoint. For infrastructure monitoring, use your cloud provider's native monitoring tools (such as Azure Monitor, AWS CloudWatch, or Google Cloud Monitoring).
 ====
 
+[#configure-redpanda-monitoring]
 == Configure Redpanda monitoring
 
 To monitor a Redpanda Cloud cluster:
 
-. On the Redpanda Cloud *Overview* page for your cluster, under *How to connect*, click the *Prometheus* tab. 
+. On the Redpanda Cloud *Overview* page for your cluster, under *How to connect*, click the *Prometheus* tab.
 
-. Click the copy icon for *Prometheus YAML* to copy the contents to your clipboard. 
+. Click the copy icon for *Prometheus YAML* to copy the contents to your clipboard.
 +
-The YAML contains the Prometheus scrape target configuration, as well as authentication, for the cluster.
+The YAML is a Prometheus scrape configuration. Use it with Prometheus, or with any Prometheus-compatible scraper such as Grafana Alloy, Grafana Agent, Grafana Mimir, Thanos, or VictoriaMetrics.
 +
 image::shared:cloud_metrics.png[How to connect screenshot]
 +
@@ -70,6 +71,32 @@ instances:
 
 NOTE: Because the OpenMetrics endpoint in Redpanda Cloud aggregates Redpanda metrics for all cluster services, only a single Datadog agent is required. The agent must run in a container in your own container infrastructure. Redpanda does not support launching this container inside a Dedicated or BYOC Kubernetes cluster. For more information, see the https://docs.datadoghq.com/integrations/redpanda/?tab=host[Datadog documentation^] and https://github.com/DataDog/integrations-extras/tree/master/redpanda[Redpanda Datadog integration^].
 
+[#connect-grafana]
+== Connect Grafana
+
+The Redpanda Cloud metrics endpoint (`/api/cloud/prometheus/public_metrics`) is a Prometheus exposition (scrape) endpoint, not a Prometheus query API. You cannot point a Grafana Prometheus data source at it directly. Grafana issues PromQL queries to paths such as `/api/v1/query`, which the endpoint does not serve, so the requests fail with `401 Unauthorized`.
+
+To use Grafana with Redpanda Cloud metrics, run a Prometheus-compatible scraper between Redpanda Cloud and Grafana:
+
+. Configure a scraper to pull metrics from Redpanda Cloud, using the Basic Auth scrape configuration from <<configure-redpanda-monitoring>>. Compatible scrapers include:
++
+* Prometheus
+* Grafana Alloy or Grafana Agent
+* Grafana Mimir, Thanos, or VictoriaMetrics
+
+. In Grafana, add a Prometheus data source pointing at your scraper, not at the Redpanda Cloud endpoint.
+
+. Import a sample dashboard into Grafana. Use xref:reference:rpk/rpk-generate/rpk-generate-grafana-dashboard.adoc[`rpk generate grafana-dashboard`] to generate a dashboard from the https://github.com/redpanda-data/observability/tree/main/cloud[redpanda-data/observability^] repository, or browse the https://github.com/redpanda-data/observability#grafana-dashboards[example Grafana dashboards^] directly.
++
+For example, to generate the sample Serverless dashboard, run:
++
+[,bash]
+----
+rpk generate grafana-dashboard --dashboard serverless
+----
+
+For an end-to-end example with Prometheus and Grafana running in Docker, see the https://github.com/redpanda-data/observability#sandbox-environment[sandbox environment^] in the same repository.
+
 == Use Redpanda monitoring examples
 
 For hands-on learning, Redpanda provides a repository with examples of monitoring Redpanda with Prometheus and Grafana: https://github.com/redpanda-data/observability/tree/main/cloud[redpanda-data/observability^].
@@ -77,18 +104,6 @@ For hands-on learning, Redpanda provides a repository with examples of monitorin
 image::https://github.com/redpanda-data/observability/blob/main/docs/images/Ops%20Dashboard.png?raw=true[Example Redpanda Ops Dashboard^]
 
 It includes https://github.com/redpanda-data/observability#grafana-dashboards[example Grafana dashboards^] and a https://github.com/redpanda-data/observability#sandbox-environment[sandbox environment^] in which you launch a Dockerized Redpanda cluster and create a custom workload to monitor with dashboards.
-
-[TIP]
-====
-Use xref:reference:rpk/rpk-generate/rpk-generate-grafana-dashboard.adoc[`rpk generate grafana-dashboard`] to generate a sample dashboard from the examples repository that you can import into a Grafana instance.
-
-For example, to generate the sample Serverless dashboard, run:
-
-[,bash]
-----
-rpk generate grafana-dashboard --dashboard serverless
-----
-====
 
 == Monitor health and performance
 

--- a/modules/manage/pages/monitor-cloud.adoc
+++ b/modules/manage/pages/monitor-cloud.adoc
@@ -46,31 +46,6 @@ image::shared:cloud_metrics.png[How to connect screenshot]
 * `<prom_pass>`: Copy and paste the onscreen Prometheus password.
 
 
-== Configure Datadog
-
-To monitor a BYOC or Dedicated cluster in https://www.datadoghq.com/[Datadog^]: 
-
-. Follow the steps to configure Redpanda monitoring.
-
-. In Datadog, define the `openmetrics_endpoint` URL for that monitored cluster. The integration configuration should look similar to the following:
-+
-[,yaml]
-----
-instances:
-  # The endpoint to collect metrics from.
-  - openmetrics_endpoint: https://console-<id>.<identifier>.fmc.cloud.redpanda.com/api/cloud/prometheus/public_metrics
-    use_openmetrics: true
-    collect_counters_with_distributions: true
-
-    auth_type: basic
-    username: prom_user
-    password: prom_pass
-----
-
-. Restart the Datadog agent.
-
-NOTE: Because the OpenMetrics endpoint in Redpanda Cloud aggregates Redpanda metrics for all cluster services, only a single Datadog agent is required. The agent must run in a container in your own container infrastructure. Redpanda does not support launching this container inside a Dedicated or BYOC Kubernetes cluster. For more information, see the https://docs.datadoghq.com/integrations/redpanda/?tab=host[Datadog documentation^] and https://github.com/DataDog/integrations-extras/tree/master/redpanda[Redpanda Datadog integration^].
-
 [#connect-grafana]
 == Connect Grafana
 
@@ -96,6 +71,31 @@ rpk generate grafana-dashboard --dashboard serverless
 ----
 
 For an end-to-end example with Prometheus and Grafana running in Docker, see the https://github.com/redpanda-data/observability#sandbox-environment[Redpanda Cloud sandbox^] in the same repository.
+
+== Configure Datadog
+
+To monitor a BYOC or Dedicated cluster in https://www.datadoghq.com/[Datadog^]:
+
+. Follow the steps to configure Redpanda monitoring.
+
+. In Datadog, define the `openmetrics_endpoint` URL for that monitored cluster. The integration configuration should look similar to the following:
++
+[,yaml]
+----
+instances:
+  # The endpoint to collect metrics from.
+  - openmetrics_endpoint: https://console-<id>.<identifier>.fmc.cloud.redpanda.com/api/cloud/prometheus/public_metrics
+    use_openmetrics: true
+    collect_counters_with_distributions: true
+
+    auth_type: basic
+    username: prom_user
+    password: prom_pass
+----
+
+. Restart the Datadog agent.
+
+NOTE: Because the OpenMetrics endpoint in Redpanda Cloud aggregates Redpanda metrics for all cluster services, only a single Datadog agent is required. The agent must run in a container in your own container infrastructure. Redpanda does not support launching this container inside a Dedicated or BYOC Kubernetes cluster. For more information, see the https://docs.datadoghq.com/integrations/redpanda/?tab=host[Datadog documentation^] and https://github.com/DataDog/integrations-extras/tree/master/redpanda[Redpanda Datadog integration^].
 
 == Use Redpanda monitoring examples
 

--- a/modules/manage/pages/monitor-cloud.adoc
+++ b/modules/manage/pages/monitor-cloud.adoc
@@ -95,7 +95,7 @@ For example, to generate the sample Serverless dashboard, run:
 rpk generate grafana-dashboard --dashboard serverless
 ----
 
-For an end-to-end example with Prometheus and Grafana running in Docker, see the https://github.com/redpanda-data/observability#sandbox-environment[sandbox environment^] in the same repository.
+For an end-to-end example with Prometheus and Grafana running in Docker, see the https://github.com/redpanda-data/observability#sandbox-environment[Redpanda Cloud sandbox^] in the same repository.
 
 == Use Redpanda monitoring examples
 
@@ -103,7 +103,7 @@ For hands-on learning, Redpanda provides a repository with examples of monitorin
 
 image::https://github.com/redpanda-data/observability/blob/main/docs/images/Ops%20Dashboard.png?raw=true[Example Redpanda Ops Dashboard^]
 
-It includes https://github.com/redpanda-data/observability#grafana-dashboards[example Grafana dashboards^] and a https://github.com/redpanda-data/observability#sandbox-environment[sandbox environment^] in which you launch a Dockerized Redpanda cluster and create a custom workload to monitor with dashboards.
+It includes https://github.com/redpanda-data/observability#grafana-dashboards[example Grafana dashboards^] and a https://github.com/redpanda-data/observability#sandbox-environment[Redpanda Cloud sandbox^] in which you launch a Dockerized Redpanda cluster and create a custom workload to monitor with dashboards.
 
 == Monitor health and performance
 


### PR DESCRIPTION
## Summary

- Customer reported that pointing a Grafana Prometheus data source at the BYOC Console's metrics endpoint with the Console-displayed username/password yields `401 Unauthorized`. Root cause is a docs gap, not a backend bug: `/api/cloud/prometheus/public_metrics` is a Prometheus *exposition (scrape) endpoint*, not a PromQL query API, so Grafana's requests to `/api/v1/query` etc. don't resolve.
- Adds a `== Connect Grafana` section (`#connect-grafana`) explaining the architecture and the Prometheus/Alloy/Mimir-in-the-middle pattern, labels the existing YAML explicitly as a scrape configuration, and consolidates the `rpk generate grafana-dashboard` tip into the new section.
- Auth scheme docs (Basic Auth, username from Console) are unchanged — verified against `cloudv2/apps/cloud-ui/.../how-to-connect/prometheus/` and the server-side `prometheus_basic_auth_ref` schema.

## Preview pages

- [Monitor Redpanda Cloud](https://deploy-preview-582--rp-cloud.netlify.app/redpanda-cloud/manage/monitor-cloud/) (updated)

## Test plan

- [x] `npm run build` — clean (warnings are pre-existing in unrelated files)
- [x] `npm run serve` — new section renders, anchor `#connect-grafana` resolves, inline xref `<<configure-redpanda-monitoring>>` resolves
- [ ] Reviewer: verify the rendered page reads naturally and the Grafana flow is unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)