### PR TITLE
docs: Wire up single-sourced Cloud Topics page

### DIFF
--- a/modules/develop/pages/topics/cloud-topics.adoc
+++ b/modules/develop/pages/topics/cloud-topics.adoc
@@ -1,5 +1,4 @@
 = Manage Cloud Topics
 :description: Cloud Topics are Redpanda topics that enable users to trade off latency for lower costs.
 
-// TODO: Single-source this content when streaming component has cloud-topics file
-// For now, this page exists as a placeholder
+include::streaming:develop:manage-topics/cloud-topics.adoc[tag=single-source]


### PR DESCRIPTION
## What

The Cloud Topics page (`develop/topics/cloud-topics.adoc`) was rendering blank in production. It was never wired up for single-sourcing: it was still a placeholder stub with a `// TODO` comment and no `include::` directive, so it had a title (appeared in nav) but no body.

This replaces the placeholder with an include of the source page in the `streaming` component (docs repo), matching the sibling `configure-producers-for-cloud-topics.adoc` page:

```asciidoc
include::streaming:develop:manage-topics/cloud-topics.adoc[tag=single-source]
```

## How it slipped through

1. The source page was created in the docs repo while the component was still `ROOT`.
2. The placeholder stub was added here with a TODO to wire it up "when streaming component has cloud-topics file."
3. The docs repo component was renamed `ROOT` -> `streaming`, satisfying that condition.
4. The sibling producers page was wired up, but this stub was forgotten.

## Companion PR (required)

- redpanda-data/docs#1722 fixes two cloud-divergent xrefs in the single-sourced content. The links on this page only resolve cleanly once that PR merges.

## Verification

Built locally against the docs PR branch. The page renders in full (overview, Prerequisites, Limitations, Enable Cloud Topics), the cloud-only Prerequisites branch shows while self-managed-only content is excluded, and all outbound links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview pages

- [Manage Cloud Topics](https://deploy-preview-604--rp-cloud.netlify.app/cloud-data-platform/develop/topics/cloud-topics/) (updated)