### PR TITLE
DOC-2021: Point cross-region PrivateLink readers to Terraform support

### DIFF
--- a/modules/manage/pages/terraform-provider.adoc
+++ b/modules/manage/pages/terraform-provider.adoc
@@ -630,7 +630,7 @@ resource "redpanda_cluster" "test" {
     enabled            = true
     connect_console    = true
     allowed_principals = ["arn:aws:iam::123456789024:root"]
-    supported_regions  = ["us-east-1", "us-west-2"]  # Optional: Enable cross-region PrivateLink
+    supported_regions  = ["us-east-1", "us-west-2"]  # Optional: Enable cross-region PrivateLink (requires a multi-AZ cluster)
   }
   tags = {
     "environment" = "dev"

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -267,8 +267,6 @@ The `supported_regions` field accepts a list of AWS region identifiers where you
 
 With this configuration, clients in VPCs located in `us-east-1`, `us-west-2`, and `eu-west-1` can create PrivateLink endpoints that connect to your Redpanda cluster, regardless of which region the cluster is deployed in.
 
-If you manage your clusters with the Redpanda Terraform provider, set the same `supported_regions` field in the `aws_private_link` block of the `redpanda_cluster` resource. See xref:manage:terraform-provider.adoc#create-a-dedicated-cluster[Create a Dedicated cluster] for an example, and the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/cluster[redpanda_cluster resource documentation^] for the full schema.
-
 === Create a cross-region VPC endpoint
 
 When creating a VPC endpoint in a different region than your Redpanda cluster, use the same process as <<create-vpc-endpoint,creating a standard VPC endpoint>>, but specify both the client VPC's region and the service region where your Redpanda cluster is deployed.

--- a/modules/networking/pages/aws-privatelink.adoc
+++ b/modules/networking/pages/aws-privatelink.adoc
@@ -267,6 +267,8 @@ The `supported_regions` field accepts a list of AWS region identifiers where you
 
 With this configuration, clients in VPCs located in `us-east-1`, `us-west-2`, and `eu-west-1` can create PrivateLink endpoints that connect to your Redpanda cluster, regardless of which region the cluster is deployed in.
 
+If you manage your clusters with the Redpanda Terraform provider, set the same `supported_regions` field in the `aws_private_link` block of the `redpanda_cluster` resource. See xref:manage:terraform-provider.adoc#create-a-dedicated-cluster[Create a Dedicated cluster] for an example, and the https://registry.terraform.io/providers/redpanda-data/redpanda/latest/docs/resources/cluster[redpanda_cluster resource documentation^] for the full schema.
+
 === Create a cross-region VPC endpoint
 
 When creating a VPC endpoint in a different region than your Redpanda cluster, use the same process as <<create-vpc-endpoint,creating a standard VPC endpoint>>, but specify both the client VPC's region and the service region where your Redpanda cluster is deployed.


### PR DESCRIPTION
## Description

Closes the remaining gap in [DOC-2021](https://redpandadata.atlassian.net/browse/DOC-2021) (ENG-1063, cross-region AWS PrivateLink via Terraform).

**Scope note (2026-07-20):** most of this ticket's gap was closed by #635, which merged today with a dedicated *Configure cross-region AWS PrivateLink* section on the provider page, a pointer from the platform page, and the What's New mention — all stating the correct provider version (**v1.7.0+**, SME-verified; this PR's original commit message said v1.8.0, which was wrong). This PR's aws-privatelink paragraph was superseded by #635's pointer and has been removed.

**What remains in this PR:**

- **`manage/terraform-provider.adoc`**: the full Dedicated-cluster example's `supported_regions` comment now notes the multi-AZ requirement (documented in the Requirements lists, but absent at this example site — prevents a confusing failure for single-AZ clusters).

Resolves [DOC-2021](https://redpandadata.atlassian.net/browse/DOC-2021) (jointly with the substantive docs from #635).

## Page previews

- [Redpanda Terraform Provider — Dedicated cluster example](https://deploy-preview-637--rp-cloud.netlify.app/cloud-data-platform/manage/terraform-provider/#create-a-dedicated-cluster) (updated — the multi-AZ note on the `supported_regions` comment is verified rendering in this preview)

## Checks

- [ ] New feature
- [x] Content gap
- [ ] Support Follow-up
- [ ] Small fix (typos, links, copyedits, etc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-2021]: https://redpandadata.atlassian.net/browse/DOC-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

