### PR TITLE
Add AWS BYOC regions ap-northeast-2 (Seoul) and ap-south-2 (Hyderabad)

### DIFF
--- a/modules/get-started/pages/whats-new-cloud.adoc
+++ b/modules/get-started/pages/whats-new-cloud.adoc
@@ -8,6 +8,13 @@ This page lists new features added to Redpanda Cloud.
 
 == July 2026
 
+=== New AWS regions for BYOC
+
+For xref:reference:tiers/byoc-tiers.adoc#byoc-supported-regions[BYOC clusters], Redpanda added support for the following AWS regions:
+
+* ap-northeast-2 (Seoul)
+* ap-south-2 (Hyderabad)
+
 === Improved Serverless trial onboarding
 
 New Serverless free-trial users now get a guided start in the Redpanda Cloud UI. After you sign up, a few quick questions help Redpanda tailor your experience. The welcome cluster's *Overview* page summarizes your trial credits, and the *Get started* button offers options to start streaming: create a Redpanda Connect pipeline, use `rpk` from the command line, or connect with your own Kafka client. See xref:get-started:cluster-types/serverless.adoc#get-started-with-serverless[Get started with Serverless].

--- a/modules/reference/partials/tiers.adoc
+++ b/modules/reference/partials/tiers.adoc
@@ -67,7 +67,9 @@ Amazon Web Services (AWS)::
 | af-south-1 
 | ap-east-1
 | ap-northeast-1
+| ap-northeast-2
 | ap-south-1
+| ap-south-2
 | ap-southeast-1
 | ap-southeast-2
 | ap-southeast-3


### PR DESCRIPTION
## Summary

Two new AWS regions are live in production for **BYOC clusters** as of 2026-07-21 ([ENG-1262](https://redpandadata.atlassian.net/browse/ENG-1262), [ENG-1263](https://redpandadata.atlassian.net/browse/ENG-1263)), validated end-to-end via certification runs in every environment:

- **ap-northeast-2** (Seoul)
- **ap-south-2** (Hyderabad)

Changes:
- `reference/partials/tiers.adoc`: added both regions to the **BYOC** supported-regions AWS table (alphabetical). The Dedicated list is deliberately unchanged — these regions are BYOC-only.
- `get-started/pages/whats-new-cloud.adoc`: July 2026 entry, matching the style of previous region announcements.

## Note for docs team

Both regions offer only the arm64 tiers (tiers 1–9). ap-south-2 runs them on AWS Graviton2 (m6gd instances) rather than Graviton3 — the existing note "Redpanda supports compute-optimized tiers with AWS Graviton3 processors" may deserve a small generalization (e.g. "AWS Graviton processors"), but we've left that wording call to you.

Source of truth for region/tier data: `tools/public-api-docs/master-data.yaml` in redpanda-data/cloudv2 (refreshed in redpanda-data/cloudv2#28248).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Preview pages

- [What's New in Redpanda Cloud](https://deploy-preview-644--rp-cloud.netlify.app/cloud-data-platform/get-started/whats-new-cloud/) (updated)
- [BYOC Tiers and Regions](https://deploy-preview-644--rp-cloud.netlify.app/cloud-data-platform/reference/tiers/byoc-tiers/) (updated)


[ENG-1262]: https://redpandadata.atlassian.net/browse/ENG-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-1263]: https://redpandadata.atlassian.net/browse/ENG-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ