### PR TITLE
docs: add try_catch processor to Cloud

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -246,6 +246,7 @@
 **** xref:develop:connect/components/processors/sync_response.adoc[]
 **** xref:develop:connect/components/processors/text_chunker.adoc[]
 **** xref:develop:connect/components/processors/try.adoc[]
+**** xref:develop:connect/components/processors/try_catch.adoc[]
 **** xref:develop:connect/components/processors/unarchive.adoc[]
 **** xref:develop:connect/components/processors/while.adoc[]
 **** xref:develop:connect/components/processors/workflow.adoc[]

--- a/modules/develop/pages/connect/components/processors/try_catch.adoc
+++ b/modules/develop/pages/connect/components/processors/try_catch.adoc
@@ -1,0 +1,4 @@
+= try_catch
+:page-aliases: components:processors/try_catch.adoc
+
+include::connect:components:processors/try_catch.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -28,6 +28,11 @@ A new guide walks Cloud customers through configuring IAM Roles for Service Acco
 
 You can now set cluster-wide defaults for new topics on BYOC and Dedicated clusters. The xref:reference:properties/cluster-properties.adoc#default_topic_partitions[`default_topic_partitions`], xref:reference:properties/cluster-properties.adoc#log_retention_ms[`log_retention_ms`], and xref:reference:properties/cluster-properties.adoc#retention_bytes[`retention_bytes`] cluster properties are now customer-managed. The default topic retention period (`log_retention_ms`) previously could only be changed by Redpanda support. See xref:manage:cluster-maintenance/config-cluster.adoc[Configure Cluster Properties].
 
+=== Redpanda Connect updates
+
+* Processors:
+** xref:develop:connect/components/processors/try_catch.adoc[try_catch]: Combines the behavior of the `try` and `catch` processors into a single block with an explicit recovery path.
+
 == May 2026
 
 === Redpanda Console: redesigned Security page


### PR DESCRIPTION
## Summary

Adds the cloud-docs page for the `try_catch` processor, which is cloud-supported as of Redpanda Connect 4.98.0 but was missing a cloud-docs page (flagged by the auto-docs generation run and CodeRabbit on redpanda-data/rp-connect-docs#452).

- Single-sourced stub at `modules/develop/pages/connect/components/processors/try_catch.adoc` (includes `connect:components:processors/try_catch.adoc[tag=single-source]`)
- Nav entry in alphabetical position (after `try`)
- What's New entry under June 2026, following the string_split precedent (#547)

## Dependency

⚠️ **Draft until redpanda-data/rp-connect-docs#452 merges.** The cloud-docs playbook builds `rp-connect-docs` from `main`, so the include target (`try_catch.adoc` source page) does not exist yet and the preview will fail to resolve it until that PR lands. Mark ready for review after #452 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)