### PR TITLE
rpk cloud auth token reference

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: ['DOC-2218-add-reference-for-rpk-cloud-auth-token', v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: ['DOC-2218-add-reference-for-rpk-cloud-auth-token', v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -793,6 +793,7 @@
 **** xref:reference:rpk/rpk-cloud/rpk-cloud-auth.adoc[]
 ***** xref:reference:rpk/rpk-cloud/rpk-cloud-auth-delete.adoc[]
 ***** xref:reference:rpk/rpk-cloud/rpk-cloud-auth-list.adoc[]
+***** xref:reference:rpk/rpk-cloud/rpk-cloud-auth-token.adoc[]
 ***** xref:reference:rpk/rpk-cloud/rpk-cloud-auth-use.adoc[]
 **** xref:reference:rpk/rpk-cloud/rpk-cloud-byoc.adoc[]
 ***** xref:reference:rpk/rpk-cloud/rpk-cloud-byoc-install.adoc[]

--- a/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-token.adoc
+++ b/modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-token.adoc
@@ -1,0 +1,3 @@
+= rpk cloud auth token
+
+include::streaming:reference:partial$rpk-cloud/rpk-cloud-auth-token.adoc[tag=single-source]

--- a/modules/sql/pages/connect-to-sql/authenticate.adoc
+++ b/modules/sql/pages/connect-to-sql/authenticate.adoc
@@ -28,7 +28,7 @@ Redpanda SQL supports three authentication modes, selected by the connection-str
 
 |Bearer token
 |`auth_method=bearer`
-|You already hold a JSON Web Token (JWT) issued by Redpanda Cloud (for example, returned by `rpk cloud auth token`).
+|You already hold a JSON Web Token (JWT) issued by Redpanda Cloud (for example, returned by xref:reference:rpk/rpk-cloud/rpk-cloud-auth-token.adoc[`rpk cloud auth token`]).
 
 |Client credentials
 |`auth_method=client_secret`

--- a/modules/sql/pages/get-started/deploy-sql-cluster.adoc
+++ b/modules/sql/pages/get-started/deploy-sql-cluster.adoc
@@ -170,7 +170,7 @@ To connect using a bearer token (xref:manage:rpk/rpk-install.adoc[`rpk` v26.1.6+
 rpk cloud login
 ----
 
-. Retrieve a temporary authentication token for the SQL engine:
+. Retrieve a temporary authentication token for the SQL engine using xref:reference:rpk/rpk-cloud/rpk-cloud-auth-token.adoc[`rpk cloud auth token`]:
 +
 [,bash]
 ----

--- a/modules/sql/pages/get-started/sql-quickstart.adoc
+++ b/modules/sql/pages/get-started/sql-quickstart.adoc
@@ -109,7 +109,7 @@ SQL connection details are available on your cluster's *SQL* tab in the https://
 rpk cloud login
 ----
 
-. Retrieve a temporary authentication token for the SQL engine:
+. Retrieve a temporary authentication token for the SQL engine using xref:reference:rpk/rpk-cloud/rpk-cloud-auth-token.adoc[`rpk cloud auth token`]:
 +
 [,bash]
 ----


### PR DESCRIPTION
## Description

Related: https://github.com/redpanda-data/docs/pull/1723

This pull request adds documentation for the new `rpk cloud auth token` command and updates related references throughout the documentation. The main changes include creating a dedicated reference page for the command, updating the navigation, and ensuring that relevant guides link to the new documentation.

**Documentation additions and updates:**

* Added a new reference page for the `rpk cloud auth token` command at `modules/reference/pages/rpk/rpk-cloud/rpk-cloud-auth-token.adoc`.
* Updated the navigation in `modules/ROOT/nav.adoc` to include the new `rpk-cloud-auth-token` reference.
* Updated SQL authentication documentation in `modules/sql/pages/connect-to-sql/authenticate.adoc` to link to the new reference page for `rpk cloud auth token`.
* Updated SQL getting started guides (`modules/sql/pages/get-started/sql-quickstart.adoc` and `modules/sql/pages/get-started/deploy-sql-cluster.adoc`) to reference the new `rpk cloud auth token` documentation when instructing users to retrieve a temporary authentication token.

**Build configuration:**

* Updated the `local-antora-playbook.yml` to use the correct branch (`DOC-2218-add-reference-for-rpk-cloud-auth-token`) for the documentation source, ensuring the new reference page is included in local builds.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

- [rpk cloud auth token](https://deploy-preview-605--rp-cloud.netlify.app/cloud-data-platform/reference/rpk/rpk-cloud/rpk-cloud-auth-token/) (new)
- [Authenticate to Redpanda SQL](https://deploy-preview-605--rp-cloud.netlify.app/cloud-data-platform/sql/connect-to-sql/authenticate/) (updated)
- [Enable Redpanda SQL on a BYOC Cluster](https://deploy-preview-605--rp-cloud.netlify.app/cloud-data-platform/sql/get-started/deploy-sql-cluster/) (updated)
- [Redpanda SQL Quickstart](https://deploy-preview-605--rp-cloud.netlify.app/cloud-data-platform/sql/get-started/sql-quickstart/) (updated)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
