### PR TITLE
docs: add jira input to cloud Connect docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -63,6 +63,7 @@
 **** xref:develop:connect/components/inputs/http_client.adoc[]
 **** xref:develop:connect/components/inputs/http_server.adoc[]
 **** xref:develop:connect/components/inputs/inproc.adoc[]
+**** xref:develop:connect/components/inputs/jira.adoc[]
 **** xref:develop:connect/components/inputs/kafka.adoc[]
 **** xref:develop:connect/components/inputs/kafka_franz.adoc[]
 **** xref:develop:connect/components/inputs/microsoft_sql_server_cdc.adoc[]

--- a/modules/develop/pages/connect/components/inputs/jira.adoc
+++ b/modules/develop/pages/connect/components/inputs/jira.adoc
@@ -1,0 +1,4 @@
+= jira
+:page-aliases: components:inputs/jira.adoc
+
+include::connect:components:inputs/jira.adoc[tag=single-source]

--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -20,6 +20,11 @@ Redpanda Cloud Console now includes a built-in SQL editor. For SQL-enabled envir
 
 You can now permanently delete a Serverless organization (free trial and pay-as-you-go plans) directly from the Cloud UI, without contacting Redpanda Support. The new *Manage organization* page, available from your profile icon, shows your plan and organization-wide resource counts, and walks you through the deletion prerequisites: delete all clusters, delete all private links, and settle any pending or outstanding invoices. See xref:manage:manage-organization.adoc[Manage Your Organization].
 
+=== Redpanda Connect updates
+
+* Inputs:
+** xref:develop:connect/components/inputs/jira.adoc[jira]: Streams Jira issues, comments, or changelog entries via JQL with incremental polling.
+
 == June 2026
 
 === Terraform provider: Redpanda SQL support


### PR DESCRIPTION
## What

Single-sources the new Redpanda Connect `jira` input into the Cloud docs, as flagged by the auto-docs PR (redpanda-data/rp-connect-docs#462):

- New stub page `modules/develop/pages/connect/components/inputs/jira.adoc` including `connect:components:inputs/jira.adoc[tag=single-source]`
- Nav entry under Connect inputs (alphabetical, after `inproc`)
- What's New (July 2026) → Redpanda Connect updates → Inputs entry

## Notes

- The `jira` **processor** is deprecated in the same Connect release; its page carries a deprecation notice pointing to this input (handled in #462).