### PR TITLE
overview: sync beta/LA list with marked pages

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -43,7 +43,7 @@ Redpanda Cloud applications are supported by three fully-managed deployment opti
 
 | *Deployment*
 | Redpanda's cloud (AWS/GCP)
-| Redpanda's cloud (AWS/Azure/GCP)
+| Redpanda's cloud (AWS/Azure/GCP)footnote:dedicated-azure-la[Dedicated on Azure is currently in glossterm:LA[, limited availability].]
 | Your cloud account (AWS/Azure/GCP)
 
 | *Redpanda ADP*
@@ -429,10 +429,12 @@ Features in beta are available for testing and feedback. They are not covered by
 
 The following features are currently in beta in Redpanda Cloud:
 
-* Serverless on GCP
-* BYOVNet on Azure
-* Secrets management for BYOVPC on GCP
-* Several Redpanda Connect components 
+* xref:get-started:cluster-types/serverless.adoc#get-started-with-serverless[Serverless on GCP]
+* xref:get-started:cluster-types/byoc/azure/vnet-azure.adoc[BYOVNet on Azure]
+* xref:get-started:cluster-types/byoc/gcp/enable-secrets-byovpc-gcp.adoc[Secrets management for BYOVPC on GCP]
+* xref:ai-agents:mcp/overview.adoc[Redpanda Cloud Management MCP Server]
+* xref:manage:iceberg/iceberg-topics-aws-glue.adoc[Querying Iceberg topics with AWS Glue]
+* xref:develop:managed-connectors/converters-and-serialization.adoc#protobuf-converter[Protobuf converter for managed connectors]
 
 include::shared:partial$suggested-video.adoc[]
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -43,7 +43,7 @@ Redpanda Cloud applications are supported by three fully-managed deployment opti
 
 | *Deployment*
 | Redpanda's cloud (AWS/GCP)
-| Redpanda's cloud (AWS/Azure/GCP)footnote:dedicated-azure-la[Dedicated on Azure is currently in glossterm:LA[, limited availability].]
+| Redpanda's cloud (AWS/Azure/GCP)footnote:dedicated-azure-la[Dedicated on Azure is in glossterm:LA[, limited availability].]
 | Your cloud account (AWS/Azure/GCP)
 
 | *Redpanda ADP*
@@ -141,7 +141,7 @@ Serverless is the fastest and easiest way to start data streaming. With Serverle
 
 [NOTE]
 ====
-* Serverless on GCP is currently in a glossterm:beta[] release. 
+* Serverless on GCP is in a glossterm:beta[] release.
 ====
 
 ==== Sign up for Serverless

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -421,7 +421,7 @@ Features in limited availability are production-ready and are covered by Redpand
 The following features are currently in limited availability in Redpanda Cloud:
 
 * xref:ai-agents:adp-overview.adoc[Redpanda Agentic Data Plane (ADP)]
-* Dedicated for Azure
+* xref:get-started:cluster-types/create-dedicated-cloud-cluster.adoc[Dedicated for Azure]
 
 == Features in beta
 

--- a/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
@@ -10,6 +10,8 @@ After you log in to https://cloud.redpanda.com[Redpanda Cloud^], you land on the
 +
 Enter a cluster name, then select the resource group, cloud provider (AWS, GCP, or Azure), xref:reference:tiers/dedicated-tiers.adoc[region, tier], availability, and Redpanda version.
 +
+IMPORTANT: Dedicated on Azure is currently in glossterm:LA[, limited availability]. It is production-ready and covered by Redpanda Support for early adopters. See xref:get-started:cloud-overview.adoc#features-in-limited-availability[Features in limited availability].
++
 [NOTE]
 ====
 * If you plan to create a private network in your own VPC, select the region where your VPC is located.

--- a/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
@@ -10,7 +10,7 @@ After you log in to https://cloud.redpanda.com[Redpanda Cloud^], you land on the
 +
 Enter a cluster name, then select the resource group, cloud provider (AWS, GCP, or Azure), xref:reference:tiers/dedicated-tiers.adoc[region, tier], availability, and Redpanda version.
 +
-IMPORTANT: Dedicated on Azure is currently in glossterm:LA[, limited availability]. It is production-ready and covered by Redpanda Support for early adopters.
+IMPORTANT: Dedicated on Azure is in glossterm:LA[, limited availability]. It is production-ready and covered by Redpanda Support for early adopters.
 +
 [NOTE]
 ====

--- a/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
+++ b/modules/get-started/pages/cluster-types/create-dedicated-cloud-cluster.adoc
@@ -10,7 +10,7 @@ After you log in to https://cloud.redpanda.com[Redpanda Cloud^], you land on the
 +
 Enter a cluster name, then select the resource group, cloud provider (AWS, GCP, or Azure), xref:reference:tiers/dedicated-tiers.adoc[region, tier], availability, and Redpanda version.
 +
-IMPORTANT: Dedicated on Azure is currently in glossterm:LA[, limited availability]. It is production-ready and covered by Redpanda Support for early adopters. See xref:get-started:cloud-overview.adoc#features-in-limited-availability[Features in limited availability].
+IMPORTANT: Dedicated on Azure is currently in glossterm:LA[, limited availability]. It is production-ready and covered by Redpanda Support for early adopters.
 +
 [NOTE]
 ====

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,9 +8,9 @@ This page lists new features added to Redpanda Cloud.
 
 == May 2026
 
-=== Centralized egress for BYOC on AWS (beta)
+=== Centralized egress for BYOC on AWS: beta
 
-You can route all BYOC cluster egress through your own AWS Transit Gateway and hub VPC instead of a per-VPC NAT Gateway, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that prohibit per-VPC NAT Gateways and for consolidating egress behind a single, predictable public IP for outbound allowlisting. Centralized egress is in beta and is enabled per organization. Contact your account team for access. See xref:networking:byoc/aws/nat-free-egress.adoc[Configure Centralized Egress with AWS Transit Gateway].
+You can route all BYOC cluster egress through your own AWS Transit Gateway and hub VPC instead of a per-VPC NAT Gateway, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that prohibit per-VPC NAT Gateways and for consolidating egress behind a single, predictable public IP for outbound allowlisting. Centralized egress is in a glossterm:beta[] release and is enabled per organization. Contact your account team for access. See xref:networking:byoc/aws/nat-free-egress.adoc[Configure Centralized Egress with AWS Transit Gateway].
 
 === Schema Registry Authorization enabled by default
 
@@ -411,7 +411,7 @@ See the link:/api/doc/cloud-controlplane/topic/topic-deprecation-policy[Cloud AP
 
 You can now xref:manage:cluster-maintenance/config-cluster.adoc#view-cluster-property-values[view the value of read-only cluster configuration properties] with `rpk cluster config` or with the Cloud API. Available properties are listed in xref:reference:properties/cluster-properties.adoc[Cluster Properties] and xref:reference:properties/object-storage-properties.adoc[Object Storage Properties].
 
-=== Iceberg topics in Azure (beta)
+=== Iceberg topics in Azure: beta
 
 xref:manage:iceberg/about-iceberg-topics.adoc[Iceberg topics] are now supported for BYOC clusters in Azure.
 


### PR DESCRIPTION
## Summary

- The cloud overview's *Features in beta* and *Features in limited availability* sections had drifted from the pages that actually mark themselves beta or LA via `:page-beta:` and the `adp-la.adoc` partial.
- Adds three missing beta entries (Redpanda Cloud Management MCP Server, Iceberg topics with AWS Glue, Protobuf converter for managed connectors) and links the three previously-unlinked beta bullets (Serverless on GCP, BYOVNet on Azure, Secrets management for BYOVPC on GCP) to their pages. Removes the generic "Several Redpanda Connect components" bullet.
- Flags Dedicated on Azure as LA on the Dedicated create page (where users pick AWS/GCP/Azure) and in the deployment comparison table footnote, so the LA status is visible at the point of decision, not just on the overview.
- Aligns the beta annotation style in *What's new* (e.g., `: beta` instead of `(beta)`, `glossterm:beta[]` for inline mentions) with the existing pattern used for `=== Dedicated on Azure: LA`.

## Preview pages

- [Redpanda Cloud Overview](https://deploy-preview-598--rp-cloud.netlify.app/redpanda-cloud/get-started/cloud-overview/) (updated)
- [Dedicated](https://deploy-preview-598--rp-cloud.netlify.app/redpanda-cloud/get-started/cluster-types/create-dedicated-cloud-cluster/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-598--rp-cloud.netlify.app/redpanda-cloud/get-started/whats-new-cloud/) (updated)

## Test plan

- [x] `npm run build` — no new warnings or xref errors from the changes
- [x] Visual check of `/redpanda-cloud/get-started/cloud-overview/#features-in-beta` and `#quick-comparison`
- [x] Visual check of `/redpanda-cloud/get-started/cluster-types/create-dedicated-cloud-cluster/` for the new IMPORTANT admonition
- [x] Visual check of `/redpanda-cloud/get-started/whats-new-cloud/` for the updated beta annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)