### PR TITLE
DOC-14: document Cloud topic segment size default

### DIFF
--- a/modules/develop/pages/topics/create-topic.adoc
+++ b/modules/develop/pages/topics/create-topic.adoc
@@ -49,7 +49,7 @@ The default is *20 MiB* for BYOC and Dedicated clusters, and *8 MiB* for Serverl
 | *Segment size*
 | The maximum size of a log segment. When a segment reaches this size, Redpanda closes it and starts a new one.
 
-The default is *128 MiB*, set at the cluster level. You can override the segment size for a topic with the `segment.bytes` property, within limits that depend on your cluster tier.
+Redpanda Cloud sets the segment size for your cluster automatically. You can override it for a topic with the `segment.bytes` property.
 |===
 
 == Next steps

--- a/modules/develop/pages/topics/create-topic.adoc
+++ b/modules/develop/pages/topics/create-topic.adoc
@@ -45,6 +45,11 @@ The default is *infinite*.
 | The maximum size of a message or batch for a newly-created topic.
 
 The default is *20 MiB* for BYOC and Dedicated clusters, and *8 MiB* for Serverless clusters. You can increase this value up to *32 MiB* for BYOC and Dedicated clusters, and *20 MiB* for Serverless clusters, with the `max.message.bytes` topic property.
+
+| *Segment size*
+| The maximum size of a log segment. When a segment reaches this size, Redpanda closes it and starts a new one.
+
+The default is *128 MiB*, set at the cluster level. This differs from self-managed Redpanda, where the default is 1 GiB. You can override the segment size for a topic with the `segment.bytes` property, within limits that depend on your cluster tier.
 |===
 
 == Next steps

--- a/modules/develop/pages/topics/create-topic.adoc
+++ b/modules/develop/pages/topics/create-topic.adoc
@@ -49,7 +49,7 @@ The default is *20 MiB* for BYOC and Dedicated clusters, and *8 MiB* for Serverl
 | *Segment size*
 | The maximum size of a log segment. When a segment reaches this size, Redpanda closes it and starts a new one.
 
-The default is *128 MiB*, set at the cluster level. This differs from self-managed Redpanda, where the default is 1 GiB. You can override the segment size for a topic with the `segment.bytes` property, within limits that depend on your cluster tier.
+The default is *128 MiB*, set at the cluster level. You can override the segment size for a topic with the `segment.bytes` property, within limits that depend on your cluster tier.
 |===
 
 == Next steps


### PR DESCRIPTION
Resolves [DOC-14](https://redpandadata.atlassian.net/browse/DOC-14).

## What
Updates the **Segment size** row in the topic-properties table on the Cloud "Topics Overview" page (`modules/develop/pages/topics/create-topic.adoc`) to describe segment size qualitatively, without citing a specific value or tier-dependent limits.

## Why
DOC-14 flagged that Cloud users could mistake the self-managed segment size default (1 GiB) for their Cloud value. The fix clarifies that Cloud differs, without publishing a Cloud number:

* Cloud segment size is set per cluster config profile, not a fixed 128 MiB "cluster default." 

The row now states that Redpanda Cloud sets the segment size automatically and that users can override it per topic with the `segment.bytes` property, with no specific numbers.

## Preview pages

- [Topics Overview](https://deploy-preview-626--rp-cloud.netlify.app/cloud-data-platform/develop/topics/create-topic/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-14]: https://redpandadata.atlassian.net/browse/DOC-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
