### PR TITLE
SQL Editor

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -343,6 +343,7 @@
 *** xref:sql:connect-to-sql/language-clients/php-pdo.adoc[]
 *** xref:sql:connect-to-sql/language-clients/dotnet-dapper.adoc[]
 ** xref:sql:query-data/index.adoc[Query Data]
+*** xref:sql:query-data/sql-editor.adoc[SQL Editor]
 *** xref:sql:query-data/redpanda-catalogs.adoc[Redpanda Catalogs]
 *** xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics]
 *** xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -10,7 +10,7 @@ This page lists new features added to Redpanda Cloud.
 
 === SQL editor in Redpanda Cloud Console
 
-Redpanda Cloud Console now includes a built-in SQL editor. You can write and run `SELECT` queries against your Redpanda topics directly in the Console without installing a separate PostgreSQL client. The editor supports syntax highlighting, autocomplete, query history, and CSV and JSON export. For Iceberg-enabled topics, an indicator shows when results span both live topic data and Iceberg-committed history. See xref:sql:query-data/sql-editor.adoc[Use the SQL Editor].
+Redpanda Cloud Console now includes a built-in SQL editor. For SQL-enabled environments, you can write and run `SELECT` queries against your Redpanda topics directly in the Console without installing a separate PostgreSQL client. The editor supports syntax highlighting, autocomplete, query history, and CSV and JSON export. For Iceberg-enabled topics, an indicator shows when results span both live topic data and Iceberg-committed history. To enable Redpanda SQL, see xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL]. To use the editor, see xref:sql:query-data/sql-editor.adoc[Use the SQL Editor].
 
 === Self-service organization deletion for Serverless
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,6 +8,10 @@ This page lists new features added to Redpanda Cloud.
 
 == July 2026
 
+=== SQL editor in Redpanda Cloud Console
+
+Redpanda Cloud Console now includes a built-in SQL editor. You can write and run `SELECT` queries against your Redpanda topics directly in the Console without installing a separate PostgreSQL client. The editor supports syntax highlighting, autocomplete, query history, and CSV and JSON export. For Iceberg-enabled topics, an indicator shows when results span both live topic data and Iceberg-committed history. See xref:sql:query-data/sql-editor.adoc[Use the SQL Editor].
+
 === Self-service organization deletion for Serverless
 
 You can now permanently delete a Serverless organization (free trial and pay-as-you-go plans) directly from the Cloud UI, without contacting Redpanda Support. The new *Manage organization* page, available from your profile icon, shows your plan and organization-wide resource counts, and walks you through the deletion prerequisites: delete all clusters, delete all private links, and settle any pending or outstanding invoices. See xref:manage:manage-organization.adoc[Manage Your Organization].

--- a/modules/sql/pages/get-started/deploy-sql-cluster.adoc
+++ b/modules/sql/pages/get-started/deploy-sql-cluster.adoc
@@ -267,5 +267,6 @@ The request returns the ID of a long-running operation. Poll link:/api/doc/cloud
 == Next steps
 
 * xref:sql:get-started/sql-quickstart.adoc[Quickstart]: Connect to Redpanda SQL with `psql` and run your first query.
+* xref:sql:query-data/sql-editor.adoc[SQL editor]: Write and run queries directly in the Cloud Console without a separate SQL client.
 * xref:sql:connect-to-sql/authenticate.adoc[Authenticate to Redpanda SQL]: Connect with an OIDC bearer token, OIDC client credentials, or a SCRAM password for clients that don't support OIDC.
 * xref:reference:sql/index.adoc[Redpanda SQL reference]: Explore the full SQL syntax, data types, functions, and clauses.

--- a/modules/sql/pages/get-started/deploy-sql-cluster.adoc
+++ b/modules/sql/pages/get-started/deploy-sql-cluster.adoc
@@ -180,14 +180,11 @@ When the operation is complete, the response shows `"state": "STATE_COMPLETED"`.
 
 == Verify the SQL engine is running
 
-After you enable Redpanda SQL, the cluster overview page in the Cloud Console shows the *SQL* tab and the *Details* pane displays the number of SQL nodes deployed with the cluster.
+After you enable Redpanda SQL, a *Redpanda SQL* tile appears in the cluster overview under *Products*. The tile shows the engine status, active sessions, queries per minute, and node count. When the *Nodes* indicator shows all nodes as ready (for example, *1/1*), the engine is provisioned and accepting connections. Provisioning can take up to 30 minutes.
 
-// TODO: Confirm UI changes for SQL engine ready indicator 
-The *SQL* tab appears as soon as you enable SQL, but you can't connect until the engine is fully provisioned. Provisioning can take up to 30 minutes.
+For the API flow, poll the long-running operation until it returns `STATE_COMPLETED`.
 
-Wait for the node-ready status indicator on the overview page to show the engine is ready. For the API flow, poll the long-running operation until it returns `STATE_COMPLETED`.
-
-To verify the SQL engine is running, use the connection details on the *SQL* tab to connect with a PostgreSQL client, such as `psql` (v16 or later required).
+To verify the SQL engine is running, use the connection details on the *SQL* tab under *Connection details* to connect with a PostgreSQL client, such as `psql` (v16 or later required). You can also query data directly using the xref:sql:query-data/sql-editor.adoc[SQL editor] in the left navigation.
 
 To connect using a bearer token (xref:manage:rpk/rpk-install.adoc[`rpk` v26.1.6+] required):
 

--- a/modules/sql/pages/get-started/sql-quickstart.adoc
+++ b/modules/sql/pages/get-started/sql-quickstart.adoc
@@ -100,6 +100,8 @@ Click *Save* to register the schema.
 
 == Connect to Redpanda SQL
 
+TIP: You can also query data directly in the Cloud Console using the built-in xref:sql:query-data/sql-editor.adoc[SQL editor], with no separate client required.
+
 SQL connection details are available on your cluster's *SQL* tab in the https://cloud.redpanda.com/[Cloud Console]. To connect using `psql`:
 
 . Log in to Redpanda Cloud with `rpk`. This opens a browser window for SSO sign-in:
@@ -201,8 +203,8 @@ The user can now connect to Redpanda SQL and run `SELECT` against the tables the
 
 == Next steps
 
-// TODO: Uncomment once DOC-1990, DOC-1999, and DOC-2006 merge (target pages are on those branches).
-// * xref:sql:query-data/query-streaming-topics.adoc[Query streaming topics]: Map a Redpanda topic to a SQL table and run analytical queries against live streaming data.
-// * xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics]: Run a single SQL query that spans live records and the Iceberg history of a topic.
-// * xref:sql:connect-to-sql/authenticate.adoc[Authenticate to Redpanda SQL]: Connect with an OIDC bearer token, OIDC client credentials, or a SCRAM password for clients that don't support OIDC (for example, Power BI).
+* xref:sql:query-data/sql-editor.adoc[SQL editor]: Write and run queries directly in the Cloud Console without a separate SQL client.
+* xref:sql:query-data/query-streaming-topics.adoc[Query streaming topics]: Map a Redpanda topic to a SQL table and run analytical queries against live streaming data.
+* xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics]: Run a single SQL query that spans live records and the Iceberg history of a topic.
+* xref:sql:connect-to-sql/authenticate.adoc[Authenticate to Redpanda SQL]: Connect with an OIDC bearer token, OIDC client credentials, or a SCRAM password for clients that don't support OIDC (for example, Power BI).
 * xref:reference:sql/index.adoc[Redpanda SQL reference]: Explore the full SQL syntax, data types, functions, and clauses.

--- a/modules/sql/pages/get-started/sql-quickstart.adoc
+++ b/modules/sql/pages/get-started/sql-quickstart.adoc
@@ -102,7 +102,7 @@ Click *Save* to register the schema.
 
 TIP: You can also query data directly in the Cloud Console using the built-in xref:sql:query-data/sql-editor.adoc[SQL editor], with no separate client required.
 
-SQL connection details are available on your cluster's *SQL* tab in the https://cloud.redpanda.com/[Cloud Console]. To connect using `psql`:
+SQL connection details are available on the *SQL* tab under *Connection details* in the https://cloud.redpanda.com/[Cloud Console]. To connect using `psql`:
 
 . Log in to Redpanda Cloud with `rpk`. This opens a browser window for SSO sign-in:
 +

--- a/modules/sql/pages/index.adoc
+++ b/modules/sql/pages/index.adoc
@@ -13,4 +13,5 @@ Get started:
 
 * xref:sql:get-started/overview.adoc[Redpanda SQL overview]
 * xref:sql:get-started/sql-quickstart.adoc[Redpanda SQL quickstart]
+* xref:sql:query-data/sql-editor.adoc[SQL editor]: Write and run SQL queries directly in the Cloud Console.
 * xref:reference:sql/index.adoc[Redpanda SQL reference]

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -17,7 +17,7 @@ After reading this page, you will be able to:
 == Prerequisites
 
 * A Redpanda BYOC cluster with the SQL engine enabled. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL].
-* A Redpanda Cloud user with the *SQL: Access* or *SQL: Manage* RBAC permission. Users with *SQL: Access* also need a `GRANT SELECT` on each table to run queries against it. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
+* A Redpanda Cloud user with the *SQL: Access* or *SQL: Manage* glossterm:RBAC[] permission. Users with *SQL: Access* also need a `GRANT SELECT` on each table to run queries against it. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
 * At least one topic mapped to a SQL table in the catalog. See xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics], or use the <<add-topic,Add a topic wizard>> in the editor.
 
 == Open the SQL editor
@@ -35,7 +35,7 @@ Each catalog is labeled by type:
 
 Click a catalog to expand it, then expand a namespace to see its tables and their row counts. To view a table's columns and data types, click the chevron (>) next to the table name.
 
-Within the Redpanda catalog, tables backed by Iceberg-enabled topics display an *Iceberg* badge. When you query one of these tables, the SQL engine automatically bridges live topic data with the Iceberg history. See <<Query Iceberg topics>>.
+Within the Redpanda catalog, tables backed by glossterm:Iceberg topic[,Iceberg-enabled topics] display an *Iceberg* badge. When you query one of these tables, the SQL engine automatically bridges live topic data with the Iceberg history. See <<Query Iceberg topics>>.
 
 To filter tables by name, type in the *Search tables* box at the top of the catalog panel. The filter applies across all catalogs and namespaces.
 

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -1,0 +1,122 @@
+= Use the SQL Editor
+:description: Write and run SQL queries against your Redpanda topics directly from Redpanda Cloud Console without a separate SQL client.
+:page-topic-type: how-to
+:personas: app_developer, data_engineer, platform_admin
+:learning-objective-1: Browse Redpanda SQL catalogs and tables from the Console SQL editor
+:learning-objective-2: Write and run a SELECT query and view the results
+:learning-objective-3: Export query results to CSV or JSON
+
+The Redpanda Cloud Console includes a built-in SQL editor. You can write and run queries against your Redpanda topics without installing a separate PostgreSQL client. The editor connects to your cluster's SQL engine using your existing Console session, so no separate credentials are required.
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
+
+== Prerequisites
+
+* A Redpanda BYOC cluster with the SQL engine enabled. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL].
+* A Redpanda Cloud user with the *SQL: Access* or *SQL: Manage* RBAC permission. Users with *SQL: Access* also need a `GRANT SELECT` on each table to run queries against it. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
+* At least one topic mapped to a SQL table in the catalog. See xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics], or use the <<add-topic,Add a topic wizard>> in the editor.
+
+== Open the SQL editor
+
+In Redpanda Cloud Console, navigate to your cluster and select *SQL* in the left sidebar. The SQL workspace opens with the catalog panel on the left and the editor and results panels on the right.
+
+== Browse the catalog tree
+
+The catalog panel lists every SQL catalog attached to your cluster.
+
+Each catalog is labeled by type:
+
+* Redpanda: Tables backed by Redpanda topics in the `default_redpanda_catalog`.
+* Iceberg: Tables backed by an external Iceberg catalog.
+
+Click a catalog to expand it, then expand a namespace to see its tables and their row counts. To view a table's columns and data types, click the chevron (>) next to the table name.
+
+Within the Redpanda catalog, tables backed by Iceberg-enabled topics display an *Iceberg* badge. When you query one of these tables, the SQL engine automatically bridges live topic data with the Iceberg history. See <<Query Iceberg topics>>.
+
+To filter tables by name, type in the *Search tables* box at the top of the catalog panel. The filter applies across all catalogs and namespaces.
+
+To open a `SELECT *` query for a table in the editor, click the run button (▶) beside the table name.
+
+If a table displays a lock icon, your account lacks a `SELECT` grant on it. Ask an admin to grant you access. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
+
+== Write and run a query
+
+=== Query tabs
+
+The editor supports multiple independent query tabs. To add a tab, click *+* in the tab bar. To close a tab, click the *×* on the tab.
+
+=== Syntax highlighting and autocomplete
+
+SQL keywords, functions, and string literals are highlighted as you type. Begin typing an identifier to see autocomplete suggestions for table names, column names, and SQL keywords. Use the arrow keys to navigate the suggestion list and press Tab or Enter to accept a suggestion. Press Escape to dismiss the list.
+
+=== Format and history
+
+Click *Format* to reformat the query in the active tab with consistent keyword casing and clause line breaks.
+
+Click *History* to see the last 40 queries run in this browser. Your browser stores query history locally. History does not sync across devices or user sessions.
+
+=== Run a query
+
+To run the query in the active tab, click *Run* or press kbd:[Cmd+Enter] (macOS) or kbd:[Ctrl+Enter] (Windows and Linux).
+
+To run a portion of the query, select the text you want to run, then click *Run selection*.
+
+The SQL editor supports only `SELECT` statements. `CREATE TABLE` and permission statements (`GRANT`, `REVOKE`) are not available in the editor. Use the <<add-topic,Add a topic wizard>> to create tables and xref:sql:manage/manage-access.adoc[Manage access] to manage grants.
+
+== View and sort results
+
+After a successful query, the results panel shows:
+
+* A status bar with a success indicator, the total row count, and the elapsed query time.
+* A results grid with one column per returned field.
+
+Each column header shows the column name and its data type. Click a column header to sort by that column. Click it again to reverse the sort order, or click it a third time to clear the sort.
+
+`NULL` values render as a distinct `NULL` label in each cell.
+
+Results load 100 rows at a time in the grid. To load the next batch, click *Load 100 more* at the bottom of the results. A single query returns a maximum of 10,000 rows.
+
+=== Query Iceberg topics
+
+When a query reads from an Iceberg-enabled topic in the Redpanda catalog, a *Bridge query* chip appears in the results status bar. This means the query returned data from both the live Redpanda topic and its Iceberg committed history.
+
+Click the chip to expand a timeline showing the Iceberg watermark and the approximate offset lag between the live topic and the Iceberg tier at the time the query ran.
+
+For details on querying across live and Iceberg-tiered data, see xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics].
+
+== Export results
+
+To download the current result set, click the export buttons in the results status bar:
+
+* CSV: Downloads a comma-separated file named `query_result.csv`.
+* JSON: Downloads a JSON array named `query_result.json`.
+
+The download includes all rows loaded in the grid, up to the query's row cap.
+
+[#add-topic]
+== Add a topic to the catalog
+
+NOTE: This task requires the Admin role.
+
+To make a Redpanda topic queryable from the editor, add it to the `default_redpanda_catalog` with the *Add a topic* wizard:
+
+. In the catalog panel, click *+ Add a topic* at the bottom of the Redpanda catalog namespace.
+. In the *Choose a topic* step, select the Redpanda topic to expose as a SQL table. Topics with Iceberg tiering enabled show an *Iceberg* badge.
+. Click *Continue*.
+. In the *Name the table* step, confirm or edit the table name. Table names must start with a letter or underscore and can contain only lowercase letters, numbers, and underscores. The catalog and source topic are fixed.
+. Review the `CREATE TABLE` statement that will run, then click *Create table*.
+
+The table appears in the catalog panel immediately and is ready to query.
+
+To remove a table from the catalog, hover over the table name and click the trash icon. Dropping a table removes it from the SQL catalog only. The underlying Redpanda topic and its data are not affected.
+
+== Suggested reading
+
+* xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics]: Map topics to SQL tables and run queries from a `psql` client.
+* xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics]: How bridge queries mesh live and Iceberg-tiered data.
+* xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL]: Grant users `SELECT` access to tables.
+* xref:reference:sql/index.adoc[Redpanda SQL Reference]: Supported statements, clauses, functions, data types, and operators.

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -51,7 +51,7 @@ The editor supports multiple independent query tabs. To add a tab, click *+* in 
 
 === Syntax highlighting and autocomplete
 
-SQL keywords, functions, and string literals are highlighted as you type. Begin typing an identifier to see autocomplete suggestions for table names, column names, and SQL keywords. Use the arrow keys to navigate the suggestion list and press Tab or Enter to accept a suggestion. Press Escape to dismiss the list.
+SQL keywords, functions, and string literals are highlighted as you type. Begin typing an identifier to see autocomplete suggestions for table names, column names, and SQL keywords. Use the arrow keys to navigate the suggestion list and press kbd:[Tab] or kbd:[Enter] to accept a suggestion. Press kbd:[Escape] to dismiss the list.
 
 === Format and history
 

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -58,7 +58,7 @@ To run the query in the active tab, click *Run* or press kbd:[Cmd+Enter] (macOS)
 
 To run a portion of the query, select the text you want to run, then click *Run selection*.
 
-The SQL editor supports only `SELECT` statements. `CREATE TABLE` and permission statements (`GRANT`, `REVOKE`) are not available in the editor. Use the <<add-topic,Add a topic wizard>> to create tables and xref:sql:manage/manage-access.adoc[Manage access] to manage grants.
+Because Redpanda SQL is a read-only query engine, the SQL editor supports only `SELECT` statements. `CREATE TABLE` and permission statements (`GRANT`, `REVOKE`) are not available in the editor. Use the <<add-topic,Add a topic wizard>> to create tables and xref:sql:manage/manage-access.adoc[Manage access] to manage grants.
 
 == View results
 
@@ -79,7 +79,7 @@ Scroll the results grid to view all rows. If the server's row limit is reached, 
 
 When a query reads from an Iceberg-enabled topic in the Redpanda catalog, a *Bridge query* chip appears in the results status bar. This means the query returned data from both the live Redpanda topic and its Iceberg committed history.
 
-If there are messages not yet committed to Iceberg, a message below the status bar shows the approximate offset lag at the time the query ran.
+If there are messages not yet committed to Iceberg, a message below the status bar shows approximately how many offsets are not yet in Iceberg at the time the query ran.
 
 For details on querying across live and Iceberg-tiered data, see xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics].
 

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -2,9 +2,9 @@
 :description: Write and run SQL queries against your Redpanda topics directly from Redpanda Cloud Console without a separate SQL client.
 :page-topic-type: how-to
 :personas: app_developer, data_engineer, platform_admin
-:learning-objective-1: Browse Redpanda SQL catalogs and tables from the Console SQL editor
-:learning-objective-2: Write and run a SELECT query and view the results
-:learning-objective-3: Export query results to CSV or JSON
+:learning-objective-1: Add a topic to the SQL catalog using the wizard in the SQL editor
+:learning-objective-2: Navigate SQL catalogs and inspect table schemas from the Console SQL editor
+:learning-objective-3: Write and run a SELECT query and view the results
 
 The Redpanda Cloud Console includes a built-in SQL editor. You can write and run queries against your Redpanda topics without installing a separate PostgreSQL client. The editor connects to your cluster's SQL engine using your existing Console session, so no separate credentials are required.
 
@@ -22,16 +22,11 @@ After reading this page, you will be able to:
 
 == Open the SQL editor
 
-In Redpanda Cloud Console, navigate to your cluster and select *SQL* in the left sidebar. The SQL workspace opens with the catalog panel on the left and the editor and results panels on the right.
+In Redpanda Cloud Console, navigate to your cluster and select *SQL* in the left navigation menu. The SQL workspace opens with the catalog panel on the left and the editor and results panels on the right.
 
 == Browse the catalog tree
 
 The catalog panel lists every SQL catalog attached to your cluster.
-
-Each catalog is labeled by type:
-
-* Redpanda: Tables backed by Redpanda topics in the `default_redpanda_catalog`.
-* Iceberg: Tables backed by an external Iceberg catalog.
 
 Click a catalog to expand it, then expand a namespace to see its tables and their row counts. To view a table's columns and data types, click the chevron (>) next to the table name.
 
@@ -40,8 +35,6 @@ Within the Redpanda catalog, tables backed by glossterm:Iceberg topic[,Iceberg-e
 To filter tables by name, type in the *Search tables* box at the top of the catalog panel. The filter applies across all catalogs and namespaces.
 
 To open a `SELECT *` query for a table in the editor, click the run button (▶) beside the table name.
-
-If a table displays a lock icon, your account lacks a `SELECT` grant on it. Ask an admin to grant you access. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
 
 == Write and run a query
 
@@ -67,24 +60,26 @@ To run a portion of the query, select the text you want to run, then click *Run 
 
 The SQL editor supports only `SELECT` statements. `CREATE TABLE` and permission statements (`GRANT`, `REVOKE`) are not available in the editor. Use the <<add-topic,Add a topic wizard>> to create tables and xref:sql:manage/manage-access.adoc[Manage access] to manage grants.
 
-== View and sort results
+== View results
 
 After a successful query, the results panel shows:
 
 * A status bar with a success indicator, the total row count, and the elapsed query time.
 * A results grid with one column per returned field.
 
-Each column header shows the column name and its data type. Click a column header to sort by that column. Click it again to reverse the sort order, or click it a third time to clear the sort.
+Each column header shows the column name and its data type. To sort results, use `ORDER BY` in your query. The results grid does not support column sorting.
 
 `NULL` values render as a distinct `NULL` label in each cell.
 
-Results load 100 rows at a time in the grid. To load the next batch, click *Load 100 more* at the bottom of the results. A single query returns a maximum of 10,000 rows.
+To view structured data in full, click a cell that contains JSON or a nested value. The results panel displays the value formatted for readability.
+
+Scroll the results grid to view all rows. If the server's row limit is reached, a *Truncated* badge appears in the status bar.
 
 === Query Iceberg topics
 
 When a query reads from an Iceberg-enabled topic in the Redpanda catalog, a *Bridge query* chip appears in the results status bar. This means the query returned data from both the live Redpanda topic and its Iceberg committed history.
 
-Click the chip to expand a timeline showing the Iceberg watermark and the approximate offset lag between the live topic and the Iceberg tier at the time the query ran.
+If there are messages not yet committed to Iceberg, a message below the status bar shows the approximate offset lag at the time the query ran.
 
 For details on querying across live and Iceberg-tiered data, see xref:sql:query-data/query-iceberg-topics.adoc[Query Iceberg-enabled Topics].
 
@@ -95,7 +90,7 @@ To download the current result set, click the export buttons in the results stat
 * CSV: Downloads a comma-separated file named `query_result.csv`.
 * JSON: Downloads a JSON array named `query_result.json`.
 
-The download includes all rows loaded in the grid, up to the query's row cap.
+The download includes all returned rows.
 
 [#add-topic]
 == Add a topic to the catalog

--- a/modules/sql/pages/query-data/sql-editor.adoc
+++ b/modules/sql/pages/query-data/sql-editor.adoc
@@ -18,7 +18,7 @@ After reading this page, you will be able to:
 
 * A Redpanda BYOC cluster with the SQL engine enabled. See xref:sql:get-started/deploy-sql-cluster.adoc[Enable Redpanda SQL].
 * A Redpanda Cloud user with the *SQL: Access* or *SQL: Manage* glossterm:RBAC[] permission. Users with *SQL: Access* also need a `GRANT SELECT` on each table to run queries against it. See xref:sql:manage/manage-access.adoc[Manage access to Redpanda SQL].
-* At least one topic mapped to a SQL table in the catalog. See xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics], or use the <<add-topic,Add a topic wizard>> in the editor.
+* At least one topic mapped to a SQL table in the catalog. See xref:sql:query-data/query-streaming-topics.adoc[Query Streaming Topics], or use the <<add-topic,Add a topic>> wizard in the editor.
 
 == Open the SQL editor
 
@@ -28,7 +28,7 @@ In Redpanda Cloud Console, navigate to your cluster and select *SQL* in the left
 
 The catalog panel lists every SQL catalog attached to your cluster.
 
-Click a catalog to expand it, then expand a namespace to see its tables and their row counts. To view a table's columns and data types, click the chevron (>) next to the table name.
+Click a catalog to expand it, then expand a namespace to see its tables. To view a table's columns and data types, click the chevron (>) next to the table name.
 
 Within the Redpanda catalog, tables backed by glossterm:Iceberg topic[,Iceberg-enabled topics] display an *Iceberg* badge. When you query one of these tables, the SQL engine automatically bridges live topic data with the Iceberg history. See <<Query Iceberg topics>>.
 
@@ -99,15 +99,13 @@ NOTE: This task requires the Admin role.
 
 To make a Redpanda topic queryable from the editor, add it to the `default_redpanda_catalog` with the *Add a topic* wizard:
 
-. In the catalog panel, click *+ Add a topic* at the bottom of the Redpanda catalog namespace.
+. In the catalog panel, click *Add a topic* at the bottom of the Redpanda catalog namespace.
 . In the *Choose a topic* step, select the Redpanda topic to expose as a SQL table. Topics with Iceberg tiering enabled show an *Iceberg* badge.
 . Click *Continue*.
 . In the *Name the table* step, confirm or edit the table name. Table names must start with a letter or underscore and can contain only lowercase letters, numbers, and underscores. The catalog and source topic are fixed.
 . Review the `CREATE TABLE` statement that will run, then click *Create table*.
 
 The table appears in the catalog panel immediately and is ready to query.
-
-To remove a table from the catalog, hover over the table name and click the trash icon. Dropping a table removes it from the SQL catalog only. The underlying Redpanda topic and its data are not affected.
 
 == Suggested reading
 


### PR DESCRIPTION
## Description

This pull request adds documentation for the new SQL Editor feature in the Redpanda Cloud Console, allowing users to write and run SQL queries directly from the browser without needing an external SQL client. The changes update navigation, quickstart, and getting started guides to reference the SQL Editor, and introduce a comprehensive new page detailing its use.

**Key changes:**

**New SQL Editor documentation:**
- Added a new page, `sql-editor.adoc`, describing how to use the built-in SQL Editor in the Redpanda Cloud Console, including browsing catalogs, writing and running queries, viewing results, exporting data, and adding topics to the catalog.

**Navigation and discoverability:**
- Updated the navigation file (`nav.adoc`) to include a link to the SQL Editor documentation under the "Query Data" section.
- Added the SQL Editor as a next step in the SQL cluster deployment guide and the SQL quickstart guide, making it easier for users to discover and access the feature. [[1]](diffhunk://#diff-53e047807d28a0255b66ea613665a131405259a0926d855ba2b3ab3dd13fbe5bR268) [[2]](diffhunk://#diff-0aaa7195ceaa99e1ae1dfb70388ac642bf4af38bba78aa1f6d43c1d1a9342e44L204-R209)
- Included a tip in the quickstart guide about querying data directly in the Cloud Console using the SQL Editor.
- Added the SQL Editor to the main "Get started" section of the SQL documentation landing page.

Resolves DOC-2211
Review deadline: 19 Jun

## Page previews

- [Use the SQL Editor](https://deploy-preview-619--rp-cloud.netlify.app/cloud-data-platform/sql/query-data/sql-editor/) (new)
- [What's New in Redpanda Cloud](https://deploy-preview-619--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/#sql-editor-in-redpanda-cloud-console) (updated)
- [Enable Redpanda SQL on a BYOC Cluster](https://deploy-preview-619--rp-cloud.netlify.app/cloud-data-platform/sql/get-started/deploy-sql-cluster/) (updated)
- [Redpanda SQL Quickstart](https://deploy-preview-619--rp-cloud.netlify.app/cloud-data-platform/sql/get-started/sql-quickstart/) (updated)
- [Redpanda SQL](https://deploy-preview-619--rp-cloud.netlify.app/cloud-data-platform/sql/) (updated)

## Checks

- [ ] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)
