### PR TITLE
topics: Link to new cloud topic producers page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -340,6 +340,7 @@
 *** xref:develop:topics/create-topic.adoc[Overview]
 *** xref:develop:topics/config-topics.adoc[Manage Topics]
 *** xref:develop:topics/cloud-topics.adoc[Manage Cloud Topics]
+**** xref:develop:topics/configure-producers-for-cloud-topics.adoc[]
 ** xref:develop:produce-data/index.adoc[Produce Data]
 *** xref:develop:produce-data/configure-producers.adoc[]
 *** xref:develop:produce-data/idempotent-producers.adoc[Idempotent Producers]
@@ -670,4 +671,3 @@
 *** xref:reference:rpk/rpk-version.adoc[]
 ** xref:reference:public-metrics-reference.adoc[Metrics Reference]
 ** xref:reference:glossary.adoc[]
-

--- a/modules/develop/pages/topics/configure-producers-for-cloud-topics.adoc
+++ b/modules/develop/pages/topics/configure-producers-for-cloud-topics.adoc
@@ -1,0 +1,4 @@
+= Configure Producers for Cloud Topics
+:description: Learn about producer configuration considerations for Cloud Topics.
+
+include::ROOT:develop:manage-topics/configure-producers-for-cloud-topics.adoc[tag=single-source]


### PR DESCRIPTION
Reference the new page that explains cloud topic producer properties also from the cloud side.

## Preview pages

- [Configure Producers for Cloud Topics](https://deploy-preview-589--rp-cloud.netlify.app/redpanda-cloud/develop/topics/configure-producers-for-cloud-topics/) (new)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)