### PR TITLE
ci: run playbook guard on every PR so it can be required

### DIFF
--- a/.github/workflows/check-playbook.yml
+++ b/.github/workflows/check-playbook.yml
@@ -1,13 +1,12 @@
 ---
 name: Check playbook branches
+# Runs on every PR (no paths filter) so it can be a required status check:
+# a required check that is skipped by a paths filter leaves PRs stuck pending.
+# It passes fast when the playbook is unchanged or standard.
 on:
   pull_request:
-    paths:
-      - local-antora-playbook.yml
   push:
     branches: [main]
-    paths:
-      - local-antora-playbook.yml
 
 jobs:
   check-branches:


### PR DESCRIPTION
## What

Removes the `paths:` filters from `check-playbook.yml` so the `check-branches` guard runs on **every** PR (and on push to main), instead of only when `local-antora-playbook.yml` changes.

## Why

PR #608 merged with the playbook pointing at a docs PR branch. The guard **detected and failed** on it, but it is not a required status check, so it didn't block the merge.

To make it required safely, it must run on every PR: a required status check that is skipped by a `paths` filter leaves unrelated PRs stuck "Expected — waiting for status." With this change the guard always runs and passes fast when the playbook is standard.

## Follow-up (repo setting, not in this PR)

Add `check-branches` as a required status check in the "Require one PR review" ruleset (or branch protection) so a red guard blocks merges going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)