### PR TITLE
DOC-2289: Emphasize required setup steps for remote read replicas (BYOVPC)

### DIFF
--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -20,7 +20,7 @@ Creating the remote read replica topic is only one of several required steps. To
 To use remote read replicas, you need:
 
 * A BYOC reader cluster in Ready state. This separate reader cluster must exist in the same Redpanda organization as the source cluster.
-** AWS: The reader cluster can be in the same or a different region as the origin cluster's S3 bucket. For cross-region remote read replica topics, see <<create-cross-region-rrr-topic>>.
+** AWS: The reader cluster must be in the same region and the same account as the source cluster.
 ** GCP: The reader cluster can be in the same or a different region as the source cluster. The reader cluster must be in the same project as the source cluster.
 ** Azure: Remote read replicas are not supported.
 
@@ -59,17 +59,24 @@ This should be done in the Terraform of the reader cluster.
 --
 ======
 
+If the reader cluster's service account does not have read access to the source cluster's storage bucket, creating the remote read replica topic fails with an error like `UNKNOWN_SERVER_ERROR: Unable to perform requested topic operation`.
+
 [[link-clusters]]
 == Link the reader cluster to the source cluster
 
 Linking is a required step. It does more than record the relationship between the clusters:
 
 * It orders upgrades safely across the linked clusters.
-* It prevents the source cluster from being deleted while a reader cluster is still reading from it.
+* It prevents the source cluster from being deleted while it is linked to a reader cluster.
+
+The way linking interacts with storage permissions depends on your deployment type:
+
+* Standard BYOC: Linking the clusters grants the reader cluster read access to the source cluster's storage bucket, so you cannot create a remote read replica topic until the clusters are linked.
+* BYOVPC: You grant the reader cluster read access to the bucket manually (see <<byovpc-storage-permissions>>), so creating the topic succeeds even when the clusters are not linked. This makes the linking step easy to miss.
 
 [WARNING]
 ====
-Creating a remote read replica topic does _not_ link the reader cluster to the source cluster. You must also set `read_replica_cluster_ids` as described in this section. Without this link, upgrades are not ordered safely across the clusters, and the source cluster is not protected from deletion while a reader is still reading.
+Creating a remote read replica topic does _not_ link the reader cluster to the source cluster. You must also set `read_replica_cluster_ids` as described in this section. Without this link, upgrades are not ordered safely across the clusters, and the source cluster is not protected from deletion, even if remote read replica topics exist.
 ====
 
 Add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:cloud-data-platform:manage:api/controlplane/index.adoc[Cloud Control Plane API]. For information on accessing the Cloud API, see the link:/api/doc/cloud-controlplane/authentication[authentication guide].
@@ -102,7 +109,7 @@ curl -X GET $API_HOST/v1/clusters/$SOURCE_CLUSTER_ID \
 
 [NOTE]
 ====
-A source cluster cannot be deleted if it has remote read replica topics. When you delete a reader cluster, that cluster's ID is removed from any existing source cluster `read_replica_cluster_ids` lists.
+A source cluster cannot be deleted while any reader cluster IDs are set in its `read_replica_cluster_ids` list. This deletion protection is based on the link, not on the existence of remote read replica topics. When you delete a reader cluster, that cluster's ID is automatically removed from any existing source cluster `read_replica_cluster_ids` lists.
 
 ====
 
@@ -119,48 +126,6 @@ rpk topic create <topic_name> -c redpanda.remote.readreplica=<source-cluster-buc
 - For `<source-cluster-bucket-name>`, use the bucket specified in the `cloud_storage_bucket` properties for the origin cluster.
 
 For standard BYOC clusters, the source cluster bucket name follows the pattern: `redpanda-cloud-storage-${SOURCE_CLUSTER_ID}`
-
-[[create-cross-region-rrr-topic]]
-=== Create a cross-region remote read replica topic on AWS
-
-Use this configuration only when the remote cluster is in a *different AWS region* than the origin cluster's S3 bucket. For same-region AWS or GCP deployments, use the standard <<create-remote-read-replica-topic,topic creation command>>.
-
-==== Create the topic
-
-To create a cross-region remote read replica topic, append `region` and `endpoint` query-string parameters to the bucket name.
-
-In the following example, replace the placeholders:
-
-- `<topic_name>`: The name of the topic in the cluster hosting the remote read replica.
-- `<bucket_name>`: The S3 bucket configured on the origin cluster (`cloud_storage_bucket`).
-- `<origin_bucket_region>`: The AWS region of the origin cluster's S3 bucket (not the remote cluster's region). 
-
-[,bash]
-----
-rpk topic create <topic_name> \
-  -c redpanda.remote.readreplica=<bucket_name>?region=<origin_bucket_region>&endpoint=s3.<origin_bucket_region>.amazonaws.com
-  --tls-enabled
-----
-
-For example, if the origin cluster stores data in a bucket called `my-bucket` in `us-east-1`:
-
-[,bash]
-----
-rpk topic create my-topic \
-  -c redpanda.remote.readreplica=my-bucket?region=us-east-1&endpoint=s3.us-east-1.amazonaws.com
-  --tls-enabled
-----
-
-NOTE: The `endpoint` value must not include the bucket name. When using `virtual_host` URL style, Redpanda automatically prepends the bucket name to the endpoint. When using `path` URL style, Redpanda appends the bucket name as a path segment.
-
-==== Limits
-
-Each unique combination of region and endpoint creates a separate object storage target on the remote cluster. A cluster supports a maximum of 10 targets.
-
-How targets are counted depends on `cloud_storage_url_style`:
-
-- `virtual_host`: Each unique combination of bucket, region, and endpoint counts as one target. You can create up to 10 distinct cross-region remote read replica topics for each cluster.
-- `path`: Each unique combination of region and endpoint counts as one target (the bucket name is not part of the key). You can create cross-region remote read replica topics for multiple buckets using the same region/endpoint combination, with a maximum of 10 distinct region/endpoint combinations for each cluster.
 
 == Optional: Tune for live topics
 

--- a/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
+++ b/modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc
@@ -6,6 +6,15 @@ A remote read replica topic is a read-only topic that mirrors a topic on a diffe
 
 Redpanda Cloud supports remote read replica topics in BYOC clusters on AWS or GCP. These clusters can be ephemeral; that is, created temporarily to handle specific or transient workloads, but they don't have to be. The ability to make them ephemeral provides flexibility and cost efficiency: you can scale resources up or down as needed and pay only for what you use. 
 
+[IMPORTANT]
+====
+Creating the remote read replica topic is only one of several required steps. To set up a remote read replica, you must complete all of the following:
+
+. *BYOVPC only*: Grant the reader cluster's service account read access to the source cluster's storage bucket. See <<byovpc-storage-permissions>>.
+. Link the reader cluster to the source cluster by setting `read_replica_cluster_ids`. See <<link-clusters>>. Creating the topic alone does _not_ link the clusters.
+. Create the remote read replica topic. See <<create-remote-read-replica-topic>>.
+====
+
 == Prerequisites
 
 To use remote read replicas, you need:
@@ -15,6 +24,7 @@ To use remote read replicas, you need:
 ** GCP: The reader cluster can be in the same or a different region as the source cluster. The reader cluster must be in the same project as the source cluster.
 ** Azure: Remote read replicas are not supported.
 
+[[byovpc-storage-permissions]]
 === BYOVPC: Grant storage permissions
 
 [NOTE]
@@ -49,7 +59,18 @@ This should be done in the Terraform of the reader cluster.
 --
 ======
 
-== Configure remote read replica
+[[link-clusters]]
+== Link the reader cluster to the source cluster
+
+Linking is a required step. It does more than record the relationship between the clusters:
+
+* It orders upgrades safely across the linked clusters.
+* It prevents the source cluster from being deleted while a reader cluster is still reading from it.
+
+[WARNING]
+====
+Creating a remote read replica topic does _not_ link the reader cluster to the source cluster. You must also set `read_replica_cluster_ids` as described in this section. Without this link, upgrades are not ordered safely across the clusters, and the source cluster is not protected from deletion while a reader is still reading.
+====
 
 Add or remove reader clusters to a source cluster in Redpanda Cloud with the xref:cloud-data-platform:manage:api/controlplane/index.adoc[Cloud Control Plane API]. For information on accessing the Cloud API, see the link:/api/doc/cloud-controlplane/authentication[authentication guide].
 
@@ -85,6 +106,7 @@ A source cluster cannot be deleted if it has remote read replica topics. When yo
 
 ====
 
+[[create-remote-read-replica-topic]]
 == Create remote read replica topic
 
 To create a remote read replica topic, run:
@@ -101,7 +123,7 @@ For standard BYOC clusters, the source cluster bucket name follows the pattern: 
 [[create-cross-region-rrr-topic]]
 === Create a cross-region remote read replica topic on AWS
 
-Use this configuration only when the remote cluster is in a *different AWS region* than the origin cluster's S3 bucket. For same-region AWS or GCP deployments, use the standard <<Create remote read replica topic,topic creation command>>.
+Use this configuration only when the remote cluster is in a *different AWS region* than the origin cluster's S3 bucket. For same-region AWS or GCP deployments, use the standard <<create-remote-read-replica-topic,topic creation command>>.
 
 ==== Create the topic
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -182,10 +182,6 @@ See xref:manage:iceberg/specify-iceberg-schema.adoc#how-iceberg-modes-translate-
 
 xref:develop:produce-data/leader-pinning.adoc[Leader pinning] now supports the `ordered_racks` configuration value, which lets you specify preferred racks in priority order. Unlike `racks`, which distributes leaders uniformly across all listed racks, `ordered_racks` places leaders in the highest-priority available rack and fails over to subsequent racks only when higher-priority racks become unavailable.
 
-=== Cross-region Remote Read Replicas on AWS
-
-xref:get-started:cluster-types/byoc/remote-read-replicas.adoc[Remote read replica] topics on AWS can now be deployed in a different region from the origin cluster's S3 bucket. This enables cross-region disaster recovery and data locality scenarios while maintaining the read-only replication model. 
-
 === BYOVPC on AWS: GA
 
 xref:get-started:cluster-types/byoc/aws/vpc-byo-aws.adoc[BYOVPC on AWS] is now generally available (GA). With Bring Your Own VPC (BYOVPC), you deploy the Redpanda data plane into your own VPC and manage security policies and resources yourself, including subnets, IAM roles, firewall rules, and storage buckets. The Redpanda BYOVPC Terraform Module contains Terraform code that deploys the resources required for a BYOVPC cluster on AWS. Secrets management is enabled by default with the Terraform module. 


### PR DESCRIPTION
## What

Restructures the BYOC remote read replicas (RRR) page to make the required setup steps stand out, so users stop skipping the cluster-linking step. Also removes cross-region RRR on AWS, which was mistakenly documented for Cloud.

Ref: DOC-2289 (Zendesk 7005, customer escalation)

## Why

A customer creating an RRR topic in a BYOVPC deployment hit `UNKNOWN_SERVER_ERROR: Unable to perform requested topic operation`. Two required steps were documented but not prominent, so they were missed:

1. Granting the reader cluster's service account read access to the source cluster's storage bucket.
2. Linking the clusters via `read_replica_cluster_ids`. The customer created the topic but never linked, and it was silently missed (caught only by an engineer reviewing the thread, not by alerting).

## Changes

In `modules/get-started/pages/cluster-types/byoc/remote-read-replicas.adoc`:

- Added an `IMPORTANT` callout before Prerequisites listing the three required steps up front, including "Creating the topic alone does not link the clusters."
- Renamed "Configure remote read replica" to "Link the reader cluster to the source cluster" so the required action is clear in the heading and TOC.
- Added the rationale for linking (safe upgrade ordering + source-deletion protection) and a `WARNING` that creating the topic does not link the clusters.
- Added section anchors (`byovpc-storage-permissions`, `link-clusters`, `create-remote-read-replica-topic`).
- Clarified that source-cluster deletion protection triggers on the `read_replica_cluster_ids` link, not on RRR topics existing (confirmed by Sarah Haskins in DOC-2289 and in review comments below).
- Explained how linking interacts with storage permissions: on standard BYOC, linking grants the reader's bucket access, so topic creation fails until the clusters are linked; on BYOVPC, bucket access is granted manually, so the topic can be created without the link.
- Added a troubleshooting note: missing bucket permissions cause topic creation to fail with `UNKNOWN_SERVER_ERROR: Unable to perform requested topic operation` (the exact customer symptom).
- Removed the "Create a cross-region remote read replica topic on AWS" section and restored the same-region AWS prerequisite. Cross-region RRR on AWS is not supported in Cloud; it was added by mistake in #524 (DOC-1599), confirmed by Sarah Haskins.

In `modules/get-started/pages/whats-new-cloud.adoc`:

- Removed the March 2026 "Cross-region Remote Read Replicas on AWS" entry for the same reason.

## Not included (deferred)

- Discoverability / navigation changes for BYOVPC content (ask #2 in the ticket) are held pending scope confirmation from the reporter.
- The Self-Managed docs for cross-region RRR (docs#1595) may also need review; pending confirmation whether the feature is valid for Self-Managed.

## Preview pages

- [Create Remote Read Replicas](https://deploy-preview-628--rp-cloud.netlify.app/cloud-data-platform/get-started/cluster-types/byoc/remote-read-replicas/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-628--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
