### PR TITLE
Add cloud-docs wrapper for the Configure Producers for Cloud Topics page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -340,6 +340,7 @@
 *** xref:develop:topics/create-topic.adoc[Overview]
 *** xref:develop:topics/config-topics.adoc[Manage Topics]
 *** xref:develop:topics/cloud-topics.adoc[Manage Cloud Topics]
+**** xref:develop:topics/configure-producers-for-cloud-topics.adoc[Configure Producers for Cloud Topics]
 ** xref:develop:produce-data/index.adoc[Produce Data]
 *** xref:develop:produce-data/configure-producers.adoc[]
 *** xref:develop:produce-data/idempotent-producers.adoc[Idempotent Producers]

--- a/modules/develop/pages/topics/configure-producers-for-cloud-topics.adoc
+++ b/modules/develop/pages/topics/configure-producers-for-cloud-topics.adoc
@@ -1,0 +1,4 @@
+= Configure Producers for Cloud Topics
+:description: Learn about producer configuration considerations for Cloud Topics.
+
+include::ROOT:develop:manage-topics/configure-producers-for-cloud-topics.adoc[tag=single-source]


### PR DESCRIPTION
## Summary

Self-managed docs PR [#1695](https://github.com/redpanda-data/docs/pull/1695) (2026-05-18, @StephanDollberg) added a new `configure-producers-for-cloud-topics.adoc` page and inserted an xref to it inside the single-sourced section of `manage-topics/cloud-topics.adoc`:

```asciidoc
// inside // tag::single-source[] ... // end::single-source[]
For client-side tuning guidance, see
xref:develop:manage-topics/configure-producers-for-cloud-topics.adoc[Configure producers for Cloud Topics].
```

The xref target exists in self-managed docs but **not** in cloud-docs, so cloud-docs main fails to build with:

```
ERROR (asciidoctor): target of xref not found:
  develop:manage-topics/configure-producers-for-cloud-topics.adoc
  file: modules/develop/pages/topics/cloud-topics.adoc
```

The new page is titled "Configure Producers for **Cloud Topics**" — its content is cloud-specific by name, so the right fix is to expose it on the cloud-docs side via a wrapper that single-sources the same page.

## Changes

- **Added** `modules/develop/pages/topics/configure-producers-for-cloud-topics.adoc` — a 4-line wrapper that single-sources from `ROOT:develop:manage-topics/configure-producers-for-cloud-topics.adoc`, matching the existing pattern used by `topics/cloud-topics.adoc`.
- **Updated** `modules/ROOT/nav.adoc` — added a sub-entry under the existing "Manage Cloud Topics" nav item.

## Preview pages

- [Configure Producers for Cloud Topics](https://deploy-preview-<n>--rp-cloud.netlify.app/redpanda-cloud/develop/topics/configure-producers-for-cloud-topics/) (will be live once the Netlify preview builds)

## Test plan

- [ ] Netlify deploy preview is green; no more `xref not found` for `configure-producers-for-cloud-topics` on cloud-docs.
- [ ] The new page renders content from the single-sourced section of the docs repo.
- [ ] The xref from `Manage Cloud Topics` (`cloud-topics.adoc`) to the new page resolves.
- [ ] The new nav entry shows up under *Develop → Topics → Manage Cloud Topics*.

## Note for next time

This is the same single-source xref-break pattern that hit the Schema Registry contexts page recently (docs#1707 + cloud-docs#588). Worth a note to the team: when adding a new page in the docs repo and xref'ing it from a single-sourced page, also add a matching wrapper in cloud-docs (or wrap the xref in `ifndef::env-cloud[]` if the target is genuinely self-managed-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)