### PR TITLE
chore: bump docs-extensions-and-macros to v5 and wire new extensions

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -18,7 +18,7 @@ content:
     branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
-    start_paths: [home]
+    start_paths: [home, data-platform, self-managed]
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']
@@ -40,6 +40,12 @@ asciidoc:
   - '@redpanda-data/docs-extensions-and-macros/asciidoc-extensions/add-line-numbers-highlights'
 antora:
   extensions:
+  # Conditional home page redirect when agentic-data-plane component doesn't exist
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/conditional-home-redirect'
+  # Unified navigation extension (config-driven)
+  # Components with page-navigation attribute use that config
+  # Components without page-navigation use standard Antora navigation
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/unified-navigation'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: Redpanda Docs
-  start_page: redpanda-cloud:get-started:cloud-overview.adoc
+  start_page: cloud-data-platform:get-started:cloud-overview.adoc
   url: http://localhost:5002
   robots: disallow
   keys:
@@ -58,8 +58,8 @@ antora:
     data:
       replacements:
         - components:
-            - 'ROOT'
-            - 'redpanda-labs'
+            - 'streaming'
+            - 'labs'
           file_patterns:
             - '**/docker-compose.yaml'
             - '**/docker-compose.yml'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@antora/cli": "3.1.2",
         "@antora/site-generator": "3.1.2",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redpanda-data/docs-extensions-and-macros": "^4.0.0",
+        "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
         "@sntke/antora-mermaid-extension": "^0.0.6"
       },
       "devDependencies": {
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "4.15.8",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-4.15.8.tgz",
-      "integrity": "sha512-Zwv9ffNP8lKr2TheXrb51Av8KahCIUAVng9t+fDfwB0TnWS5+f3TkFaS6pU/7QBfr+lXBcweZL16phek+VhuGQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-5.0.0.tgz",
+      "integrity": "sha512-39rjNtv1oiHl/5vPYbkMwG+X6MYCc20868sfg4/Z5+WmcT0YcIuDtig/+CmbMHBmvuucRrUClk6DBYAtsUXoYQ==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@antora/cli": "3.1.2",
     "@antora/site-generator": "3.1.2",
     "@asciidoctor/tabs": "^1.0.0-beta.5",
-    "@redpanda-data/docs-extensions-and-macros": "^4.0.0",
+    "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
     "@sntke/antora-mermaid-extension": "^0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Add conditional-home-redirect and unified-navigation extensions, and extend docs-site start_paths with data-platform and self-managed.

## Description

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)