### PR TITLE
Add BigLake doc to Cloud

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: ['DOC-2221-document-feature-support-gcp-biglake-as-rest-cata', v/*, shared, site-search]
+    branches: [main, v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -15,7 +15,7 @@ content:
   - url: .
     branches: HEAD
   - url: https://github.com/redpanda-data/documentation
-    branches: [main, v/*, shared, site-search]
+    branches: ['DOC-2221-document-feature-support-gcp-biglake-as-rest-cata', v/*, shared, site-search]
   - url: https://github.com/redpanda-data/docs-site
     branches: [main]
     start_paths: [home, data-platform, self-managed]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -435,6 +435,7 @@
 *** xref:manage:iceberg/rest-catalog/index.adoc[]
 **** xref:manage:iceberg/iceberg-topics-aws-glue.adoc[AWS Glue]
 **** xref:manage:iceberg/iceberg-topics-databricks-unity.adoc[Databricks Unity Catalog]
+**** xref:manage:iceberg/iceberg-topics-gcp-biglake.adoc[GCP Lakehouse]
 **** xref:manage:iceberg/redpanda-topics-iceberg-snowflake-catalog.adoc[Snowflake and Open Catalog]
 *** xref:manage:iceberg/query-iceberg-topics.adoc[]
 *** xref:manage:iceberg/migrate-iceberg-catalog.adoc[]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,6 +8,10 @@ This page lists new features added to Redpanda Cloud.
 
 == June 2026
 
+=== GCP Lakehouse catalog for Iceberg topics
+
+BYOC clusters on GCP can now use GCP Lakehouse as an Iceberg REST catalog. See xref:manage:iceberg/iceberg-topics-gcp-biglake.adoc[].
+
 === Connect to Amazon Aurora with IAM roles
 
 A new guide walks Cloud customers through configuring IAM Roles for Service Accounts (IRSA) so Redpanda Connect pipelines can authenticate to Amazon Aurora without storing static database credentials. The setup uses a two-hop role chain: the Connect pipeline role assumes a customer-owned database connect role in the Aurora account, which generates a short-lived RDS IAM authentication token. Applies to `postgres_cdc`, `pg_stream`, and `mysql_cdc` inputs. See xref:develop:connect/guides/cloud/aws-iam-aurora.adoc[Authenticate to Amazon Aurora using IAM roles].

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -1,6 +1,5 @@
 = Use Iceberg Topics with GCP Lakehouse
 :description: Add Redpanda topics as Iceberg tables to Google Lakehouse for Apache Iceberg that you can query from Google BigQuery.
 :page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
-:page-beta: true
 
 include::streaming:manage:iceberg/iceberg-topics-gcp-biglake.adoc[tag=single-source]

--- a/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
+++ b/modules/manage/pages/iceberg/iceberg-topics-gcp-biglake.adoc
@@ -1,0 +1,6 @@
+= Use Iceberg Topics with GCP Lakehouse
+:description: Add Redpanda topics as Iceberg tables to Google Lakehouse for Apache Iceberg that you can query from Google BigQuery.
+:page-categories: Iceberg, Tiered Storage, Management, High Availability, Data Replication, Integration
+:page-beta: true
+
+include::streaming:manage:iceberg/iceberg-topics-gcp-biglake.adoc[tag=single-source]


### PR DESCRIPTION
## Description

Related: https://github.com/redpanda-data/docs/pull/1731

This pull request adds documentation support for using Redpanda topics as Iceberg tables with Google Cloud Platform's Lakehouse (BigLake) and makes related navigation and configuration updates. The main changes are the addition of a new documentation page, updates to navigation, and a modification to the Antora playbook to include the relevant documentation branch.

**Documentation Additions and Navigation Updates:**

* Added a new documentation page, `iceberg-topics-gcp-biglake.adoc`, describing how to use Redpanda topics as Iceberg tables in Google Lakehouse (BigLake). The page is marked as beta and includes content from a shared source.
* Updated the navigation (`nav.adoc`) to include a new entry for "GCP Lakehouse" under the Iceberg topics section, linking to the new documentation page.

**Antora Playbook Configuration:**

* Modified the `local-antora-playbook.yml` to use the `'DOC-2221-document-feature-support-gcp-biglake-as-rest-cata'` branch of the documentation repository, ensuring the new GCP Lakehouse documentation is included in the build.

Resolves https://github.com/redpanda-data/documentation-private/issues/<add-your-issue-number-here>
Review deadline:

## Page previews

https://deploy-preview-613--rp-cloud.netlify.app/cloud-data-platform/manage/iceberg/iceberg-topics-gcp-biglake/

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)