### PR TITLE
fix(ai-agents/mcp): repoint broken xref to canonical data-platform target

### DIFF
--- a/modules/ai-agents/pages/mcp/overview.adoc
+++ b/modules/ai-agents/pages/mcp/overview.adoc
@@ -70,4 +70,4 @@ MCP servers authenticate to Redpanda Cloud using your personal or service accoun
 * xref:ai-agents:mcp/quickstart.adoc[]
 * xref:ai-agents:mcp/configuration.adoc[]
 
-TIP: The Redpanda documentation site has a read-only MCP server that provides access to Redpanda docs and examples. This server has no access to your Redpanda Cloud account or clusters. See xref:home:ROOT:mcp-setup.adoc[].
+TIP: The Redpanda documentation site has a read-only MCP server that provides access to Redpanda docs and examples. This server has no access to your Redpanda Cloud account or clusters. See xref:data-platform:ROOT:how-to-use-these-docs.adoc[].


### PR DESCRIPTION
## Summary

Repoints a broken xref in `modules/ai-agents/pages/mcp/overview.adoc` to its canonical target.

## Why

`xref:home:ROOT:mcp-setup.adoc[]` pointed to a `page-aliases` entry on `data-platform/modules/ROOT/pages/how-to-use-these-docs.adoc`, not a real file. The canonical target is the underlying page itself, so this PR points the xref directly at it.

## What changed

```diff
-See xref:home:ROOT:mcp-setup.adoc[].
+See xref:data-platform:ROOT:how-to-use-these-docs.adoc[].
```

## Resolution behavior across build contexts

- **Production** (`docs-site/antora-playbook.yml`): includes the `data-platform` component. Xref resolves. Renders correctly.
- **Cloud-docs preview builds** (`cloud-docs/local-antora-playbook.yml`): includes `docs-site` with `start_paths: [home, data-platform, self-managed]`. Xref resolves.
- **docs-repo PR previews** (`docs/local-antora-playbook.yml`): does **not** include `docs-site` as a content source. Xref will continue to log `target of xref not found`, the same as the original `home:ROOT:mcp-setup.adoc` form. This is a pre-existing infrastructure gap and not within scope of this PR.

## Verified during diagnosis of redpanda-data/docs#1741

This xref's "target not found" error is one of several pre-existing cross-component errors that surface as `ERROR (asciidoctor)` lines on every docs-repo PR preview build. Using the canonical xref (this PR) is the correct cloud-docs change; closing the remaining "phantom error" class fully requires adding the docs-site `data-platform` and `home` components to `docs/local-antora-playbook.yml` (separate change, in the docs repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
