### PR TITLE
docs(DOC-1919): add cloud stub for Connect Aurora IAM-roles guide

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -324,6 +324,7 @@
 **** xref:develop:connect/guides/bloblang/arithmetic.adoc[]
 *** Cloud Credentials
 **** xref:develop:connect/guides/cloud/aws.adoc[]
+**** xref:develop:connect/guides/cloud/aws-iam-aurora.adoc[]
 **** xref:develop:connect/guides/cloud/gcp.adoc[]
 *** xref:develop:connect/guides/cloud/gateway.adoc[]
 *** xref:develop:connect/guides/sync_responses.adoc[]

--- a/modules/develop/pages/connect/guides/cloud/aws-iam-aurora.adoc
+++ b/modules/develop/pages/connect/guides/cloud/aws-iam-aurora.adoc
@@ -1,0 +1,3 @@
+= Authenticate to Amazon Aurora using IAM roles
+:page-aliases: guides:cloud/aws-iam-aurora.adoc
+include::connect:guides:cloud/aws-iam-aurora.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,6 +8,10 @@ This page lists new features added to Redpanda Cloud.
 
 == June 2026
 
+=== Connect to Amazon Aurora with IAM roles
+
+A new guide walks Cloud customers through configuring IAM Roles for Service Accounts (IRSA) so Redpanda Connect pipelines can authenticate to Amazon Aurora without storing static database credentials. The setup uses a two-hop role chain: the Connect pipeline role assumes a customer-owned database connect role in the Aurora account, which generates a short-lived RDS IAM authentication token. Applies to `postgres_cdc`, `pg_stream`, and `mysql_cdc` inputs. See xref:develop:connect/guides/cloud/aws-iam-aurora.adoc[Authenticate to Amazon Aurora using IAM roles].
+
 === Customer-managed default topic settings
 
 You can now set cluster-wide defaults for new topics on BYOC and Dedicated clusters. The xref:reference:properties/cluster-properties.adoc#default_topic_partitions[`default_topic_partitions`], xref:reference:properties/cluster-properties.adoc#log_retention_ms[`log_retention_ms`], and xref:reference:properties/cluster-properties.adoc#retention_bytes[`retention_bytes`] cluster properties are now customer-managed. The default topic retention period (`log_retention_ms`) previously could only be changed by Redpanda support. See xref:manage:cluster-maintenance/config-cluster.adoc[Configure Cluster Properties].


### PR DESCRIPTION
## Summary

Adds the cloud-docs stub for the new "Authenticate to Amazon Aurora using IAM roles" Connect guide so it publishes under `/cloud-data-platform/develop/connect/guides/cloud/aws-iam-aurora/` alongside the existing AWS/GCP credential guides.

The Connect-side guide already carries `tag::single-source[]` markers but had no cloud-docs stub, so the page was only publishing under the standalone Redpanda Connect docs. Since [DOC-1919](https://redpandadata.atlassian.net/browse/DOC-1919) targets Cloud customers and `postgres_cdc` / `pg_stream` / `mysql_cdc` are Cloud-supported, this stub completes the Pattern B single-source.

## Changes

- **`modules/develop/pages/connect/guides/cloud/aws-iam-aurora.adoc`** — new stub matching the shape of sibling `aws.adoc` and `gcp.adoc` (single-source include + page alias)
- **`modules/ROOT/nav.adoc`** — adds the new entry under "Cloud Credentials", between the existing AWS and GCP entries
- **`modules/get-started/pages/whats-new-cloud.adoc`** — June 2026 entry describing the new guide

## Companion PR

Connect-side content: [redpanda-data/rp-connect-docs#396](https://github.com/redpanda-data/rp-connect-docs/pull/396)

This cloud-docs PR is **safe to merge in either order** relative to the Connect-side one, since the include resolves through the `connect:` component and the existing guide content is already on `main` in Connect (the rp-connect-docs PR refines headings and adds anchors but the body remains in place).

## Preview pages

- [Authenticate to Amazon Aurora using IAM roles](https://deploy-preview-612--rp-cloud.netlify.app/cloud-data-platform/develop/connect/guides/cloud/aws-iam-aurora/) — preview URL fills in once Netlify builds
- [What's New: Connect to Amazon Aurora with IAM roles](https://deploy-preview-612--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/#connect-to-amazon-aurora-with-iam-roles)

## Test plan

- [ ] Netlify preview builds without errors
- [ ] Page renders at `/cloud-data-platform/develop/connect/guides/cloud/aws-iam-aurora/` with full body content (the headings + anchors from rp-connect-docs#396 should all surface)
- [ ] Nav entry appears under *Develop > Connect > Guides > Cloud Credentials*, between AWS and GCP
- [ ] What's New entry renders in the June 2026 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-1919]: https://redpandadata.atlassian.net/browse/DOC-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ