### PR TITLE
docs(DOC-2012): mirror Kafka Compatibility frontmatter on cloud stub

### DIFF
--- a/modules/develop/pages/kafka-clients.adoc
+++ b/modules/develop/pages/kafka-clients.adoc
@@ -1,5 +1,9 @@
 = Kafka Compatibility
 :page-aliases: development:kafka-clients.adoc
 :description: Kafka clients, version 0.11 or later, are compatible with Redpanda. Validations and exceptions are listed.
+:page-topic-type: reference
+:personas: developer
+:learning-objective-1: Identify which Kafka clients are validated with Redpanda
+:learning-objective-2: Identify unsupported Kafka features when integrating with Redpanda
 
 include::streaming:develop:kafka-clients.adoc[tag=single-source]


### PR DESCRIPTION
## Summary

Companion to [redpanda-data/docs#1614](https://github.com/redpanda-data/docs/pull/1614). Resolves [DOC-2012](https://redpandadata.atlassian.net/browse/DOC-2012) on the cloud side.

The docs-side page (`docs/modules/develop/pages/kafka-clients.adoc`) added `page-topic-type`, `personas`, and two learning objectives in the frontmatter so the page carries proper metadata in the streaming component. The cloud stub `cloud-docs/modules/develop/pages/kafka-clients.adoc` includes the body via `include::streaming:develop:kafka-clients.adoc[tag=single-source]` but Antora does **not** inherit frontmatter through a single-source include — it has to live in the stub.

This PR mirrors the same four attributes on the cloud stub so the page renders with consistent metadata under `/cloud-data-platform/`.

This is the **Pattern B** fix `@micheleRP` recommended: leave the docs-side header as-is, duplicate the frontmatter on the cloud stub. Reference stubs that follow the same pattern: `schema-reg-contexts.adoc`, `manage-throughput.adoc`.

## Preview pages

- [Kafka Compatibility (cloud)](https://deploy-preview-606--rp-cloud.netlify.app/cloud-data-platform/develop/kafka-clients/)

## Test plan

- [ ] Netlify preview builds without errors
- [ ] Page renders the new metadata (topic type, persona, learning objectives) at `/cloud-data-platform/develop/kafka-clients/`
- [ ] Body content (Kafka 4.x scope, KIP-890 bullet, terminology fixes) is unchanged — it still comes from the docs single-source include

[DOC-2012]: https://redpandadata.atlassian.net/browse/DOC-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ