### PR TITLE
SQL: Terraform provider

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,6 +8,10 @@ This page lists new features added to Redpanda Cloud.
 
 == June 2026
 
+=== Terraform provider: Redpanda SQL support
+
+The Redpanda Terraform provider (v2.1.0+) now supports enabling and managing Redpanda SQL on BYOC clusters on AWS. Use the `rpsql` block on a `redpanda_cluster` resource to enable SQL, configure compute replicas, and retrieve the SQL endpoint URL. See xref:manage:terraform-provider.adoc#enable-redpanda-sql-on-a-byoc-cluster[Enable Redpanda SQL on a BYOC cluster].
+
 === Centralized egress for BYOC on GCP: beta
 
 You can route all GCP BYOC cluster egress through your own GCP hub VPC and NAT VM instead of a per-cluster Cloud NAT, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that require a single, predictable public IP for outbound allowlisting or that prohibit per-cluster Cloud NAT. Centralized egress is in a glossterm:beta[] release and is enabled per organization. Contact your account team for access. See xref:networking:byoc/gcp/nat-free-egress.adoc[Configure Centralized Egress with GCP VPC Peering].

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -429,6 +429,11 @@ This example requires provider version `>= 2.0.0`.
 |No
 |Number of SQL compute replicas. Scalable in place. Default: `1`.
 
+|`zones`
+|List of String
+|No
+|For multi-AZ clusters, the single availability zone to deploy the SQL engine into. Provide one zone from the cluster's `zones` list. If omitted, a zone is chosen automatically. The zone is locked when SQL is first enabled and cannot be changed afterward. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
+
 |`url`
 |String
 |Read-only
@@ -491,6 +496,7 @@ resource "redpanda_cluster" "example" {
   rpsql = {
     enabled  = true
     replicas = 3
+    zones    = ["use2-az1"]
   }
 }
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -1,5 +1,10 @@
 = Redpanda Terraform Provider
 :description: Use the Redpanda Terraform provider to create and manage Redpanda Cloud resources.
+:page-topic-type: how-to
+:personas: platform_admin
+:learning-objective-1: Configure and deploy Redpanda Cloud clusters using Terraform
+:learning-objective-2: Manage sensitive credentials using Terraform write-only attributes
+:learning-objective-3: Enable Redpanda SQL on a BYOC cluster using the rpsql block
 
 Use the https://registry.terraform.io/providers/redpanda-data/redpanda/latest[Redpanda Terraform provider^] to define, automate, and track changes to your Redpanda Cloud infrastructure as code.
 
@@ -18,6 +23,12 @@ With the Redpanda Terraform provider, you can manage:
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/serverless_private_link[Serverless private links^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/topic[Topics^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/user[Users^]
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
 
 == Why use Terraform with Redpanda?
 
@@ -411,9 +422,7 @@ resource "redpanda_cluster" "test" {
 
 === Enable Redpanda SQL on a BYOC cluster
 
-Use the `rpsql` block on a `redpanda_cluster` resource to enable and manage Redpanda SQL on a BYOC cluster. You can add or change `rpsql` settings on an existing cluster without recreating it.
-
-This example requires provider version `>= 2.0.0`.
+Use the `rpsql` block on a `redpanda_cluster` resource (requires provider version `>= 2.0.0`) to enable and manage Redpanda SQL on a BYOC cluster. You can add or change `rpsql` settings on an existing cluster without recreating it.
 
 [cols="<25%,<15%,<10%,<50%",options="header"]
 |===
@@ -432,7 +441,7 @@ This example requires provider version `>= 2.0.0`.
 |`zones`
 |List of String
 |No
-|For multi-AZ clusters, the single availability zone to deploy the SQL engine into. Provide one zone from the cluster's `zones` list. If omitted, a zone is chosen automatically. The zone is locked when SQL is first enabled and cannot be changed afterward. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
+|For multi-AZ clusters, the single availability zone to deploy the SQL engine into. Provide one zone from the cluster's `zones` list. If omitted, a zone is chosen automatically. Redpanda locks the zone when SQL is first enabled; you cannot change it afterward. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
 
 |`url`
 |String
@@ -505,7 +514,7 @@ output "sql_url" {
 }
 ----
 
-To scale Redpanda SQL, update `replicas` and run `terraform apply`. To disable it, set `enabled = false`. Both are in-place updates. Terraform applies the change without recreating the cluster.
+To scale Redpanda SQL, update `replicas` and run `terraform apply`. To disable it, set `enabled = false`. Both operations update the cluster in place. Terraform does not recreate the cluster.
 
 For the full enable workflow using the Cloud Console or Cloud API, see xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -409,6 +409,71 @@ resource "redpanda_cluster" "test" {
 }
 ----
 
+=== Enable Redpanda SQL on a BYOC cluster
+
+Use the `rpsql` block on a `redpanda_cluster` resource to enable and manage Redpanda SQL on a BYOC cluster. You can add or change `rpsql` settings on an existing cluster without recreating it.
+
+This example requires provider version `>= 2.0.0`.
+
+[cols="<25%,<15%,<10%,<50%",options="header"]
+|===
+|Attribute |Type |Required |Description
+
+|`enabled`
+|Boolean
+|No
+|Whether Redpanda SQL is enabled. Default: `false`.
+
+|`replicas`
+|Number
+|No
+|Number of SQL compute replicas. Scalable in place. Default: `1`.
+
+|`url`
+|String
+|Read-only
+|SQL engine endpoint URL. Empty while disabled; populated by the server when SQL is enabled.
+|===
+
+[source,hcl]
+----
+terraform {
+  required_providers {
+    redpanda = {
+      source  = "redpanda-data/redpanda"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+provider "redpanda" {}
+
+resource "redpanda_cluster" "example" {
+  name              = var.cluster_name
+  resource_group_id = var.resource_group_id
+  network_id        = var.network_id
+  cloud_provider    = "aws"
+  region            = var.region
+  cluster_type      = "byoc"
+  connection_type   = "public"
+  throughput_tier   = var.throughput_tier
+  zones             = var.zones
+
+  rpsql = {
+    enabled  = true
+    replicas = 3
+  }
+}
+
+output "sql_url" {
+  value = redpanda_cluster.example.rpsql.url
+}
+----
+
+To scale Redpanda SQL, update `replicas` and run `terraform apply`. To disable it, set `enabled = false`. Both are in-place updates. Terraform applies the change without recreating the cluster.
+
+For the full enable workflow using the Cloud Console or Cloud API, see xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
+
 === Create a Dedicated cluster
 
 Redpanda fully manages Dedicated clusters for consistent performance. This example creates one on AWS with specific zones and a usage tier.

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -446,6 +446,35 @@ terraform {
   }
 }
 
+variable "cluster_name" {
+  description = "Name of the Redpanda BYOC cluster"
+  default     = "sql-enabled-cluster"
+}
+
+variable "resource_group_id" {
+  description = "ID of the Redpanda resource group"
+}
+
+variable "network_id" {
+  description = "ID of the Redpanda network"
+}
+
+variable "region" {
+  description = "Region for the cluster"
+  default     = "us-east-2"
+}
+
+variable "throughput_tier" {
+  description = "Throughput tier for the cluster"
+  default     = "tier-1-aws-v2-x86"
+}
+
+variable "zones" {
+  description = "List of availability zones for the cluster"
+  type        = list(string)
+  default     = ["use2-az1", "use2-az2", "use2-az3"]
+}
+
 provider "redpanda" {}
 
 resource "redpanda_cluster" "example" {

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -462,11 +462,11 @@ Use the `rpsql` block on a `redpanda_cluster` resource (requires provider versio
 |`zones`
 |List of String
 |No
-|For multi-AZ clusters, the single availability zone to deploy the SQL engine into. Provide one zone from the cluster's `zones` list. If omitted, a zone is chosen automatically. Redpanda locks the zone when SQL is first enabled; you cannot change it afterward. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
+|For multi-AZ clusters, the single availability zone to deploy the SQL engine into. Provide one zone from the cluster's `zones` list. If omitted, a zone is chosen automatically. Redpanda locks the zone when SQL is first enabled. You cannot change it afterward. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
 
 |`url`
 |String
-|Read-only
+|No (computed)
 |SQL engine endpoint URL. Empty while disabled; populated by the server when SQL is enabled.
 |===
 
@@ -535,7 +535,7 @@ output "sql_url" {
 }
 ----
 
-To scale Redpanda SQL, update `replicas` and run `terraform apply`. To disable it, set `enabled = false`. Both operations update the cluster in place. Terraform does not recreate the cluster.
+To scale Redpanda SQL, update `replicas` and run `terraform apply`. To disable Redpanda SQL, set `enabled = false`. Both operations update the cluster in place. Terraform does not recreate the cluster.
 
 For the full enable workflow using the Cloud Console or Cloud API, see xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL on a BYOC cluster].
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -422,7 +422,7 @@ resource "redpanda_cluster" "test" {
 
 === Enable Redpanda SQL on a BYOC cluster
 
-Use the `rpsql` block on a `redpanda_cluster` resource (requires provider version `>= 2.0.0`) to enable and manage Redpanda SQL on a BYOC cluster. You can add or change `rpsql` settings on an existing cluster without recreating it.
+Use the `rpsql` block on a `redpanda_cluster` resource (requires provider version `>= 2.1.0`) to enable and manage Redpanda SQL on a BYOC cluster. You can add or change `rpsql` settings on an existing cluster without recreating it.
 
 [cols="<25%,<15%,<10%,<50%",options="header"]
 |===
@@ -455,7 +455,7 @@ terraform {
   required_providers {
     redpanda = {
       source  = "redpanda-data/redpanda"
-      version = ">= 2.0.0"
+      version = ">= 2.1.0"
     }
   }
 }

--- a/modules/sql/pages/get-started/deploy-sql-cluster.adoc
+++ b/modules/sql/pages/get-started/deploy-sql-cluster.adoc
@@ -16,9 +16,9 @@ After reading this page, you will be able to:
 
 NOTE: Redpanda SQL is currently available only on BYOC clusters running on AWS.
 
-== Prerequisites
-
 TIP: If you manage your infrastructure with Terraform, see xref:manage:terraform-provider.adoc#enable-redpanda-sql-on-a-byoc-cluster[Enable Redpanda SQL on a BYOC cluster] in the Terraform provider guide.
+
+== Prerequisites
 
 To enable Redpanda SQL, you need:
 

--- a/modules/sql/pages/get-started/deploy-sql-cluster.adoc
+++ b/modules/sql/pages/get-started/deploy-sql-cluster.adoc
@@ -18,6 +18,8 @@ NOTE: Redpanda SQL is currently available only on BYOC clusters running on AWS.
 
 == Prerequisites
 
+TIP: If you manage your infrastructure with Terraform, see xref:manage:terraform-provider.adoc#enable-redpanda-sql-on-a-byoc-cluster[Enable Redpanda SQL on a BYOC cluster] in the Terraform provider guide.
+
 To enable Redpanda SQL, you need:
 
 * A Redpanda Cloud organization on xref:billing:billing.adoc[usage-based billing].


### PR DESCRIPTION
## Description

This pull request adds documentation for enabling and managing Redpanda SQL on BYOC clusters using the Terraform provider. It introduces a new section to the Terraform provider guide, provides a configuration example, and adds a cross-reference in the SQL deployment guide to help Terraform users discover this workflow.

**Documentation updates for Redpanda SQL management:**

* Added a new section describing how to enable and configure Redpanda SQL on BYOC clusters using the `rpsql` block in the `redpanda_cluster` Terraform resource, including a table of attributes, example configuration, and usage notes.
* Included a cross-reference tip in the SQL deployment guide to direct Terraform users to the relevant provider documentation for enabling Redpanda SQL.

NOTE: Combined What's New entry added to https://github.com/redpanda-data/cloud-docs/pull/620

Resolves DOC-2228
Review deadline:

## Page previews

https://deploy-preview-617--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/#enable-redpanda-sql-on-a-byoc-cluster

<!--- add your page preview here. 
A simple way to do it is to open the link generated by Netlify bot + file path. Remember to remove page, module, and the .adoc extension.
A preview looks like this
https://deploy-preview-487--redpanda-docs-preview.netlify.app/current/manage/node-management/
https://deploy-preview-<PR-NUMBER>--redpanda-docs-preview.netlify.app/<VERSION>/<PATH-TO-FILE-WITHOUT-ADOC>
-->

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)