### PR TITLE
docs: revert playbook streaming branch to main (DOC-2222)

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -14,11 +14,8 @@ content:
   sources:
   - url: .
     branches: HEAD
-  # TEMPORARY (DOC-2222): pull the streaming component from the docs PR branch
-  # (redpanda-data/docs#1728) instead of main so the deploy preview renders the
-  # three customer-managed Cloud properties. REVERT to `main` before merging.
   - url: https://github.com/redpanda-data/documentation
-    branches: [doc-2222-cloud-cmc-default-topic-props, v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]


### PR DESCRIPTION
## What

Reverts `local-antora-playbook.yml` so the `documentation` (streaming) component points at `main` again:

```yaml
- url: https://github.com/redpanda-data/documentation
  branches: [main, v/*, shared, site-search]
```

## Why

PR #608 merged with the playbook still set to the docs PR branch `doc-2222-cloud-cmc-default-topic-props` (the "REVERT before merging" note was missed). That branch was deleted when [redpanda-data/docs#1728](https://github.com/redpanda-data/docs/pull/1728) merged, so `main` now references a non-existent branch and cloud-docs builds / deploy previews will fail to fetch it. The docs change is now on `main`, so the standard branch list renders it correctly.

The `check-branches` guard correctly failed on #608 (and on the push to main), but it is not a required status check, so it did not block the merge. A separate change will make it enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)