### PR TITLE
docs: document service account token daily rate limit

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -28,6 +28,10 @@ xref:security:cloud-authentication.adoc#account-impersonation[Account impersonat
 
 The free trial for Redpanda Serverless now lasts 30 days, up from 14 days. The $100 (USD) credit allowance and 7-day grace period are unchanged. Sign up at https://www.redpanda.com/try-data-streaming[redpanda.com^]. See xref:get-started:cluster-types/serverless.adoc[Serverless clusters].
 
+=== Service account token rate limits
+
+A daily limit now applies to service account access token requests for each organization. Clients that exceed the limit receive `HTTP 429` responses. Cache tokens until close to expiry to stay within the limit, and contact Redpanda Support if your workload requires a higher daily limit. See xref:security:cloud-authentication.adoc#service-account-token-rate-limits[Service account token rate limits].
+
 == April 2026
 
 === Self-service sign-up through Google Cloud Marketplace

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -311,10 +311,10 @@ Redpanda Cloud enforces a daily limit on service account access token requests t
 
 Most workloads do not approach this limit. Access tokens are valid for several hours, so cache the token returned by the `/oauth/token` endpoint and reuse it until close to expiry rather than requesting a new token for each API call.
 
-Every response from the token endpoint, including responses that return `HTTP 429`, includes an `Auth0-Organization-Quota-Limit` header that reports your organization's current quota usage. The header carries one or more comma-separated buckets in the form `b=<window>;q=<limit>;r=<remaining>;t=<seconds-to-reset>`. For example:
+Every response from the token endpoint, including responses that return `HTTP 429`, includes an `Auth0-Organization-Quota-Limit` header that reports your organization's current daily quota usage. The header value has the form `b=<window>;q=<limit>;r=<remaining>;t=<seconds-to-reset>`. For example:
 
 ----
-Auth0-Organization-Quota-Limit: b=per_hour;q=50;r=47;t=3540,b=per_day;q=250;r=247;t=43200
+Auth0-Organization-Quota-Limit: b=per_day;q=100;r=83;t=43200
 ----
 
 [cols="1,3"]
@@ -322,10 +322,10 @@ Auth0-Organization-Quota-Limit: b=per_hour;q=50;r=47;t=3540,b=per_day;q=250;r=24
 |Field |Description
 
 |`b`
-|Bucket window. For example, `per_hour` or `per_day`.
+|Quota window. Redpanda Cloud uses `per_day`.
 
 |`q`
-|The bucket's token-issuance limit.
+|The token-issuance limit for the window.
 
 |`r`
 |Tokens remaining in the current window.
@@ -334,7 +334,7 @@ Auth0-Organization-Quota-Limit: b=per_hour;q=50;r=47;t=3540,b=per_day;q=250;r=24
 |Seconds until the current window resets.
 |===
 
-When the token endpoint returns `HTTP 429`, find the bucket whose `r` is `0` and back off for that bucket's `t` seconds before retrying.
+When the token endpoint returns `HTTP 429`, back off for `t` seconds before retrying.
 
 If your workload requires a higher daily limit, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your organization ID and your expected token issuance rate.
 

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -297,6 +297,22 @@ Make sure to replace the following variables:
 |Client secret.
 |===
 
+=== Service account token rate limits
+
+Redpanda Cloud enforces a daily limit on service account access token requests to `\https://auth.prd.cloud.redpanda.com/oauth/token` for each organization. When you exceed the limit, the token endpoint returns `HTTP 429` with the following response body:
+
+[,json]
+----
+{
+  "error": "too_many_requests",
+  "error_description": "Organization quota exceeded"
+}
+----
+
+Most workloads do not approach this limit. Access tokens are valid for several hours, so cache the token returned by the `/oauth/token` endpoint and reuse it until close to expiry rather than requesting a new token for each API call.
+
+If your workload requires a higher daily limit, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your organization ID and your expected token issuance rate.
+
 [[mtls]]
 === Enable mTLS authentication
 :description: Use the Cloud API to enable mTLS for Kafka API, HTTP Proxy, and Schema Registry connections on your Redpanda cluster.

--- a/modules/security/pages/cloud-authentication.adoc
+++ b/modules/security/pages/cloud-authentication.adoc
@@ -311,6 +311,31 @@ Redpanda Cloud enforces a daily limit on service account access token requests t
 
 Most workloads do not approach this limit. Access tokens are valid for several hours, so cache the token returned by the `/oauth/token` endpoint and reuse it until close to expiry rather than requesting a new token for each API call.
 
+Every response from the token endpoint, including responses that return `HTTP 429`, includes an `Auth0-Organization-Quota-Limit` header that reports your organization's current quota usage. The header carries one or more comma-separated buckets in the form `b=<window>;q=<limit>;r=<remaining>;t=<seconds-to-reset>`. For example:
+
+----
+Auth0-Organization-Quota-Limit: b=per_hour;q=50;r=47;t=3540,b=per_day;q=250;r=247;t=43200
+----
+
+[cols="1,3"]
+|===
+|Field |Description
+
+|`b`
+|Bucket window. For example, `per_hour` or `per_day`.
+
+|`q`
+|The bucket's token-issuance limit.
+
+|`r`
+|Tokens remaining in the current window.
+
+|`t`
+|Seconds until the current window resets.
+|===
+
+When the token endpoint returns `HTTP 429`, find the bucket whose `r` is `0` and back off for that bucket's `t` seconds before retrying.
+
 If your workload requires a higher daily limit, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your organization ID and your expected token issuance rate.
 
 [[mtls]]


### PR DESCRIPTION
## Summary

- Adds a `Service account token rate limits` subsection under `Authenticate to the Cloud API` in `modules/security/pages/cloud-authentication.adoc`, covering the `HTTP 429` response, token caching guidance, and the path to contact Redpanda Support for higher daily limits.
- Adds a matching May 2026 entry to `modules/get-started/pages/whats-new-cloud.adoc` linking back to the new subsection.

Reference (internal): cupboard `engineering/auth/2026-05-22-service-account-token-rate-limit.md` and the matching runbook.

## Preview pages

- [Authentication](https://deploy-preview-600--rp-cloud.netlify.app/cloud-data-platform/security/cloud-authentication/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-600--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)

## Test plan

- [ ] Local Antora build completes without new warnings or broken xrefs for the changed files
- [ ] `Security > Authentication > Service account token rate limits` renders below `Authenticate to the Cloud API` and above `Enable mTLS authentication`
- [ ] `Get Started > What's New > May 2026 > Service account token rate limits` renders and the `See` link resolves to the new anchor on the authentication page
- [ ] No em dashes; sentence-case headings; second-person voice; passes docs-team-standards review on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)