### PR TITLE
Remove ADP (Agentic Data Plane) content from cloud-docs

### DIFF
--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -154,8 +154,6 @@ Redpanda creates a cloud organization for you and sends you a welcome email.
 
 === Bring Your Own Cloud (BYOC)
 
-With BYOC clusters, the Redpanda data plane deploys into your existing VPC or VNet, ensuring all data remains in your environment.
-
 With BYOC clusters, you deploy the Redpanda glossterm:data plane[] into your existing VPC (for AWS and GCP) or VNet (for Azure), and all data is
 contained in your own environment. This provides an additional layer of security and isolation. (See xref:get-started:byoc-arch.adoc[].) Redpanda manages provisioning, monitoring, upgrades, and security policies, including the underlying infrastructure and Kubernetes used to run the cluster. Redpanda also manages required resources in your VPC or VNet, including subnets (subnetworks in GCP), IAM roles, and object storage resources (for example, S3 buckets or Azure Storage accounts). For full details, see xref:manage:maintenance.adoc[].
 

--- a/modules/get-started/pages/cloud-overview.adoc
+++ b/modules/get-started/pages/cloud-overview.adoc
@@ -1,19 +1,8 @@
 = Redpanda Cloud Overview
-:description: Learn about the Redpanda Agentic Data Plane (ADP) and deployment options including BYOC, Dedicated, and Serverless clusters.
+:description: Learn about Redpanda Cloud deployment options including BYOC, Dedicated, and Serverless clusters.
 :page-aliases: cloud:dedicated-byoc.adoc, deploy:deployment-option/cloud/dedicated-byoc.adoc, deploy:deployment-option/cloud/cloud-overview.adoc
 
-Redpanda Cloud is a complete data streaming and agentic data plane platform delivered as a fully-managed service. It provides automated upgrades and patching, data balancing, and support while continuously monitoring your data to meet strict performance, availability, reliability, and security requirements. All Redpanda Cloud clusters are deployed with an integrated glossterm:Redpanda Console[], and all clusters have access to unlimited retention and 300+ data connectors with glossterm:Redpanda Connect[].
-
-== Redpanda Agentic Data Plane (ADP)
-
-Redpanda ADP is enterprise-grade infrastructure for building, deploying, and governing glossterm:AI agent[,AI agents] at scale. It combines Redpanda's streaming-native immutable log, 300+ data connectors, and declarative agent definitions into a unified platform with built-in governance, cost controls, and compliance-grade audit trails.
-
-Redpanda ADP includes the following key components:
-
-* *AI agents*: Declare the behavior you want instead of writing code. Redpanda powers declarative definitions with 300+ connectors.
-* *MCP servers*: Translate agent intent into connections to your business systems using proven connectors, no glue code required.
-* *Transcripts*: End-to-end execution records built on an immutable log with formal correctness guarantees. Transcripts are the keystone of agent governance.
-* *AI Gateway*: High-availability model routing with fiscal controls and per-tenant cost attribution across LLM providers.
+Redpanda Cloud is a complete data streaming platform delivered as a fully-managed service. It provides automated upgrades and patching, data balancing, and support while continuously monitoring your data to meet strict performance, availability, reliability, and security requirements. All Redpanda Cloud clusters are deployed with an integrated glossterm:Redpanda Console[], and all clusters have access to unlimited retention and 300+ data connectors with glossterm:Redpanda Connect[].
 
 == Redpanda Cloud deployment options
 
@@ -41,11 +30,6 @@ Redpanda Cloud applications are supported by three fully-managed deployment opti
 | Redpanda's cloud (AWS/GCP)
 | Redpanda's cloud (AWS/Azure/GCP)
 | Your cloud account (AWS/Azure/GCP)
-
-| *Redpanda ADP*
-| ✗
-| ✗
-| ✓
 
 | *Tenancy*
 | Multi-tenant
@@ -170,7 +154,7 @@ Redpanda creates a cloud organization for you and sends you a welcome email.
 
 === Bring Your Own Cloud (BYOC)
 
-With BYOC clusters, the Redpanda data plane (including Redpanda ADP components and Redpanda brokers) deploys into your existing VPC or VNet, ensuring all data remains in your environment.
+With BYOC clusters, the Redpanda data plane deploys into your existing VPC or VNet, ensuring all data remains in your environment.
 
 With BYOC clusters, you deploy the Redpanda glossterm:data plane[] into your existing VPC (for AWS and GCP) or VNet (for Azure), and all data is
 contained in your own environment. This provides an additional layer of security and isolation. (See xref:get-started:byoc-arch.adoc[].) Redpanda manages provisioning, monitoring, upgrades, and security policies, including the underlying infrastructure and Kubernetes used to run the cluster. Redpanda also manages required resources in your VPC or VNet, including subnets (subnetworks in GCP), IAM roles, and object storage resources (for example, S3 buckets or Azure Storage accounts). For full details, see xref:manage:maintenance.adoc[].
@@ -198,7 +182,6 @@ Serverless clusters are a good fit for the following use cases:
 
 Consider BYOC or Dedicated if you need more control over the deployment or if you have workloads with consistently-high throughput. BYOC and Dedicated clusters offer the following features:
 
-* Redpanda Agentic Data Plane (ADP): BYOC only
 * Multiple availability zones (AZs). A multi-AZ cluster provides higher resiliency in the event of a failure in one of the zones. 
 * Role-based access control (RBAC) in the data plane
 * Group-based access control (GBAC)
@@ -409,7 +392,6 @@ Features in limited availability are production-ready and are covered by Redpand
 
 The following features are currently in limited availability in Redpanda Cloud:
 
-* Redpanda ADP including AI agents, AI Gateway, and transcripts
 * Dedicated for Azure
 
 == Features in beta

--- a/modules/get-started/pages/cluster-types/serverless.adoc
+++ b/modules/get-started/pages/cluster-types/serverless.adoc
@@ -36,8 +36,6 @@ Each Serverless cluster has the following maximum usage limits:
 ** **Max subjects**: 500
 ** **Rate limit**: 100 requests/s
 * **Redpanda Connect pipelines**: 100
-* **MCP servers**: 100
-* **AI agents**: 10
 
 
 NOTE: The partition limit is the number of logical partitions before replication occurs. Redpanda Cloud uses a replication factor of 3.

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -102,9 +102,9 @@ GBAC is available for BYOC and Dedicated clusters. In addition to the predefined
 
 Remote MCP has been deprecated and removed from Redpanda Cloud.
 
-=== Increased Serverless limits for Redpanda Connect pipelines and MCP servers
+=== Increased Serverless limits for Redpanda Connect pipelines
 
-Serverless clusters now support up to 100 Redpanda Connect pipelines and MCP servers. See xref:get-started:cluster-types/serverless.adoc#_serverless_usage_limits[Serverless usage limits].
+Serverless clusters now support up to 100 Redpanda Connect pipelines. See xref:get-started:cluster-types/serverless.adoc#_serverless_usage_limits[Serverless usage limits].
 
 === Terraform provider: Write-only attributes for sensitive fields
 
@@ -200,9 +200,6 @@ Redpanda Cloud now sends email notifications to organization admins when credit 
 
 == February 2026
 
-=== Agentic Data Plane (ADP): LA
-
-Redpanda Agentic Data Plane (ADP) is now available in glossterm:LA[, limited availability] (LA). Redpanda ADP provides enterprise-grade infrastructure for building, deploying, and governing AI agents at scale. Key capabilities include declarative agents, MCP servers backed by 300+ connectors, an AI Gateway with model failover and fiscal controls, and compliance-grade transcripts built on Redpanda's immutable log. 
 === Serverless on AWS: GA
 
 xref:get-started:cluster-types/serverless.adoc[Serverless] on AWS is now generally available (GA). This release includes private networking with AWS PrivateLink. You can use the Cloud Console, the Cloud API, or the Redpanda Terraform provider to create and manage Serverless private links. Serverless is the easiest and fastest way to begin streaming data with Redpanda.

--- a/modules/shared/partials/feature-flag-agents.adoc
+++ b/modules/shared/partials/feature-flag-agents.adoc
@@ -1,5 +1,0 @@
-[IMPORTANT]
-====
-- AI agents are not available on BYOVPC/BYOVNet or Serverless clusters.
-- AI agents are currently in beta and not suitable for use in production.
-==== 


### PR DESCRIPTION
## What

Removes the remaining ADP (Agentic Data Plane) content from cloud-docs. ADP documentation now lives solely in the [adp-docs](https://github.com/redpanda-data/adp-docs) repo.

## Changes

- **cloud-overview**: Drop the "Redpanda Agentic Data Plane (ADP)" overview section, the ADP row in the deployment-options table, and ADP mentions in the BYOC, Serverless, and LA sections. Fix a description typo ("Clouddeployment" → "Cloud deployment").
- **serverless**: Remove the `AI agents` and `MCP servers` serverless usage limits (kept `Redpanda Connect pipelines`).
- **whats-new**: Trim "and MCP servers" from the increased-serverless-limits entry, and drop the "Agentic Data Plane (ADP): LA" changelog entry.
- Delete the orphaned `shared/partials/feature-flag-agents.adoc` (was not included anywhere).

## Not changed (intentionally)

- The **Redpanda Cloud Management MCP Server** (`develop/cloud-mcp/` + `rpk cloud mcp`) stays — it's the local cluster-management tool, not ADP.
- **GBAC role-scope list** (`security/.../gbac.adoc`) keeps `MCP server` — it remains a valid, selectable scope resource in the Cloud Console, independent of where the feature is documented.
- The "Remote MCP: Deprecated" changelog entry and the API Gateway "MCP Server API" networking line were left in place.

## Preview pages

- [Redpanda Cloud Overview](https://deploy-preview-621--rp-cloud.netlify.app/cloud-data-platform/get-started/cloud-overview/) (updated)
- [Serverless](https://deploy-preview-621--rp-cloud.netlify.app/cloud-data-platform/get-started/cluster-types/serverless/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-621--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)