### PR TITLE
DOC-1384: Add Manage Your Organization page for Serverless org deletion

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -405,6 +405,7 @@
 *** xref:develop:managed-connectors/create-snowflake-connector.adoc[Snowflake Sink Connector]
 
 * xref:manage:index.adoc[Manage]
+** xref:manage:manage-organization.adoc[]
 ** xref:manage:rpk/index.adoc[Redpanda CLI]
 *** xref:manage:rpk/intro-to-rpk.adoc[]
 *** xref:manage:rpk/rpk-install.adoc[]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -10,7 +10,7 @@ This page lists new features added to Redpanda Cloud.
 
 === Self-service organization deletion for Serverless
 
-You can now permanently delete a Serverless organization (free trial and pay-as-you-go plans) directly from the Cloud UI, without contacting Redpanda Support. The new *Manage organization* page, available from your profile menu, shows your plan and organization-wide resource counts, and walks you through the deletion prerequisites: delete all clusters, delete all private links, and settle any pending or outstanding invoices. See xref:manage:manage-organization.adoc[Manage Your Organization].
+You can now permanently delete a Serverless organization (free trial and pay-as-you-go plans) directly from the Cloud UI, without contacting Redpanda Support. The new *Manage organization* page, available from your profile icon, shows your plan and organization-wide resource counts, and walks you through the deletion prerequisites: delete all clusters, delete all private links, and settle any pending or outstanding invoices. See xref:manage:manage-organization.adoc[Manage Your Organization].
 
 == June 2026
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -6,6 +6,12 @@
 
 This page lists new features added to Redpanda Cloud.
 
+== July 2026
+
+=== Self-service organization deletion for Serverless
+
+You can now permanently delete a Serverless organization (free trial and pay-as-you-go plans) directly from the Cloud UI, without contacting Redpanda Support. The new *Manage organization* page, available from your profile menu, shows your plan and organization-wide resource counts, and walks you through the deletion prerequisites: delete all clusters, delete all private links, and settle any pending or outstanding invoices. See xref:manage:manage-organization.adoc[Manage Your Organization].
+
 == June 2026
 
 === Terraform provider: Redpanda SQL support

--- a/modules/manage/pages/manage-organization.adoc
+++ b/modules/manage/pages/manage-organization.adoc
@@ -18,7 +18,7 @@ After reading this page, you will be able to:
 
 To open the *Manage organization* page, sign in to https://cloud.redpanda.com[Redpanda Cloud^], click your profile icon, and select *Manage organization*.
 
-The page shows your plan (for example, *Free trial* or *Pay-as-you-go*) and the resources in your organization. Each count links to the page where you manage that resource.
+The page shows your plan (for example, *Free trial* or *Pay-as-you-go*) and the resources in your organization. Each resource count links to the page where you manage that resource.
 
 == Delete your organization
 
@@ -26,14 +26,14 @@ You can delete Serverless organizations on the free trial and pay-as-you-go plan
 
 [WARNING]
 ====
-Deleting an organization cannot be undone. All organization data and resources are permanently deleted.
+Deleting an organization cannot be undone. Redpanda permanently deletes all organization data and resources.
 ====
 
-To delete organizations on other plans, including BYOC and Dedicated, contact https://support.redpanda.com/[Redpanda Support^].
+To delete organizations on other plans, including Bring Your Own Cloud (BYOC) and Dedicated, contact https://support.redpanda.com/[Redpanda Support^].
 
 === Prerequisites
 
-* You must have permission to delete the organization. If you do not have permission, the *Manage organization* page prompts you to contact an administrator in your organization.
+* Confirm that you have permission to delete the organization. If you do not have permission, the *Manage organization* page prompts you to contact an administrator in your organization. See xref:security:authorization/cloud-authorization.adoc[].
 * Delete all clusters in the organization.
 * Delete all private links. Private links incur charges even when they are not attached to a cluster. See xref:networking:serverless/index.adoc[].
 * Settle all invoices. You cannot delete an organization with pending usage or outstanding invoices. Pending usage settles automatically at the end of the billing period. Return to delete your organization after it settles. See xref:billing:view-billing-activity.adoc[].
@@ -46,7 +46,7 @@ The *Manage organization* page shows each prerequisite in a checklist, with a li
 . Click *Delete*.
 . In the confirmation dialog, type the name of your organization, and click *Permanently delete*.
 
-Redpanda Cloud signs you out and confirms that deletion has started. All organization resources are usually removed within two days. You do not need to take any further action.
+Redpanda Cloud signs you out and confirms that deletion has started. Redpanda usually removes all organization resources within two days. You do not need to take any further action.
 
 You can optionally answer a short exit survey to tell Redpanda why you deleted your organization.
 
@@ -55,3 +55,4 @@ NOTE: Deleting your organization is not the same as a data privacy erasure reque
 == Next steps
 
 * xref:get-started:cluster-types/serverless.adoc[]
+* xref:billing:view-billing-activity.adoc[]

--- a/modules/manage/pages/manage-organization.adoc
+++ b/modules/manage/pages/manage-organization.adoc
@@ -1,0 +1,57 @@
+= Manage Your Organization
+:description: View details about your Redpanda Cloud organization and delete your Serverless organization from the Manage organization page.
+:page-topic-type: how-to
+:personas: app_developer, platform_admin
+:learning-objective-1: Locate organization details, such as your plan and resource counts, in the Cloud UI
+:learning-objective-2: Complete the prerequisites to delete a Serverless organization
+:learning-objective-3: Permanently delete a Serverless organization
+
+Use the *Manage organization* page to see your plan and organization-wide resources at a glance, and to permanently delete your organization when you no longer need it.
+
+After reading this page, you will be able to:
+
+* [ ] {learning-objective-1}
+* [ ] {learning-objective-2}
+* [ ] {learning-objective-3}
+
+== View organization details
+
+To open the *Manage organization* page, sign in to https://cloud.redpanda.com[Redpanda Cloud^], click your profile icon, and select *Manage organization*.
+
+The page shows your plan (for example, *Free trial* or *Pay-as-you-go*) and the resources in your organization. Each count links to the page where you manage that resource.
+
+== Delete your organization
+
+You can delete Serverless organizations on the free trial and pay-as-you-go plans directly from the *Manage organization* page. Deleting your organization removes all of its resources, including clusters, users, service accounts, resource groups, networks, and Redpanda Connect pipelines.
+
+[WARNING]
+====
+Deleting an organization cannot be undone. All organization data and resources are permanently deleted.
+====
+
+To delete organizations on other plans, including BYOC and Dedicated, contact https://support.redpanda.com/[Redpanda Support^].
+
+=== Prerequisites
+
+* You must have permission to delete the organization. If you do not have permission, the *Manage organization* page prompts you to contact an administrator in your organization.
+* Delete all clusters in the organization.
+* Delete all private links. Private links incur charges even when they are not attached to a cluster. See xref:networking:serverless/index.adoc[].
+* Settle all invoices. You cannot delete an organization with pending usage or outstanding invoices. Pending usage settles automatically at the end of the billing period. Return to delete your organization after it settles. See xref:billing:view-billing-activity.adoc[].
+
+The *Manage organization* page shows each prerequisite in a checklist, with a link to resolve any that are unmet. The *Delete* button stays unavailable until all prerequisites are complete.
+
+=== Delete the organization
+
+. On the *Manage organization* page, confirm that all items in the prerequisites checklist are complete.
+. Click *Delete*.
+. In the confirmation dialog, type the name of your organization, and click *Permanently delete*.
+
+Redpanda Cloud signs you out and confirms that deletion has started. All organization resources are usually removed within two days. You do not need to take any further action.
+
+You can optionally answer a short exit survey to tell Redpanda why you deleted your organization.
+
+NOTE: Deleting your organization is not the same as a data privacy erasure request. For personal data requests, see the https://www.redpanda.com/legal/privacy-policy[Redpanda privacy policy^].
+
+== Next steps
+
+* xref:get-started:cluster-types/serverless.adoc[]

--- a/modules/manage/pages/manage-organization.adoc
+++ b/modules/manage/pages/manage-organization.adoc
@@ -44,7 +44,7 @@ The *Manage organization* page shows each prerequisite in a checklist, with a li
 
 . On the *Manage organization* page, confirm that all items in the prerequisites checklist are complete.
 . Click *Delete*.
-. In the confirmation dialog, type the name of your organization, and click *Permanently delete*.
+. In the confirmation dialog, type the name of your organization, and click *Confirm delete*.
 
 Redpanda Cloud signs you out and confirms that deletion has started. Redpanda usually removes all organization resources within two days. You do not need to take any further action.
 


### PR DESCRIPTION
## Summary

Documents the new self-service organization deletion feature for Serverless ([ENG-538](https://redpandadata.atlassian.net/browse/ENG-538), shipped to production 2026-07-06). Resolves [DOC-1384](https://redpandadata.atlassian.net/browse/DOC-1384).

## Changes

- **New page** `modules/manage/pages/manage-organization.adoc`: covers the new **Manage organization** page in the Cloud UI (reached from the profile menu) and the deletion flow for Serverless orgs on the free trial and pay-as-you-go plans: prerequisites checklist (delete clusters, delete private links, settle invoices), permission behavior, type-to-confirm dialog, and post-deletion behavior (~2-day resource removal, exit survey).
- **Nav**: added the page as the first entry in the **Manage** section.
- **What's New**: added a July 2026 entry linking to the new page.

## Notes for reviewers

- Button labels (*Delete*, *Permanently delete*) follow the final copy agreed in the July 6 review meeting and cloudv2#27477; please flag if the shipped UI differs.
- The Cloud API also exposes `DELETE /v1/organizations/current`; not documented here until the API spec update (api-docs#72) is published.

## Preview pages

- [Manage Your Organization](https://deploy-preview-629--rp-cloud.netlify.app/cloud-data-platform/manage/manage-organization/) (new)
- [What's New in Redpanda Cloud](https://deploy-preview-629--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-538]: https://redpandadata.atlassian.net/browse/ENG-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-1384]: https://redpandadata.atlassian.net/browse/DOC-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
