### PR TITLE
billing: remove deprecated Remote MCP references

### DIFF
--- a/modules/billing/pages/billing.adoc
+++ b/modules/billing/pages/billing.adoc
@@ -129,25 +129,6 @@ Pricing per pipeline depends on the compute units you allocate. The cost of a co
 1 compute unit = 0.1 CPU + 400 MB memory
 |===
 
-== Remote MCP billing metrics
-
-Remote MCP usage appears as a separate line item on your invoice and uses the same pricing structure as Redpanda Connect.
-
-Pricing per MCP server depends on the compute units you allocate. The cost of a compute unit can vary based on the cloud provider and region you select for your cluster.
-
-[cols="1,3",options="header"]
-|===
-| Metric | Description
-
-| Compute | Tracks the server resources (vCPU and memory) an MCP server uses in compute units per hour. Where:
-
-1 compute unit = 0.1 CPU + 400 MB memory
-|===
-
-NOTE: Compute units for Remote MCP use the same definition and rates as those for Redpanda Connect.
-
-MCP servers automatically emit OpenTelemetry traces to the xref:ai-agents:observability/concepts.adoc#opentelemetry-traces-topic[`redpanda.otel_traces` topic]. For Serverless clusters, usage of this system-managed traces topic is not billed. You will not incur ingress, egress, storage, or partition charges for trace data. For Dedicated and BYOC clusters, standard billing metrics apply to the traces topic.
-
 == Support plans
 
 All organizations in Redpanda require one of the following support plans:

--- a/modules/billing/pages/manage-payment-methods.adoc
+++ b/modules/billing/pages/manage-payment-methods.adoc
@@ -6,7 +6,7 @@
 :learning-objective-2: Set a default payment method that Redpanda charges automatically
 :learning-objective-3: Update the billing contact information for your organization
 
-To pay for usage in Redpanda Cloud, you must add a credit card on the *Billing* page. The card you add is the payment method for all billable resources in your organization, including Serverless, Dedicated, and BYOC clusters, Redpanda Connect pipelines, Remote MCP servers, and your support plan. The most recently added card becomes the default payment method, but you can change the default at any time.
+To pay for usage in Redpanda Cloud, you must add a credit card on the *Billing* page. The card you add is the payment method for all billable resources in your organization, including Serverless, Dedicated, and BYOC clusters, Redpanda Connect pipelines, and your support plan. The most recently added card becomes the default payment method, but you can change the default at any time.
 
 After reading this page, you will be able to:
 

--- a/modules/billing/pages/view-billing-activity.adoc
+++ b/modules/billing/pages/view-billing-activity.adoc
@@ -28,7 +28,7 @@ After reading this page, you will be able to:
 The tab has three sections:
 
 * *Usage totals*: A high-level summary that subtotals usage by resource type (Dedicated, BYOC, Serverless) and shows the total amount owed for the selected time range. Expand any row to see the metrics that contribute to that subtotal. Amounts are shown before any discounts are applied.
-* *Resources breakdown*: A per-resource list showing the cost of each cluster, Redpanda Connect pipeline, Remote MCP server, and your support plan. Filter the list by:
+* *Resources breakdown*: A per-resource list showing the cost of each cluster, Redpanda Connect pipeline, and your support plan. Filter the list by:
 +
 ** Resource type: All, Dedicated, Serverless, Redpanda Connect pipeline, or Support.
 ** Resource group: Limit results to a specific resource group.


### PR DESCRIPTION
## Description

Resolves: no linked issue — incidental cleanup of pages missed by #562 (Remove deprecated ADP content) and `b4b87469` (Remove deprecated Remote MCP documentation).
Review deadline: none

Removes the `== Remote MCP billing metrics` section from the Billing page and strips incidental `Remote MCP` mentions from the Manage payment methods and View billing activity pages. Remote MCP was deprecated and removed from Redpanda Cloud; these three billing pages were missed in earlier cleanup PRs.

## Page previews

- [Billing and Support](https://deploy-preview-595--rp-cloud.netlify.app/redpanda-cloud/billing/billing/) (updated)
- [Manage Payment Methods](https://deploy-preview-595--rp-cloud.netlify.app/redpanda-cloud/billing/manage-payment-methods/) (updated)
- [View Billing Activity](https://deploy-preview-595--rp-cloud.netlify.app/redpanda-cloud/billing/view-billing-activity/) (updated)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [x] Small fix (typos, links, copyedits, etc)