### PR TITLE
DOC-2277: Warn that BYOC GCP credential rotation needs Support

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/gcp/create-byoc-cluster-gcp.adoc
@@ -56,6 +56,8 @@ include::get-started:partial$no-access.adoc[]
 
 include::get-started:partial$custom-tags-gcp.adoc[]
 
+include::security:partial$byoc-gcp-credential-rotation.adoc[]
+
 == Next steps
 
 xref:networking:byoc/gcp/index.adoc[Configure private networking]

--- a/modules/security/pages/authorization/cloud-iam-policies-gcp.adoc
+++ b/modules/security/pages/authorization/cloud-iam-policies-gcp.adoc
@@ -5,3 +5,5 @@
 :env-gcp: true
 
 include::security:partial$iam-policies.adoc[]
+
+include::security:partial$byoc-gcp-credential-rotation.adoc[]

--- a/modules/security/partials/byoc-gcp-credential-rotation.adoc
+++ b/modules/security/partials/byoc-gcp-credential-rotation.adoc
@@ -4,5 +4,5 @@ To rotate service account credentials for your BYOC cluster, contact https://sup
 
 [WARNING]
 ====
-GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt agent connectivity, cluster connectivity, monitoring, and tiered storage uploads, and can leave the cluster stuck and unable to complete future operations.
+GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt agent connectivity, monitoring, and tiered storage uploads, and can leave the cluster stuck and unable to complete future operations.
 ====

--- a/modules/security/partials/byoc-gcp-credential-rotation.adoc
+++ b/modules/security/partials/byoc-gcp-credential-rotation.adoc
@@ -1,0 +1,8 @@
+== Service account credential rotation
+
+To rotate service account credentials for your BYOC cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your cluster ID, the service accounts that need rotation, and your target timeline.
+
+[WARNING]
+====
+GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt cluster connectivity, monitoring, and tiered storage, and can leave the cluster in an unrecoverable state.
+====

--- a/modules/security/partials/byoc-gcp-credential-rotation.adoc
+++ b/modules/security/partials/byoc-gcp-credential-rotation.adoc
@@ -4,5 +4,5 @@ To rotate service account credentials for your BYOC cluster, contact https://sup
 
 [WARNING]
 ====
-GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt cluster connectivity, monitoring, and tiered storage, and can leave the cluster in an unrecoverable state.
+GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt agent connectivity, cluster connectivity, monitoring, and tiered storage uploads, and can leave the cluster stuck and unable to complete future operations.
 ====

--- a/modules/security/partials/byoc-gcp-credential-rotation.adoc
+++ b/modules/security/partials/byoc-gcp-credential-rotation.adoc
@@ -4,5 +4,5 @@ To rotate service account credentials for your BYOC cluster, contact https://sup
 
 [WARNING]
 ====
-GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt agent connectivity, monitoring, and tiered storage uploads, and can leave the cluster stuck and unable to complete future operations.
+GCP service account credential rotation for BYOC clusters is not self-service. Rotating these credentials without coordinating with Redpanda can disrupt agent connectivity, monitoring, and Tiered Storage uploads, and can leave the cluster stuck and unable to complete future operations.
 ====

--- a/modules/security/partials/byoc-gcp-credential-rotation.adoc
+++ b/modules/security/partials/byoc-gcp-credential-rotation.adoc
@@ -1,6 +1,6 @@
 == Service account credential rotation
 
-To rotate service account credentials for your BYOC cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your cluster ID, the service accounts that need rotation, and your target timeline.
+To rotate service account credentials for your BYOC cluster, contact https://support.redpanda.com/hc/en-us/requests/new[Redpanda Support^] with your cluster ID, the service accounts that require rotation, and your target timeline.
 
 [WARNING]
 ====


### PR DESCRIPTION
## What

Adds a **Service account credential rotation** callout to two BYOC GCP pages:

- **GCP IAM Policies** (`cloud-iam-policies-gcp.adoc`) — new section at the bottom.
- **Create a BYOC Cluster on GCP** (`create-byoc-cluster-gcp.adoc`) — section before "Next steps".

The callout text lives in a single shared partial (`security:partial$byoc-gcp-credential-rotation.adoc`) included by both pages, so it stays in sync.

## Why

Customer incident ZD-6896: a BYOC GCP customer rotated their GCP service account credentials without coordinating with Redpanda Support. The agent lost connectivity, the cluster stuck in "Upgrading," tiered storage was disrupted, and recovery took 8 days of Engineering effort. The docs never warned that credential rotation is not self-service. This PR closes that gap.

Resolves [DOC-2277](https://redpandadata.atlassian.net/browse/DOC-2277).

## Notes

- Uses a `[WARNING]` admonition for the not-self-service / disruption risk, with the "contact Support" instructions as body text above it.
- The internal CIAINFRA-3907 reference is intentionally omitted from the public docs.

## Preview pages

- [GCP IAM Policies](https://deploy-preview-625--rp-cloud.netlify.app/cloud-data-platform/security/authorization/cloud-iam-policies-gcp/) (updated)
- [Create a BYOC Cluster on GCP](https://deploy-preview-625--rp-cloud.netlify.app/cloud-data-platform/get-started/cluster-types/byoc/gcp/create-byoc-cluster-gcp/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2277]: https://redpandadata.atlassian.net/browse/DOC-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
