### PR TITLE
docs(DOC-2222): document customer-managed default topic properties

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -14,8 +14,11 @@ content:
   sources:
   - url: .
     branches: HEAD
+  # TEMPORARY (DOC-2222): pull the streaming component from the docs PR branch
+  # (redpanda-data/docs#1728) instead of main so the deploy preview renders the
+  # three customer-managed Cloud properties. REVERT to `main` before merging.
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: [doc-2222-cloud-cmc-default-topic-props, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -6,6 +6,12 @@
 
 This page lists new features added to Redpanda Cloud.
 
+== June 2026
+
+=== Customer-managed default topic settings
+
+You can now set cluster-wide defaults for new topics on BYOC and Dedicated clusters. The xref:reference:properties/cluster-properties.adoc#default_topic_partitions[`default_topic_partitions`], xref:reference:properties/cluster-properties.adoc#log_retention_ms[`log_retention_ms`], and xref:reference:properties/cluster-properties.adoc#retention_bytes[`retention_bytes`] cluster properties are now customer-managed. The default topic retention period (`log_retention_ms`) previously could only be changed by Redpanda support. See xref:manage:cluster-maintenance/config-cluster.adoc[Configure Cluster Properties].
+
 == May 2026
 
 === Redpanda SQL

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -108,7 +108,7 @@ NOTE: Some properties require a rolling restart for the update to take effect. T
 
 == Set default topic properties
 
-You can set cluster-wide defaults that apply to new topics on BYOC and Dedicated clusters:
+You can set cluster-wide defaults that apply to new topics:
 
 [cols="1,3a"]
 |===
@@ -118,7 +118,7 @@ You can set cluster-wide defaults that apply to new topics on BYOC and Dedicated
 | Default number of partitions for new topics.
 
 | xref:reference:properties/cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
-| Default length of time to retain topic data before it becomes eligible for deletion. This sets the default topic retention period, which applies when a topic doesn't set its own `retention.ms`. Previously, this default could only be changed by Redpanda support.
+| Default length of time to retain topic data before it becomes eligible for deletion. This sets the default topic retention period, which applies when a topic doesn't set its own `retention.ms`.  
 
 | xref:reference:properties/cluster-properties.adoc#retention_bytes[`retention_bytes`]
 | Default maximum size per partition before the oldest data becomes eligible for deletion. Applies when a topic doesn't set its own `retention.bytes`.

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -106,6 +106,31 @@ NOTE: Some properties require a rolling restart for the update to take effect. T
 --
 ====
 
+== Set default topic properties
+
+You can set cluster-wide defaults that apply to new topics on BYOC and Dedicated clusters:
+
+[cols="1,3a"]
+|===
+| Property | Description
+
+| xref:reference:properties/cluster-properties.adoc#default_topic_partitions[`default_topic_partitions`]
+| Default number of partitions for new topics.
+
+| xref:reference:properties/cluster-properties.adoc#log_retention_ms[`log_retention_ms`]
+| Default length of time to retain topic data before it becomes eligible for deletion. This sets the default topic retention period, which applies when a topic doesn't set its own `retention.ms`. Previously, this default could only be changed by Redpanda support.
+
+| xref:reference:properties/cluster-properties.adoc#retention_bytes[`retention_bytes`]
+| Default maximum size per partition before the oldest data becomes eligible for deletion. Applies when a topic doesn't set its own `retention.bytes`.
+|===
+
+For example, to set the default topic retention period to 24 hours:
+
+[source,bash]
+----
+rpk cluster config set log_retention_ms 86400000
+----
+
 == View cluster property values
 
 You can see the value of a cluster configuration property using `rpk` or the Cloud API.

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -124,12 +124,42 @@ You can set cluster-wide defaults that apply to new topics on BYOC and Dedicated
 | Default maximum size per partition before the oldest data becomes eligible for deletion. Applies when a topic doesn't set its own `retention.bytes`.
 |===
 
-Set these properties using `rpk` or the Cloud API, as described in <<set-cluster-configuration-properties>>. For example, to set the default topic retention period to 24 hours with `rpk`:
+Set these properties using `rpk` or the Cloud API. For example, to set the default topic retention period to 24 hours:
 
+[tabs]
+====
+`rpk`::
++
+--
 [source,bash]
 ----
 rpk cluster config set log_retention_ms 86400000
 ----
+--
+Cloud API::
++
+--
+[source,bash]
+----
+# Store your cluster ID in a variable.
+export RP_CLUSTER_ID=<cluster-id>
+
+# Retrieve a Redpanda Cloud access token.
+export RP_CLOUD_TOKEN=`curl -X POST "https://auth.prd.cloud.redpanda.com/oauth/token" \
+    -H "content-type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=<client-id>" \
+    -d "client_secret=<client-secret>"`
+
+# Set the default topic retention period to 24 hours.
+curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
+  "https://api.cloud.redpanda.com/v1/clusters/${RP_CLUSTER_ID}" \
+ -H 'accept: application/json'\
+ -H 'content-type: application/json' \
+ -d '{"cluster_configuration":{"custom_properties": {"log_retention_ms":86400000}}}'
+----
+--
+====
 
 == View cluster property values
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -124,7 +124,7 @@ You can set cluster-wide defaults that apply to new topics on BYOC and Dedicated
 | Default maximum size per partition before the oldest data becomes eligible for deletion. Applies when a topic doesn't set its own `retention.bytes`.
 |===
 
-For example, to set the default topic retention period to 24 hours:
+Set these properties using `rpk` or the Cloud API, as described in <<set-cluster-configuration-properties>>. For example, to set the default topic retention period to 24 hours with `rpk`:
 
 [source,bash]
 ----


### PR DESCRIPTION
> [!IMPORTANT]
> **Temporary preview override — must be reverted before merge.**
> Commit `19c5b8b3` points `local-antora-playbook.yml` at the docs PR branch (redpanda-data/docs#1728) instead of `main` so this deploy preview renders the three Cloud properties. **Before merging:** merge docs#1728 first, then revert that commit so the playbook pulls `main` again.

## What

Documents three cluster properties that are now customer-managed in Redpanda Cloud (BYOC + Dedicated): `default_topic_partitions`, `log_retention_ms`, and `retention_bytes`. Backs [cloudv2#26519](https://github.com/redpanda-data/cloudv2/pull/26519).

These are **cluster** configuration properties that set cluster-wide defaults for new topics (a topic can still override the equivalent per-topic property). They are surfaced on the Cloud cluster-properties reference by the companion docs PR ([redpanda-data/docs#1728](https://github.com/redpanda-data/docs/pull/1728)), which regenerates the property partials with cloud support.

## Changes

- **Configure Cluster Properties** (`manage/cluster-maintenance/config-cluster.adoc`): adds a **Set default topic properties** section listing the three properties (with reference links), clarifying that `log_retention_ms` sets the cluster-wide default topic retention period (previously changeable only by Redpanda support), and noting they can be set with `rpk` or the Cloud API.
- **What's New** (`get-started/whats-new-cloud.adoc`): adds a June 2026 entry for the new customer-managed default topic settings.

## Preview pages

- [Configure Cluster Properties](https://deploy-preview-608--rp-cloud.netlify.app/cloud-data-platform/manage/cluster-maintenance/config-cluster/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-608--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)
- [Cluster Configuration Properties](https://deploy-preview-608--rp-cloud.netlify.app/cloud-data-platform/reference/properties/cluster-properties/) — see `default_topic_partitions`, `log_retention_ms`, `retention_bytes` (rendered via the temporary docs-branch override)

## Verification

Built locally against the docs-repo branch: the three properties render on the Cloud cluster-properties reference with correct anchors, the how-to and What's New sections render and their xrefs resolve, and there are **0 broken xrefs**.

## Merge order

1. Merge [redpanda-data/docs#1728](https://github.com/redpanda-data/docs/pull/1728) (regenerated partials land on `main`).
2. Revert the temporary playbook commit `19c5b8b3` here.
3. Merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)