### PR TITLE
DOC-2199, ENG-1063: Document Terraform redpanda_secret and cross-region AWS PrivateLink

### DIFF
--- a/modules/develop/pages/connect/configuration/secret-management.adoc
+++ b/modules/develop/pages/connect/configuration/secret-management.adoc
@@ -1,5 +1,5 @@
 = Manage Secrets
-:description: Learn how to manage secrets in Redpanda Connect using the Cloud UI, Data Plane API, or Terraform, and how to add them to your data pipelines.
+:description: Learn how to manage secrets in Redpanda Connect using the Cloud Console, Data Plane API, or Terraform, and learn how to add them to your data pipelines.
 
 Learn how to manage secrets in Redpanda Connect, and how to add them to your data pipelines without exposing them.
 

--- a/modules/develop/pages/connect/configuration/secret-management.adoc
+++ b/modules/develop/pages/connect/configuration/secret-management.adoc
@@ -1,5 +1,5 @@
 = Manage Secrets
-:description: Learn how to manage secrets in Redpanda Connect using the Cloud UI or Data Plane API, and how to add them to your data pipelines.
+:description: Learn how to manage secrets in Redpanda Connect using the Cloud UI, Data Plane API, or Terraform, and how to add them to your data pipelines.
 
 Learn how to manage secrets in Redpanda Connect, and how to add them to your data pipelines without exposing them.
 
@@ -7,7 +7,7 @@ Secrets are stored in the secret management solution of your cloud provider and 
 
 == Manage secrets
 
-You can manage secrets from the Cloud UI or the Data Plane API.
+You can manage secrets from the Cloud UI or the Data Plane API. If you manage your Redpanda Cloud resources with Terraform, you can also create secrets with the `redpanda_secret` resource. See xref:manage:terraform-provider.adoc#manage-cluster-secrets[Manage cluster secrets].
 
 === Create a secret
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -26,6 +26,10 @@ You can now permanently delete a Serverless organization (free trial and pay-as-
 
 The Redpanda Terraform provider (v2.1.0+) now supports enabling and managing Redpanda SQL on BYOC clusters on AWS. Use the `rpsql` block on a `redpanda_cluster` resource to enable SQL, configure compute replicas, and retrieve the SQL endpoint URL. See xref:manage:terraform-provider.adoc#enable-redpanda-sql-on-a-byoc-cluster[Enable Redpanda SQL on a BYOC cluster].
 
+=== Terraform provider: Secrets management
+
+The Redpanda Terraform provider (v2.0.0+) now supports managing cluster secrets with the new `redpanda_secret` resource. The secret value is a write-only attribute, so Terraform never stores it in your state file, and scopes control which features can use the secret, such as Redpanda Connect pipelines. See xref:manage:terraform-provider.adoc#manage-cluster-secrets[Manage cluster secrets].
+
 === Centralized egress for BYOC on GCP: beta
 
 You can route all GCP BYOC cluster egress through your own GCP hub VPC and NAT VM instead of a per-cluster Cloud NAT, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that require a single, predictable public IP for outbound allowlisting or that prohibit per-cluster Cloud NAT. Centralized egress is in a glossterm:beta[] release and is enabled per organization. Contact your account team for access. See xref:networking:byoc/gcp/nat-free-egress.adoc[Configure Centralized Egress with GCP VPC Peering].

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -30,6 +30,10 @@ The Redpanda Terraform provider (v2.1.0+) now supports enabling and managing Red
 
 The Redpanda Terraform provider (v2.0.0+) now supports managing cluster secrets with the new `redpanda_secret` resource. The secret value is a write-only attribute, so Terraform never stores it in your state file, and scopes control which features can use the secret, such as Redpanda Connect pipelines. See xref:manage:terraform-provider.adoc#manage-cluster-secrets[Manage cluster secrets].
 
+=== Terraform provider: Cross-region AWS PrivateLink
+
+The Redpanda Terraform provider (v2.0.0+) now supports configuring cross-region AWS PrivateLink with the `supported_regions` attribute of the `aws_private_link` block on a `redpanda_cluster` resource, allowing clients in other AWS regions to connect to your cluster through PrivateLink. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink].
+
 === Centralized egress for BYOC on GCP: beta
 
 You can route all GCP BYOC cluster egress through your own GCP hub VPC and NAT VM instead of a per-cluster Cloud NAT, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that require a single, predictable public IP for outbound allowlisting or that prohibit per-cluster Cloud NAT. Centralized egress is in a glossterm:beta[] release and is enabled per organization. Contact your account team for access. See xref:networking:byoc/gcp/nat-free-egress.adoc[Configure Centralized Egress with GCP VPC Peering].

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -237,7 +237,7 @@ You can now enable xref:manage:schema-reg/schema-id-validation.adoc[schema ID va
 
 === Cross-region AWS PrivateLink
 
-AWS PrivateLink now supports cross-region connectivity, allowing clients in different AWS regions to connect to your Redpanda cluster through PrivateLink. Configure supported regions in the xref:networking:configure-privatelink-in-cloud-ui.adoc#cross-region-privatelink[Cloud UI], using the xref:networking:aws-privatelink.adoc#cross-region-privatelink[Cloud API], or with the Redpanda Terraform provider (v1.7.0+) using the `supported_regions` attribute of the `aws_private_link` block. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink]. This feature requires multi-AZ cluster deployments.
+AWS PrivateLink now supports cross-region connectivity, allowing clients in different AWS regions to connect to your Redpanda cluster through PrivateLink. Configure supported regions in the xref:networking:configure-privatelink-in-cloud-ui.adoc#cross-region-privatelink[Cloud Console], using the xref:networking:aws-privatelink.adoc#cross-region-privatelink[Cloud API], or with the Redpanda Terraform provider (v1.7.0+) using the `supported_regions` attribute of the `aws_private_link` block. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink]. This feature requires multi-AZ cluster deployments.
 
 == January 2026
 

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -30,10 +30,6 @@ The Redpanda Terraform provider (v2.1.0+) now supports enabling and managing Red
 
 The Redpanda Terraform provider (v2.0.0+) now supports managing cluster secrets with the new `redpanda_secret` resource. The secret value is a write-only attribute, so Terraform never stores it in your state file, and scopes control which features can use the secret, such as Redpanda Connect pipelines. See xref:manage:terraform-provider.adoc#manage-cluster-secrets[Manage cluster secrets].
 
-=== Terraform provider: Cross-region AWS PrivateLink
-
-The Redpanda Terraform provider (v2.0.0+) now supports configuring cross-region AWS PrivateLink with the `supported_regions` attribute of the `aws_private_link` block on a `redpanda_cluster` resource, allowing clients in other AWS regions to connect to your cluster through PrivateLink. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink].
-
 === Centralized egress for BYOC on GCP: beta
 
 You can route all GCP BYOC cluster egress through your own GCP hub VPC and NAT VM instead of a per-cluster Cloud NAT, so outbound traffic exits through your centralized inspection point. This is useful for regulated environments that require a single, predictable public IP for outbound allowlisting or that prohibit per-cluster Cloud NAT. Centralized egress is in a glossterm:beta[] release and is enabled per organization. Contact your account team for access. See xref:networking:byoc/gcp/nat-free-egress.adoc[Configure Centralized Egress with GCP VPC Peering].
@@ -241,7 +237,7 @@ You can now enable xref:manage:schema-reg/schema-id-validation.adoc[schema ID va
 
 === Cross-region AWS PrivateLink
 
-AWS PrivateLink now supports cross-region connectivity, allowing clients in different AWS regions to connect to your Redpanda cluster through PrivateLink. Configure supported regions in the xref:networking:configure-privatelink-in-cloud-ui.adoc#cross-region-privatelink[Cloud UI] or using the xref:networking:aws-privatelink.adoc#cross-region-privatelink[Cloud API] to specify which regions can establish PrivateLink connections. This feature requires multi-AZ cluster deployments.
+AWS PrivateLink now supports cross-region connectivity, allowing clients in different AWS regions to connect to your Redpanda cluster through PrivateLink. Configure supported regions in the xref:networking:configure-privatelink-in-cloud-ui.adoc#cross-region-privatelink[Cloud UI], using the xref:networking:aws-privatelink.adoc#cross-region-privatelink[Cloud API], or with the Redpanda Terraform provider (v1.7.0+) using the `supported_regions` attribute of the `aws_private_link` block. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink]. This feature requires multi-AZ cluster deployments.
 
 == January 2026
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -109,7 +109,6 @@ output "cluster_api_url" {
 The following functionality is supported in the Cloud API but not in the Redpanda Terraform provider:
 
 * Creating or deleting BYOVNet clusters on Azure
-* Secrets
 * Kafka Connect
 
 [WARNING]
@@ -240,7 +239,7 @@ For each supported sensitive field, the provider exposes two new attributes alon
 * `<field>_wo`: A write-only attribute. Terraform sends the value to the provider during `apply` but never persists it to state.
 * `<field>_wo_version`: An integer version. Because Terraform cannot detect changes in a write-only value (there is nothing to compare against in state), you increment this number to signal that the value has changed and to trigger an update on the next apply.
 
-NOTE: `redpanda_pipeline` is an exception to this naming convention. The existing `client_secret` attribute is the write-only attribute (no separate `client_secret_wo` field), and is paired with `secret_version` instead of `client_secret_wo_version`.
+NOTE: `redpanda_pipeline` and `redpanda_secret` are exceptions to this naming convention. For `redpanda_pipeline`, the existing `client_secret` attribute is the write-only attribute (no separate `client_secret_wo` field), and is paired with `secret_version` instead of `client_secret_wo_version`. For `redpanda_secret`, the `secret_data` attribute is write-only by design (there is no plaintext variant), and is paired with `secret_data_version`.
 
 The provider retains the original plaintext attributes for backward compatibility. You can migrate to the write-only variants on your own schedule. Avoid setting both the plaintext attribute and its write-only counterpart on the same resource. If both are set, the provider uses the write-only value.
 
@@ -268,6 +267,11 @@ The provider retains the original plaintext attributes for backward compatibilit
 | `client_secret`
 | `client_secret` (write-only)
 | `secret_version`
+
+| `redpanda_secret`
+| None (write-only by design)
+| `secret_data`
+| `secret_data_version`
 |===
 
 === Set a write-only attribute
@@ -318,6 +322,36 @@ resource "redpanda_user" "schema_user" {
 ----
 
 After running `terraform apply`, the provider sends the new password to Redpanda Cloud. Neither the old nor the new value is written to state.
+
+== Manage cluster secrets
+
+The Redpanda Terraform provider (v2.0.0+) supports creating and managing secrets in a cluster's secret store with the `redpanda_secret` resource. Cluster secrets hold sensitive values, such as pipeline credentials, that other resources reference by name using `${secrets.<NAME>}`.
+
+The secret value (`secret_data`) is a write-only attribute, so Terraform never stores it in state. To rotate the value, change `secret_data` and increment `secret_data_version`, following the same pattern as <<manage-sensitive-attributes-with-write-only-fields,other write-only attributes>>.
+
+[source,hcl]
+----
+variable "secret_value" {
+  description = "Value to store in the secret"
+  sensitive   = true
+}
+
+resource "redpanda_secret" "example" {
+  name                = "EXAMPLE_SECRET"
+  secret_data         = var.secret_value
+  secret_data_version = 1
+  scopes              = ["SCOPE_REDPANDA_CONNECT"]
+  cluster_api_url     = redpanda_cluster.example.cluster_api_url
+  allow_deletion      = true
+}
+----
+
+* `name`: An uppercase identifier matching `^[A-Z][A-Z0-9_]*$`. You cannot rename a secret after you create it.
+* `secret_data`: The secret value, Base64-encoded. Requires Terraform 1.11 or later.
+* `scopes`: The features that can use the secret. For example, use `SCOPE_REDPANDA_CONNECT` for Redpanda Connect pipelines or `SCOPE_REDPANDA_CLUSTER` for Shadowing credentials. If a secret doesn't have a scope that matches its consumer, the consumer fails at runtime.
+* `labels` (optional): Labels to organize your secrets. You cannot change labels after you create the secret.
+
+For the full schema and import syntax, see the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/secret[redpanda_secret resource documentation^]. To use secrets in Redpanda Connect pipelines, see xref:develop:connect/configuration/secret-management.adoc[].
 
 == Configure cluster properties
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -20,6 +20,7 @@ With the Redpanda Terraform provider, you can manage:
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/role_assignments[Role assignments^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/schema[Schemas^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/schema_registry_acl[Schema Registry ACLs^]
+* link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/secret[Secrets^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/serverless_cluster[Serverless clusters^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/serverless_private_link[Serverless private links^]
 * link:https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/topic[Topics^]
@@ -343,7 +344,7 @@ resource "redpanda_secret" "example" {
   secret_data         = var.secret_value
   secret_data_version = 1
   scopes              = ["SCOPE_REDPANDA_CONNECT"]
-  cluster_api_url     = redpanda_cluster.example.cluster_api_url
+  cluster_api_url     = data.redpanda_cluster.byoc.cluster_api_url
   allow_deletion      = true
 }
 ----

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -5,6 +5,7 @@
 :learning-objective-1: Configure and deploy Redpanda Cloud clusters using Terraform
 :learning-objective-2: Manage sensitive credentials using Terraform write-only attributes
 :learning-objective-3: Enable Redpanda SQL on a BYOC cluster using the rpsql block
+:learning-objective-4: Configure cross-region AWS PrivateLink on a cluster
 
 Use the https://registry.terraform.io/providers/redpanda-data/redpanda/latest[Redpanda Terraform provider^] to define, automate, and track changes to your Redpanda Cloud infrastructure as code.
 
@@ -29,6 +30,7 @@ After reading this page, you will be able to:
 * [ ] {learning-objective-1}
 * [ ] {learning-objective-2}
 * [ ] {learning-objective-3}
+* [ ] {learning-objective-4}
 
 == Why use Terraform with Redpanda?
 
@@ -374,6 +376,46 @@ Only the properties listed in xref:reference:properties/cluster-properties.adoc[
 
 NOTE: Cluster properties are not available on Serverless clusters or on BYOC and Dedicated clusters running on Azure.
 
+== Configure cross-region AWS PrivateLink
+
+By default, AWS PrivateLink only accepts connections from VPCs in the same region as your Redpanda cluster. The Redpanda Terraform provider (v2.0.0+) supports xref:networking:aws-privatelink.adoc#cross-region-privatelink[cross-region PrivateLink], which allows clients in other AWS regions to connect to your cluster through PrivateLink.
+
+To enable cross-region PrivateLink, add the `supported_regions` attribute to the `aws_private_link` block of a `redpanda_cluster` resource. The attribute accepts a list of up to 50 unique AWS region identifiers from which PrivateLink endpoints can connect. If you omit it, only same-region connections are allowed.
+
+Requirements:
+
+* The cluster must be deployed across multiple availability zones (multi-AZ). This is an AWS limitation for cross-region PrivateLink.
+* For BYOC clusters, the Redpanda agent IAM role must have the `vpce:AllowMultiRegion` and `elasticloadbalancing:DescribeListenerAttributes` permissions.
+
+[source,hcl]
+----
+resource "redpanda_cluster" "example" {
+  # ... other cluster arguments ...
+
+  zones = ["use2-az1", "use2-az2", "use2-az3"]  # Cross-region PrivateLink requires a multi-AZ cluster
+
+  aws_private_link = {
+    enabled            = true
+    connect_console    = true
+    allowed_principals = ["arn:aws:iam::123456789012:root"]
+    supported_regions  = ["us-east-1", "us-west-2", "eu-west-1"]
+  }
+}
+
+output "privatelink_service_name" {
+  value = redpanda_cluster.example.aws_private_link.status.service_name
+}
+----
+
+* `enabled`: Whether the Redpanda PrivateLink endpoint service is enabled.
+* `connect_console`: Whether Redpanda Console is connected over PrivateLink.
+* `allowed_principals`: The ARNs of the AWS principals allowed to access the endpoint service. To allow all principals, use an asterisk (`*`).
+* `supported_regions` (optional): The AWS regions from which clients can create PrivateLink endpoints that connect to the cluster.
+
+You can add or change the `aws_private_link` block on an existing cluster. Terraform updates the cluster in place without recreating it.
+
+After you apply the configuration, clients in the listed regions can create VPC endpoints that connect to the cluster's endpoint service, identified by the `service_name` output in the example. See xref:networking:aws-privatelink.adoc#create-a-cross-region-vpc-endpoint[Create a cross-region VPC endpoint] for the AWS CLI workflow, and xref:networking:aws-privatelink.adoc[] for the full PrivateLink setup, including client VPC configuration and connection testing.
+
 == Examples
 
 The following examples use the Redpanda Terraform provider to create and manage clusters. For descriptions of resources and data sources, see the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs[Redpanda Terraform Provider documentation^].
@@ -671,6 +713,8 @@ resource "redpanda_cluster" "test" {
   }
 }
 ----
+
+For details on the `aws_private_link` block, including the multi-AZ requirement for cross-region PrivateLink, see <<configure-cross-region-aws-privatelink>>.
 
 === Create a Serverless cluster
 

--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -349,9 +349,9 @@ resource "redpanda_secret" "example" {
 ----
 
 * `name`: An uppercase identifier matching `^[A-Z][A-Z0-9_]*$`. You cannot rename a secret after you create it.
-* `secret_data`: The secret value, Base64-encoded. Requires Terraform 1.11 or later.
+* `secret_data`: The secret value. Requires Terraform 1.11 or later.
 * `scopes`: The features that can use the secret. For example, use `SCOPE_REDPANDA_CONNECT` for Redpanda Connect pipelines or `SCOPE_REDPANDA_CLUSTER` for Shadowing credentials. If a secret doesn't have a scope that matches its consumer, the consumer fails at runtime.
-* `labels` (optional): Labels to organize your secrets. You cannot change labels after you create the secret.
+* `labels` (optional): Labels to organize your secrets. You can update labels on an existing secret (provider v2.1.0+).
 
 For the full schema and import syntax, see the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/secret[redpanda_secret resource documentation^]. To use secrets in Redpanda Connect pipelines, see xref:develop:connect/configuration/secret-management.adoc[].
 
@@ -378,7 +378,7 @@ NOTE: Cluster properties are not available on Serverless clusters or on BYOC and
 
 == Configure cross-region AWS PrivateLink
 
-By default, AWS PrivateLink only accepts connections from VPCs in the same region as your Redpanda cluster. The Redpanda Terraform provider (v2.0.0+) supports xref:networking:aws-privatelink.adoc#cross-region-privatelink[cross-region PrivateLink], which allows clients in other AWS regions to connect to your cluster through PrivateLink.
+By default, AWS PrivateLink only accepts connections from VPCs in the same region as your Redpanda cluster. The Redpanda Terraform provider (v1.7.0+) supports xref:networking:aws-privatelink.adoc#cross-region-privatelink[cross-region PrivateLink], which allows clients in other AWS regions to connect to your cluster through PrivateLink.
 
 To enable cross-region PrivateLink, add the `supported_regions` attribute to the `aws_private_link` block of a `redpanda_cluster` resource. The attribute accepts a list of up to 50 unique AWS region identifiers from which PrivateLink endpoints can connect. If you omit it, only same-region connections are allowed.
 

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -251,7 +251,7 @@ For more information about AWS cross-region PrivateLink support, see the https:/
 
 === Configure cross-region PrivateLink
 
-To enable cross-region PrivateLink, add the `supported_regions` field to your `aws_private_link` configuration when <<create-new-cluster-with-privatelink-endpoint-service-enabled,creating a new cluster>> or <<enable-privatelink-endpoint-service-for-existing-clusters,enabling PrivateLink on an existing cluster>>.
+To enable cross-region PrivateLink, add the `supported_regions` field to your `aws_private_link` configuration when <<create-new-cluster-with-privatelink-endpoint-service-enabled,creating a new cluster>> or <<enable-privatelink-endpoint-service-for-existing-clusters,enabling PrivateLink on an existing cluster>>. You can also configure it with the Redpanda Terraform provider. See xref:manage:terraform-provider.adoc#configure-cross-region-aws-privatelink[Configure cross-region AWS PrivateLink].
 
 The `supported_regions` field accepts a list of AWS region identifiers where you want to allow PrivateLink connections from. For example:
 

--- a/modules/security/pages/secrets.adoc
+++ b/modules/security/pages/secrets.adoc
@@ -12,3 +12,5 @@ https://cloud.google.com/secret-manager[GCP Secret Manager^] services. Static
 secrets managed through Redpanda Console never leave their corresponding
 data plane account or network. They stay securely stored in AWS Secrets Manager or
 GCP Secret Manager.
+
+To manage the static secrets in a cluster's secret store, use the Cloud UI, the link:/api/doc/cloud-dataplane/topic/topic-quickstart[Data Plane API], or the xref:manage:terraform-provider.adoc#manage-cluster-secrets[Redpanda Terraform provider].

--- a/modules/security/pages/secrets.adoc
+++ b/modules/security/pages/secrets.adoc
@@ -13,4 +13,4 @@ secrets managed through Redpanda Console never leave their corresponding
 data plane account or network. They stay securely stored in AWS Secrets Manager or
 GCP Secret Manager.
 
-To manage the static secrets in a cluster's secret store, use the Cloud UI, the link:/api/doc/cloud-dataplane/topic/topic-quickstart[Data Plane API], or the xref:manage:terraform-provider.adoc#manage-cluster-secrets[Redpanda Terraform provider].
+To manage the static secrets in a cluster's secret store, use the Cloud Console, the link:/api/doc/cloud-dataplane/topic/topic-quickstart[Data Plane API], or the xref:manage:terraform-provider.adoc#manage-cluster-secrets[Redpanda Terraform provider].


### PR DESCRIPTION
## Description

This PR documents two shipped Terraform provider features on the Redpanda Terraform Provider page:

### 1. `redpanda_secret` resource ([ENG-1062], resolves [DOC-2199])

The Redpanda Terraform provider v2.0.0 (released 2026-06-03) added the `redpanda_secret` resource for managing cluster secrets. Its `secret_data` attribute is write-only (Terraform 1.11+), so the plaintext never lands in state; rotation uses the `secret_data_version` counter.

- **`manage/terraform-provider.adoc`**:
  - Removed `Secrets` from the Limitations list — it has been incorrect on the live site since v2.0.0 shipped.
  - Added a new **Manage cluster secrets** section with a working example (from the provider repo's shipped example), the rotation pattern, scope behavior, and links to the registry doc and the Connect secret-management page.
  - Extended the write-only naming-exception NOTE and the Supported attributes table to cover `redpanda_secret` (`secret_data`/`secret_data_version`, no plaintext variant).
- **`develop/connect/configuration/secret-management.adoc`**: mentions Terraform as a management option (this was the originating customer use case: pipeline auth via `SCOPE_REDPANDA_CONNECT`).
- **`security/secrets.adoc`**: added a sentence listing the management interfaces for the cluster secret store, including the Terraform provider.

### 2. Cross-region AWS PrivateLink ([ENG-1063])

Cross-region AWS PrivateLink was already documented for the UI and API on the [AWS PrivateLink page](https://docs.redpanda.com/redpanda-cloud/networking/aws-privatelink/#cross-region-privatelink) but not for Terraform. The provider supports it via the optional `supported_regions` attribute of the `aws_private_link` block on `redpanda_cluster` (v2.0.0+, up to 50 unique regions, updates in place).

- **`manage/terraform-provider.adoc`**:
  - Added a new **Configure cross-region AWS PrivateLink** section with the requirements (multi-AZ cluster, BYOC agent IAM permissions), a working example including a `service_name` output for creating VPC endpoints, and links to the networking page for the cross-region VPC endpoint workflow.
  - Pointed the existing Dedicated cluster example (which already showed `supported_regions` inline) at the new section.
  - Added a learning objective for the new section.
- **`networking/aws-privatelink.adoc`**: the **Configure cross-region PrivateLink** section now links to the new Terraform section.

### What's New

**`get-started/whats-new-cloud.adoc`**: added June 2026 entries (v2.0.0) for both features, grouped with the existing Terraform SQL entry, following the established Terraform What's New pattern.

**For SME confirmation (@gene):** the registry doc says `secret_data` must be Base64-encoded, but the shipped provider example passes a plain `sensitive` variable without `base64encode()`. This PR mirrors the shipped example and states the Base64 requirement in the attribute list — please confirm which is authoritative.

**Not covered here:** `redpanda_shadow_link` (also v2.0.0) — assumed tracked separately; say the word if the What's New entry should cover both.

Resolves [DOC-2199]
Documents [ENG-1063]

## Page previews

- [Redpanda Terraform Provider: Manage cluster secrets](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/#manage-cluster-secrets) (updated)
- [Redpanda Terraform Provider: Configure cross-region AWS PrivateLink](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/#configure-cross-region-aws-privatelink) (updated)
- [AWS PrivateLink](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/networking/aws-privatelink/#configure-cross-region-privatelink) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/#terraform-provider-secrets-management) (updated)
- [Manage Secrets (Connect)](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/develop/connect/configuration/secret-management/) (updated)
- [Secrets (security)](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/security/secrets/) (updated)

## Checks

- [x] New feature
- [ ] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-1062]: https://redpandadata.atlassian.net/browse/ENG-1062
[ENG-1063]: https://redpandadata.atlassian.net/browse/ENG-1063
[DOC-2199]: https://redpandadata.atlassian.net/browse/DOC-2199


## Preview pages

- [Redpanda Terraform Provider](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/) (updated)
- [What's New in Redpanda Cloud](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)
- [Configure AWS PrivateLink with the Cloud API](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/networking/aws-privatelink/) (updated)
- [Manage Secrets](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/develop/connect/configuration/secret-management/) (updated)
- [Secrets](https://deploy-preview-635--rp-cloud.netlify.app/cloud-data-platform/security/secrets/) (updated)
