### PR TITLE
docs: fetch read coalescing stub (DOC-2386)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -369,6 +369,7 @@
 ** xref:develop:consume-data/index.adoc[Consume Data]
 *** xref:develop:consume-data/consumer-offsets.adoc[Consumer Offsets]
 *** xref:develop:consume-data/follower-fetching.adoc[Follower Fetching]
+*** xref:develop:consume-data/fetch-read-coalescing.adoc[Fetch Read Coalescing]
 *** xref:develop:consume-data/paginate-messages-events.adoc[]
 ** xref:develop:http-proxy.adoc[]
 ** xref:develop:cloud-mcp/index.adoc[Cloud Management MCP Server]

--- a/modules/develop/pages/consume-data/fetch-read-coalescing.adoc
+++ b/modules/develop/pages/consume-data/fetch-read-coalescing.adoc
@@ -1,0 +1,4 @@
+= Fetch Read Coalescing
+:description: Reduce redundant read CPU and fetch-response memory under high consumer fan-out by sharing one read result across concurrent fetches of the same data.
+
+include::streaming:develop:consume-data/fetch-read-coalescing.adoc[tag=single-source]


### PR DESCRIPTION
Companion to https://github.com/redpanda-data/docs/pull/1821 (DOC-2386).

Adds the consuming stub `modules/develop/pages/consume-data/fetch-read-coalescing.adoc` (same module path as the source, so shared xrefs resolve) and a nav entry after Follower Fetching.

Per Brandon Allard: fetch read coalescing can be enabled on BYOC and Dedicated clusters. The shared content is env-gated in the source: the cloud build gets an availability line, the enable procedure with a pointer to [cluster configuration](https://docs.redpanda.com/cloud-data-platform/manage/cluster-maintenance/config-cluster/), and the limitations — while the internal-metrics evaluation section is excluded (Cloud exposes only `public_metrics`; the `vectorized_*` coalescer counters are not customer-visible).

## ⚠️ Merge order

**Do not merge until docs#1821's content reaches the docs `main` branch** (26.2 beta→main promotion). This repo consumes `streaming` content from `main`/`v/*`, so merging earlier breaks the include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)