### PR TITLE
Clarify which cluster properties are configurable in Redpanda Cloud

### DIFF
--- a/modules/develop/pages/topics/create-topic.adoc
+++ b/modules/develop/pages/topics/create-topic.adoc
@@ -44,7 +44,7 @@ The default is *infinite*.
 | *Message size*
 | The maximum size of a message or batch for a newly-created topic.
 
-The default is *20 MiB* for BYOC and Dedicated clusters, and *8 MiB* for Serverless clusters. You can increase this value up to *32 MiB* for BYOC and Dedicated clusters, and *20 MiB* for Serverless clusters, with the `message.max.bytes` topic property.
+The default is *20 MiB* for BYOC and Dedicated clusters, and *8 MiB* for Serverless clusters. You can increase this value up to *32 MiB* for BYOC and Dedicated clusters, and *20 MiB* for Serverless clusters, with the `max.message.bytes` topic property.
 |===
 
 == Next steps

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -267,7 +267,7 @@ You can view details about Kafka client connections using `rpk` or the Data Plan
 
 === Increased message size limit
 
-Redpanda Cloud increased the xref:develop:topics/create-topic.adoc[message size limit] on newly-created topics. BYOC and Dedicated clusters have a default message size limit of 20 MiB with a maximum of 32 MiB. Serverless clusters have a default message size limit of 8 MiB with a maximum of 20 MiB. Configure the message size limit with the `max_message_bytes` topic property.
+Redpanda Cloud increased the xref:develop:topics/create-topic.adoc[message size limit] on newly-created topics. BYOC and Dedicated clusters have a default message size limit of 20 MiB with a maximum of 32 MiB. Serverless clusters have a default message size limit of 8 MiB with a maximum of 20 MiB. Configure the message size limit with the `max.message.bytes` topic property.
 
 The message size setting on existing topics is not changed, but the message size limit on existing topics can only be updated to the new maximum.
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -22,7 +22,7 @@ Cluster properties are supported on BYOC and Dedicated clusters running on AWS a
 - They are not available on BYOC and Dedicated clusters running on Azure.
 - They are not available on Serverless clusters.
 
-Only the cluster properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] can be configured in Redpanda Cloud. Setting any other property through `rpk`, the Cloud API, or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider] returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. To control the maximum message size, see <<max-message-size>>.
+Only the cluster properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] are configurable in Redpanda Cloud. Setting an unsupported property through the Cloud API or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider] returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. To control the maximum message size, see <<max-message-size>>.
 
 
 == Set cluster configuration properties
@@ -168,7 +168,7 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 
 To control the maximum message size in Redpanda Cloud, set the `max.message.bytes` property on each topic. The default is 20 MiB for BYOC and Dedicated clusters and 8 MiB for Serverless clusters. You can increase it up to 32 MiB for BYOC and Dedicated clusters and 20 MiB for Serverless clusters. To set this property, see xref:develop:topics/create-topic.adoc[].
 
-The cluster property `kafka_batch_max_bytes` is not configurable in Redpanda Cloud. Setting it through `rpk`, the Cloud API, or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider] returns `REASON_INVALID_INPUT` with the message `The properties [kafka_batch_max_bytes] are not allowed`.
+The cluster property `kafka_batch_max_bytes` cannot be set through the Cloud API or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider]. Attempting to set it returns `REASON_INVALID_INPUT` with the message `The properties [kafka_batch_max_bytes] are not allowed`.
 
 == View cluster property values
 

--- a/modules/manage/pages/cluster-maintenance/config-cluster.adoc
+++ b/modules/manage/pages/cluster-maintenance/config-cluster.adoc
@@ -17,13 +17,15 @@ To verify that you're logged into the Redpanda control plane and have the correc
 
 == Limitations
 
-Cluster properties are supported on BYOC and Dedicated clusters running on AWS and GCP. 
+Cluster properties are supported on BYOC and Dedicated clusters running on AWS and GCP.
 
 - They are not available on BYOC and Dedicated clusters running on Azure.
-- They are not available on Serverless clusters. 
+- They are not available on Serverless clusters.
+
+Only the cluster properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] can be configured in Redpanda Cloud. Setting any other property through `rpk`, the Cloud API, or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider] returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. To control the maximum message size, see <<max-message-size>>.
 
 
-== Set cluster configuration properties 
+== Set cluster configuration properties
 
 You can set cluster configuration properties using the `rpk` command-line tool or the Cloud API.
 
@@ -160,6 +162,13 @@ curl -H "Authorization: Bearer ${RP_CLOUD_TOKEN}" -X PATCH \
 ----
 --
 ====
+
+[[max-message-size]]
+== Configure the maximum message size
+
+To control the maximum message size in Redpanda Cloud, set the `max.message.bytes` property on each topic. The default is 20 MiB for BYOC and Dedicated clusters and 8 MiB for Serverless clusters. You can increase it up to 32 MiB for BYOC and Dedicated clusters and 20 MiB for Serverless clusters. To set this property, see xref:develop:topics/create-topic.adoc[].
+
+The cluster property `kafka_batch_max_bytes` is not configurable in Redpanda Cloud. Setting it through `rpk`, the Cloud API, or the xref:manage:terraform-provider.adoc[Redpanda Terraform provider] returns `REASON_INVALID_INPUT` with the message `The properties [kafka_batch_max_bytes] are not allowed`.
 
 == View cluster property values
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -325,7 +325,7 @@ resource "redpanda_cluster" "test" {
 }
 ----
 
-Only the properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] can be configured in Redpanda Cloud. Setting any other property returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. For example, `kafka_batch_max_bytes` is not configurable through the provider. To control the maximum message size, set the `max.message.bytes` property on each topic instead. For more information, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+Only the properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] can be configured through the provider. Setting an unsupported property returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. For example, `kafka_batch_max_bytes` cannot be set through the provider. To control the maximum message size, set the `max.message.bytes` property on each topic instead. For more information, see xref:manage:cluster-maintenance/config-cluster.adoc[].
 
 NOTE: Cluster properties are not available on Serverless clusters or on BYOC and Dedicated clusters running on Azure.
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -308,6 +308,27 @@ resource "redpanda_user" "schema_user" {
 
 After running `terraform apply`, the provider sends the new password to Redpanda Cloud. Neither the old nor the new value is written to state.
 
+== Configure cluster properties
+
+To set xref:reference:properties/cluster-properties.adoc[cluster configuration properties] on a BYOC or Dedicated cluster, add a `cluster_configuration` block to the `redpanda_cluster` resource and pass the properties as a JSON string with `custom_properties_json`:
+
+[source,hcl]
+----
+resource "redpanda_cluster" "test" {
+  # ... other cluster arguments ...
+
+  cluster_configuration = {
+    custom_properties_json = jsonencode({
+      "audit_enabled" = true
+    })
+  }
+}
+----
+
+Only the properties listed in xref:reference:properties/cluster-properties.adoc[] and xref:reference:properties/object-storage-properties.adoc[] can be configured in Redpanda Cloud. Setting any other property returns a `REASON_INVALID_INPUT` error indicating that the property is not allowed. For example, `kafka_batch_max_bytes` is not configurable through the provider. To control the maximum message size, set the `max.message.bytes` property on each topic instead. For more information, see xref:manage:cluster-maintenance/config-cluster.adoc[].
+
+NOTE: Cluster properties are not available on Serverless clusters or on BYOC and Dedicated clusters running on Azure.
+
 == Examples
 
 The following examples use the Redpanda Terraform provider to create and manage clusters. For descriptions of resources and data sources, see the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs[Redpanda Terraform Provider documentation^].


### PR DESCRIPTION
## What

Clarifies which cluster configuration properties can be set in Redpanda Cloud (via `rpk`, the Cloud API, or the Terraform provider), and redirects users to the topic-level property for controlling maximum message size.

Prompted by a customer/field report: a BYOC user tried to set `kafka_batch_max_bytes` through the Terraform provider and hit `REASON_INVALID_INPUT ... The properties [kafka_batch_max_bytes] are not allowed`. The provider passes the property through correctly; the Cloud control-plane API rejects it because only an allowlisted subset of properties is accepted in `cluster_configuration.custom_properties`. The docs didn't state this, and the AI assistant recommended a cluster property that Cloud doesn't accept.

## Changes

- **`manage/cluster-maintenance/config-cluster.adoc`**
  - Limitations: note that only properties in the Cloud reference are configurable; setting others returns `REASON_INVALID_INPUT`.
  - New "Configure the maximum message size" section: use topic-level `max.message.bytes`; `kafka_batch_max_bytes` is not configurable in Cloud.
- **`manage/terraform-provider.adoc`**
  - New "Configure cluster properties" section showing the `cluster_configuration { custom_properties_json = jsonencode({...}) }` syntax, the allowlist caveat, and the `kafka_batch_max_bytes` example, plus a Serverless/Azure note.
- **`develop/topics/create-topic.adoc`** and **`get-started/whats-new-cloud.adoc`**
  - Correct the topic property name to `max.message.bytes` (was `message.max.bytes` / `max_message_bytes`).

## Notes for reviewers

- Open product question: is there any supported way to set a **cluster-wide default** max message size in Cloud (Console or API), or is topic-level `max.message.bytes` the only path? These edits state the topic-level path, which is accurate today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview pages

- [Configure Cluster Properties](https://deploy-preview-627--rp-cloud.netlify.app/cloud-data-platform/manage/cluster-maintenance/config-cluster/) (updated)
- [Redpanda Terraform Provider](https://deploy-preview-627--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/) (updated)
- [Topics Overview](https://deploy-preview-627--rp-cloud.netlify.app/cloud-data-platform/develop/topics/create-topic/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-627--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)
