### PR TITLE
docs: Single-source missing Connect component pages

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -97,6 +97,7 @@
 **** xref:develop:connect/components/inputs/redpanda_common.adoc[]
 **** xref:develop:connect/components/inputs/redpanda_migrator.adoc[]
 **** xref:develop:connect/components/inputs/resource.adoc[]
+**** xref:develop:connect/components/inputs/salesforce.adoc[]
 **** xref:develop:connect/components/inputs/salesforce_cdc.adoc[]
 **** xref:develop:connect/components/inputs/salesforce_graphql.adoc[]
 **** xref:develop:connect/components/inputs/schema_registry.adoc[]
@@ -132,6 +133,7 @@
 **** xref:develop:connect/components/outputs/elasticsearch_v8.adoc[]
 **** xref:develop:connect/components/outputs/fallback.adoc[]
 **** xref:develop:connect/components/outputs/gcp_bigquery.adoc[]
+**** xref:develop:connect/components/outputs/gcp_bigquery_write_api.adoc[]
 **** xref:develop:connect/components/outputs/gcp_cloud_storage.adoc[]
 **** xref:develop:connect/components/outputs/gcp_pubsub.adoc[]
 **** xref:develop:connect/components/outputs/iceberg.adoc[]
@@ -304,10 +306,12 @@
 *** xref:develop:connect/components/tracers/about.adoc[]
 **** xref:develop:connect/components/tracers/gcp_cloudtrace.adoc[]
 **** xref:develop:connect/components/tracers/none.adoc[]
+**** xref:develop:connect/components/tracers/open_telemetry_collector.adoc[]
 **** xref:develop:connect/components/tracers/redpanda.adoc[]
 
 *** xref:develop:connect/components/metrics/about.adoc[]
 **** xref:develop:connect/components/metrics/none.adoc[]
+**** xref:develop:connect/components/metrics/open_telemetry_collector.adoc[]
 **** xref:develop:connect/components/metrics/prometheus.adoc[]
 
 *** xref:develop:connect/components/redpanda/about.adoc[Redpanda]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -243,7 +243,6 @@
 **** xref:develop:connect/components/processors/redis_script.adoc[]
 **** xref:develop:connect/components/processors/resource.adoc[]
 **** xref:develop:connect/components/processors/retry.adoc[]
-**** xref:develop:connect/components/processors/salesforce.adoc[]
 **** xref:develop:connect/components/processors/schema_registry_decode.adoc[]
 **** xref:develop:connect/components/processors/schema_registry_encode.adoc[]
 **** xref:develop:connect/components/processors/select_parts.adoc[]

--- a/modules/develop/pages/connect/components/inputs/salesforce.adoc
+++ b/modules/develop/pages/connect/components/inputs/salesforce.adoc
@@ -1,0 +1,3 @@
+= salesforce
+:page-aliases: components:inputs/salesforce.adoc
+include::connect:components:inputs/salesforce.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/metrics/open_telemetry_collector.adoc
+++ b/modules/develop/pages/connect/components/metrics/open_telemetry_collector.adoc
@@ -1,0 +1,3 @@
+= open_telemetry_collector
+:page-aliases: components:metrics/open_telemetry_collector.adoc
+include::connect:components:metrics/open_telemetry_collector.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/outputs/gcp_bigquery_write_api.adoc
+++ b/modules/develop/pages/connect/components/outputs/gcp_bigquery_write_api.adoc
@@ -1,0 +1,3 @@
+= gcp_bigquery_write_api
+:page-aliases: components:outputs/gcp_bigquery_write_api.adoc
+include::connect:components:outputs/gcp_bigquery_write_api.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/processors/salesforce.adoc
+++ b/modules/develop/pages/connect/components/processors/salesforce.adoc
@@ -1,3 +1,0 @@
-= salesforce
-:page-aliases: components:processors/salesforce.adoc, components:inputs/salesforce.adoc
-include::connect:components:inputs/salesforce.adoc[tag=single-source]

--- a/modules/develop/pages/connect/components/tracers/open_telemetry_collector.adoc
+++ b/modules/develop/pages/connect/components/tracers/open_telemetry_collector.adoc
@@ -1,0 +1,3 @@
+= open_telemetry_collector
+:page-aliases: components:tracers/open_telemetry_collector.adoc
+include::connect:components:tracers/open_telemetry_collector.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -24,34 +24,27 @@ Schema Registry Authorization is now enabled automatically on all new BYOC and D
 
 xref:security:cloud-authentication.adoc#account-impersonation[Account impersonation] now supports Schema Registry in addition to the Kafka API. With Schema Registry impersonation enabled, the schemas and subjects users see in the Redpanda Cloud UI match exactly what they can access with the Cloud API or `rpk`. You can enable impersonation independently for each subsystem from the *Dataplane settings* page.
 
-=== New Redpanda Connect component pages
+=== Redpanda Connect updates
 
-Added documentation for the following Redpanda Connect components:
+* Inputs:
+** xref:develop:connect/components/inputs/salesforce.adoc[salesforce]: Executes a SOQL query against Salesforce and emits one message per record.
+** xref:develop:connect/components/inputs/salesforce_cdc.adoc[salesforce_cdc]: Captures change data from Salesforce objects using the Pub/Sub API.
+** xref:develop:connect/components/inputs/salesforce_graphql.adoc[salesforce_graphql]: Executes GraphQL queries against Salesforce.
+* Outputs:
+** xref:develop:connect/components/outputs/gcp_bigquery_write_api.adoc[gcp_bigquery_write_api]: Writes records to BigQuery using the Storage Write API for higher throughput and lower latency than the streaming insert API.
+* Metrics:
+** xref:develop:connect/components/metrics/open_telemetry_collector.adoc[open_telemetry_collector]: Pushes metrics using the OpenTelemetry Protocol (OTLP) over HTTP or gRPC.
+* Tracers:
+** xref:develop:connect/components/tracers/open_telemetry_collector.adoc[open_telemetry_collector]: Pushes tracing data using the OpenTelemetry Protocol (OTLP) over HTTP or gRPC.
 
-* xref:develop:connect/components/inputs/salesforce.adoc[salesforce input]: Executes a SOQL query against Salesforce and emits one message per record.
-* xref:develop:connect/components/outputs/gcp_bigquery_write_api.adoc[gcp_bigquery_write_api output]: Writes records to BigQuery using the Storage Write API.
-* xref:develop:connect/components/metrics/open_telemetry_collector.adoc[open_telemetry_collector metrics]: Pushes metrics using the OpenTelemetry Protocol.
-* xref:develop:connect/components/tracers/open_telemetry_collector.adoc[open_telemetry_collector tracer]: Pushes tracing data using the OpenTelemetry Protocol.
+* Behavior changes:
+** xref:develop:connect/components/outputs/gcp_bigquery_write_api.adoc[`gcp_bigquery_write_api`] output: The default value of `max_in_flight` has been reduced from `64` to `4`. If you rely on the previous behavior for throughput, set `max_in_flight` explicitly in your pipeline configuration. The output also gained new fields for tuning Storage Write API behavior: `max_cached_streams`, `schema_resolve_timeout`, and `schema_evolution_timeout`.
 
-=== Salesforce connector refactoring
+* New field support:
+** Kafka producer tuning fields on the xref:develop:connect/components/outputs/kafka_franz.adoc[`kafka_franz`] and xref:develop:connect/components/outputs/redpanda.adoc[`redpanda`] outputs: `acks`, `max_in_flight_requests`, `max_buffered_records`, `max_buffered_bytes`, `record_retries`, and `record_delivery_timeout`. Use these to align pipeline producers with broker durability and back-pressure requirements.
 
-The `salesforce` processor (introduced in April 2026) has been removed and replaced with dedicated input components that provide the same functionality with better separation of concerns:
-
-[cols="1,2"]
-|===
-|New component |Use case
-
-|xref:develop:connect/components/inputs/salesforce.adoc[salesforce input]
-|Executes SOQL queries against Salesforce.
-
-|xref:develop:connect/components/inputs/salesforce_cdc.adoc[salesforce_cdc input]
-|Captures change data from Salesforce objects using the Pub/Sub API.
-
-|xref:develop:connect/components/inputs/salesforce_graphql.adoc[salesforce_graphql input]
-|Executes GraphQL queries against Salesforce.
-|===
-
-The xref:develop:connect/components/outputs/salesforce_sink.adoc[salesforce_sink output] remains available.
+* Removed components:
+** `salesforce` processor (introduced in April 2026): Replaced with the dedicated xref:develop:connect/components/inputs/salesforce.adoc[`salesforce`], xref:develop:connect/components/inputs/salesforce_cdc.adoc[`salesforce_cdc`], and xref:develop:connect/components/inputs/salesforce_graphql.adoc[`salesforce_graphql`] inputs. The xref:develop:connect/components/outputs/salesforce_sink.adoc[`salesforce_sink`] output remains available.
 
 === Extended Serverless free trial
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -24,6 +24,35 @@ Schema Registry Authorization is now enabled automatically on all new BYOC and D
 
 xref:security:cloud-authentication.adoc#account-impersonation[Account impersonation] now supports Schema Registry in addition to the Kafka API. With Schema Registry impersonation enabled, the schemas and subjects users see in the Redpanda Cloud UI match exactly what they can access with the Cloud API or `rpk`. You can enable impersonation independently for each subsystem from the *Dataplane settings* page.
 
+=== New Redpanda Connect component pages
+
+Added documentation for the following Redpanda Connect components:
+
+* xref:develop:connect/components/inputs/salesforce.adoc[salesforce input]: Executes a SOQL query against Salesforce and emits one message per record.
+* xref:develop:connect/components/outputs/gcp_bigquery_write_api.adoc[gcp_bigquery_write_api output]: Writes records to BigQuery using the Storage Write API.
+* xref:develop:connect/components/metrics/open_telemetry_collector.adoc[open_telemetry_collector metrics]: Pushes metrics using the OpenTelemetry Protocol.
+* xref:develop:connect/components/tracers/open_telemetry_collector.adoc[open_telemetry_collector tracer]: Pushes tracing data using the OpenTelemetry Protocol.
+
+=== Salesforce connector refactoring
+
+The xref:develop:connect/components/processors/salesforce.adoc[salesforce processor] (introduced in April 2026) has been removed and replaced with dedicated input components that provide the same functionality with better separation of concerns:
+
+[cols="1,2"]
+|===
+|New component |Use case
+
+|xref:develop:connect/components/inputs/salesforce.adoc[salesforce input]
+|Executes SOQL queries against Salesforce.
+
+|xref:develop:connect/components/inputs/salesforce_cdc.adoc[salesforce_cdc input]
+|Captures change data from Salesforce objects using the Pub/Sub API.
+
+|xref:develop:connect/components/inputs/salesforce_graphql.adoc[salesforce_graphql input]
+|Executes GraphQL queries against Salesforce.
+|===
+
+The xref:develop:connect/components/outputs/salesforce_sink.adoc[salesforce_sink output] remains available.
+
 === Extended Serverless free trial
 
 The free trial for Redpanda Serverless now lasts 30 days, up from 14 days. The $100 (USD) credit allowance and 7-day grace period are unchanged. Sign up at https://www.redpanda.com/try-data-streaming[redpanda.com^]. See xref:get-started:cluster-types/serverless.adoc[Serverless clusters].

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -35,7 +35,7 @@ Added documentation for the following Redpanda Connect components:
 
 === Salesforce connector refactoring
 
-The xref:develop:connect/components/processors/salesforce.adoc[salesforce processor] (introduced in April 2026) has been removed and replaced with dedicated input components that provide the same functionality with better separation of concerns:
+The `salesforce` processor (introduced in April 2026) has been removed and replaced with dedicated input components that provide the same functionality with better separation of concerns:
 
 [cols="1,2"]
 |===
@@ -94,7 +94,7 @@ The Redpanda Terraform provider (v1.6.0+) now supports https://developer.hashico
 ** xref:develop:connect/components/outputs/salesforce_sink.adoc[salesforce_sink]: Write messages to Salesforce, routing each Kafka topic to its own sObject configuration. Supports both realtime (sObject Collections REST API) and bulk modes (Bulk API 2.0).
 * Processors:
 ** xref:develop:connect/components/processors/string_split.adoc[string_split]: Splits strings into multiple parts using a delimiter, creating new messages or fields for each part.
-** xref:develop:connect/components/processors/salesforce.adoc[salesforce]: Fetch data from Salesforce based on input messages. Supports sObject REST snapshots, SOQL queries via REST or GraphQL, Change Data Capture (CDC) streaming, and Platform Events via the Pub/Sub gRPC API.
+** `salesforce` (deprecated May 2026): Replaced with dedicated xref:develop:connect/components/inputs/salesforce.adoc[salesforce], xref:develop:connect/components/inputs/salesforce_cdc.adoc[salesforce_cdc], and xref:develop:connect/components/inputs/salesforce_graphql.adoc[salesforce_graphql] inputs.
 
 == March 2026
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@antora/cli": "3.1.2",
         "@antora/site-generator": "3.1.2",
         "@asciidoctor/tabs": "^1.0.0-beta.5",
-        "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
+        "@redpanda-data/docs-extensions-and-macros": "^5.0.2",
         "@sntke/antora-mermaid-extension": "^0.0.6"
       },
       "devDependencies": {
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-5.0.0.tgz",
-      "integrity": "sha512-39rjNtv1oiHl/5vPYbkMwG+X6MYCc20868sfg4/Z5+WmcT0YcIuDtig/+CmbMHBmvuucRrUClk6DBYAtsUXoYQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-5.0.2.tgz",
+      "integrity": "sha512-QecykqggIMKKxu4T//272/RImrhueBGWpgeSwJYAeg7O6GNCXYZDnbCAgtscLp1fNjHrR5Eay1m4tT/thPZGIg==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@antora/cli": "3.1.2",
     "@antora/site-generator": "3.1.2",
     "@asciidoctor/tabs": "^1.0.0-beta.5",
-    "@redpanda-data/docs-extensions-and-macros": "^5.0.0",
+    "@redpanda-data/docs-extensions-and-macros": "^5.0.2",
     "@sntke/antora-mermaid-extension": "^0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds stub pages for Redpanda Connect components that were missing from cloud-docs, fixing build warnings about missing cloud docs.

## Changes

- Added single-sourced stub pages for:
  - `inputs/salesforce` - Salesforce SOQL query input
  - `outputs/gcp_bigquery_write_api` - BigQuery Storage Write API output
  - `metrics/open_telemetry_collector` - OpenTelemetry metrics exporter
  - `tracers/open_telemetry_collector` - OpenTelemetry tracing exporter

- Added nav entries in alphabetical order
- Added What's New entry for May 2026

## Build warnings fixed

```
WARN (redpanda-connect-info-extension): Cloud docs missing for: gcp_bigquery_write_api of type: output
WARN (redpanda-connect-info-extension): Cloud docs missing for: open_telemetry_collector of type: metric
WARN (redpanda-connect-info-extension): Cloud docs missing for: open_telemetry_collector of type: tracer
WARN (redpanda-connect-info-extension): Cloud docs missing for: salesforce of type: input
```

## Preview pages

- [salesforce input](https://deploy-preview-601--rp-cloud.netlify.app/cloud-data-platform/develop/connect/components/inputs/salesforce/) (new)
- [gcp_bigquery_write_api output](https://deploy-preview-601--rp-cloud.netlify.app/cloud-data-platform/develop/connect/components/outputs/gcp_bigquery_write_api/) (new)
- [open_telemetry_collector metrics](https://deploy-preview-601--rp-cloud.netlify.app/cloud-data-platform/develop/connect/components/metrics/open_telemetry_collector/) (new)
- [open_telemetry_collector tracer](https://deploy-preview-601--rp-cloud.netlify.app/cloud-data-platform/develop/connect/components/tracers/open_telemetry_collector/) (new)
- [What's New in Redpanda Cloud](https://deploy-preview-601--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
